### PR TITLE
Leaguemate intel: survival estimator, schema and context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ sleeper_player_api-*.tar
 
 /config/*.secret.exs
 
+
+# Harvested Sleeper corpus for the leaguemate-intel golden tests.
+# NOT source controlled: this repo is public, and the corpus is a compiled
+# behavioural profile of 13 real, named leaguemates (user ids, display names,
+# and their full draft history across 70 drafts). Each datum is individually
+# public via the Sleeper API; the aggregate is not ours to publish.
+/test/support/corpus/

--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -1,0 +1,376 @@
+defmodule SleeperPlayerApi.Intel do
+  @moduledoc """
+  Context for the leaguemate-intel corpus: storing the Sleeper drafts/picks
+  harvested by the (not-yet-built, see `docs/leaguemate-intel.md` §3f steps
+  2-3) crawler, and shaping what's stored back out into the plain-map input
+  `SleeperPlayerApi.Intel.Estimator` expects.
+
+  Two halves, per the plan's §3e "where the math runs":
+
+    * **Upserts** — batched `Repo.insert_all/3` with `on_conflict`, never a
+      per-row SELECT+INSERT (that's the exact pattern `GetSleeperPlayerData`
+      uses across ~9,400 players, and the plan calls out that the crawler
+      must not copy it).
+    * **Queries** — `GROUP BY` aggregates (league ADP/spread, per-manager
+      ADP/counts) computed in SQL, plus `drafts_corpus/1`, which shapes
+      `observed_drafts`/`observed_picks` into exactly the structure
+      `test/support/intel_corpus.ex` builds from JSON, so the estimator is
+      indifferent to which one fed it.
+
+  No HTTP, no crawler, no controllers here — see plan §3f step 1.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias SleeperPlayerApi.Repo
+
+  alias SleeperPlayerApi.Intel.{
+    SleeperUser,
+    ObservedDraft,
+    ObservedPick,
+    ObservedTradedPick,
+    PlayerValue,
+    DraftParticipant
+  }
+
+  @batch_size 1000
+
+  # ---------------------------------------------------------------------
+  # Upserts
+  # ---------------------------------------------------------------------
+
+  @doc """
+  Upserts a batch of `%{id, username, display_name, avatar, last_crawled_at}`
+  maps into `sleeper_users`, keyed on `id` (Sleeper's own user id — never
+  `username`, which Sleeper documents as mutable).
+  """
+  @spec upsert_sleeper_users([map]) :: {non_neg_integer, nil}
+  def upsert_sleeper_users(users) do
+    insert_all_batched(
+      SleeperUser,
+      users,
+      conflict_target: [:id],
+      replace: [:username, :display_name, :avatar, :last_crawled_at]
+    )
+  end
+
+  @doc """
+  Upserts a batch of draft attribute maps into `observed_drafts`, keyed on
+  `id` (the Sleeper draft id).
+  """
+  @spec upsert_observed_drafts([map]) :: {non_neg_integer, nil}
+  def upsert_observed_drafts(drafts) do
+    insert_all_batched(
+      ObservedDraft,
+      drafts,
+      conflict_target: [:id],
+      replace: [
+        :league_id,
+        :season,
+        :status,
+        :draft_type,
+        :player_type,
+        :teams,
+        :rounds,
+        :start_time,
+        :slot_to_roster_id,
+        :picks_fetched_at
+      ]
+    )
+  end
+
+  @doc """
+  Upserts every pick of one draft into `observed_picks`. `picks` entries omit
+  `draft_id` — it's stamped onto every row here so callers just pass what
+  `/draft/:id/picks` returns.
+
+  Keyed on `(draft_id, pick_no)`, so re-crawling an in-progress draft (the
+  `status == "drafting"` refresh case from plan §3c) safely overwrites.
+  """
+  @spec upsert_observed_picks(integer, [map]) :: {non_neg_integer, nil}
+  def upsert_observed_picks(draft_id, picks) do
+    picks
+    |> Enum.map(&Map.put(&1, :draft_id, draft_id))
+    |> then(
+      &insert_all_batched(
+        ObservedPick,
+        &1,
+        conflict_target: [:draft_id, :pick_no],
+        replace: [:round, :draft_slot, :roster_id, :player_id, :picked_by]
+      )
+    )
+  end
+
+  @doc """
+  Upserts one draft's traded-pick rows into `observed_traded_picks`.
+  `/draft/:id/traded_picks` doesn't return a `draft_id` field (it's implicit
+  in the URL), so it's stamped on here same as `upsert_observed_picks/2`.
+
+  Keyed on `(draft_id, season, round, roster_id)` — the natural key for "who
+  owns this future pick".
+  """
+  @spec upsert_observed_traded_picks(integer, [map]) :: {non_neg_integer, nil}
+  def upsert_observed_traded_picks(draft_id, traded_picks) do
+    traded_picks
+    |> Enum.map(&Map.put(&1, :draft_id, draft_id))
+    |> then(
+      &insert_all_batched(
+        ObservedTradedPick,
+        &1,
+        conflict_target: [:draft_id, :season, :round, :roster_id],
+        replace: [:previous_owner_id, :owner_id]
+      )
+    )
+  end
+
+  @doc """
+  Upserts the `(draft_id, user_id)` participation join rows for one draft.
+  Idempotent — re-running with the same `user_ids` is a no-op on conflict.
+  """
+  @spec upsert_draft_participants(integer, [integer]) :: {non_neg_integer, nil}
+  def upsert_draft_participants(draft_id, user_ids) do
+    user_ids
+    |> Enum.uniq()
+    |> Enum.map(&%{draft_id: draft_id, user_id: &1})
+    |> then(
+      &insert_all_batched(
+        DraftParticipant,
+        &1,
+        conflict_target: [:draft_id, :user_id],
+        on_conflict: :nothing
+      )
+    )
+  end
+
+  @doc """
+  Upserts a batch of `%{player_id, source, value, ...}` maps into
+  `player_values`, keyed on `(player_id, source)` — one row per provider per
+  player, refreshed in place (see plan §2's swappable-`source` design).
+  """
+  @spec upsert_player_values([map]) :: {non_neg_integer, nil}
+  def upsert_player_values(values) do
+    insert_all_batched(
+      PlayerValue,
+      values,
+      conflict_target: [:player_id, :source],
+      replace: [:value, :overall_rank, :position_rank, :roster_percent, :trade_frequency, :as_of]
+    )
+  end
+
+  defp insert_all_batched(schema, entries, opts) do
+    {conflict_target, opts} = Keyword.pop!(opts, :conflict_target)
+
+    on_conflict =
+      case Keyword.pop(opts, :replace) do
+        {nil, opts} -> Keyword.fetch!(opts, :on_conflict)
+        {fields, _opts} -> {:replace, fields}
+      end
+
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    entries
+    |> Enum.map(&stamp_timestamps(&1, now))
+    |> Enum.chunk_every(@batch_size)
+    |> Enum.reduce({0, nil}, fn chunk, {count, _} ->
+      {n, _} =
+        Repo.insert_all(schema, chunk, on_conflict: on_conflict, conflict_target: conflict_target)
+
+      {count + n, nil}
+    end)
+  end
+
+  defp stamp_timestamps(entry, now) do
+    entry
+    |> Map.put_new(:inserted_at, now)
+    |> Map.put(:updated_at, now)
+  end
+
+  # ---------------------------------------------------------------------
+  # Corpus shaping — the estimator-input adapter
+  # ---------------------------------------------------------------------
+
+  @doc """
+  Every stored draft, shaped into exactly the input
+  `SleeperPlayerApi.Intel.Estimator` expects:
+
+      %{l_d: float, picks: [%{norm: float, player_id: String.t(), manager: String.t() | nil}]}
+
+  `user_id_to_manager` is `%{integer => String.t()}` (Sleeper user id ->
+  leaguemate display name) — the DB-backed analog of
+  `SleeperPlayerApi.IntelCorpus.user_id_to_manager/0`. A pick whose
+  `picked_by` isn't in the map gets `manager: nil`, same as the JSON path.
+
+  Drafts with no stored picks are skipped (`Enum.max/1` on an empty pick
+  list is undefined, same trap the JSON loader would hit — the crawler is
+  expected to only mark a draft's picks fetched once it actually has some).
+
+  Picks within a draft are returned in ascending `pick_no` order for
+  determinism; `IntelCorpus.drafts/0` preserves JSON array order, which is
+  already pick order, so the two are directly comparable once sorted the
+  same way.
+  """
+  @spec drafts_corpus(%{integer => String.t()}) :: [map]
+  def drafts_corpus(user_id_to_manager \\ %{}) do
+    teams_by_draft =
+      from(d in ObservedDraft, select: {d.id, d.teams})
+      |> Repo.all()
+      |> Map.new()
+
+    picks_by_draft =
+      from(p in ObservedPick, order_by: [asc: p.draft_id, asc: p.pick_no])
+      |> Repo.all()
+      |> Enum.group_by(& &1.draft_id)
+
+    for {draft_id, picks} <- picks_by_draft, picks != [] do
+      teams = Map.fetch!(teams_by_draft, draft_id)
+
+      shaped_picks =
+        for pick <- picks do
+          %{
+            norm: normalize(pick.pick_no, teams),
+            player_id: pick.player_id,
+            manager: Map.get(user_id_to_manager, pick.picked_by)
+          }
+        end
+
+      max_pick_no = picks |> Enum.map(& &1.pick_no) |> Enum.max()
+
+      %{l_d: normalize(max_pick_no, teams), picks: shaped_picks}
+    end
+  end
+
+  defp normalize(pick_no, teams), do: (pick_no - 1) / teams * 12 + 1
+
+  # ---------------------------------------------------------------------
+  # GROUP BY aggregates (plan §3e / §4a / §4e)
+  # ---------------------------------------------------------------------
+
+  @doc """
+  League-wide ADP summary for one player: `n`, `adp` (mean), `sd`
+  (population — `STDDEV_POP`, matching `Estimator.adp_summary/1`'s choice,
+  see its moduledoc), `min`, `max` — over every normalized pick at which he
+  was taken across every stored draft. `nil` if the player was never taken
+  in the corpus.
+
+  This is a `GROUP BY` aggregate computed in SQL, per plan §3e — it's the
+  same number `Estimator.adp_summary/1` produces from `player_events/2`, just
+  computed without pulling every row into the app first.
+  """
+  @spec league_adp_summary(String.t()) ::
+          %{n: non_neg_integer, adp: float, sd: float, min: float, max: float} | nil
+  def league_adp_summary(player_id) do
+    # `fragment/1` is a query macro, expanded at compile time — it can't be
+    # factored into a runtime helper and interpolated with `^` here, because
+    # Ecto only allows a *whole* dynamic expression to be interpolated at
+    # the top level of `select` (not nested inside `avg(...)`/`fragment(...)`
+    # calls). So the normalization formula is written out at each use site
+    # instead — same SQL text as `Estimator.normalize_pick/2`, just run by
+    # Postgres over every stored row instead of pulled into the app first.
+    result =
+      from(p in ObservedPick,
+        join: d in ObservedDraft,
+        on: d.id == p.draft_id,
+        where: p.player_id == ^player_id,
+        select: %{
+          n: count(p.pick_no),
+          adp: avg(fragment("((? - 1)::float / ? * 12) + 1", p.pick_no, d.teams)),
+          sd: fragment("stddev_pop(((? - 1)::float / ? * 12) + 1)", p.pick_no, d.teams),
+          min: min(fragment("((? - 1)::float / ? * 12) + 1", p.pick_no, d.teams)),
+          max: max(fragment("((? - 1)::float / ? * 12) + 1", p.pick_no, d.teams))
+        }
+      )
+      |> Repo.one()
+
+    case result do
+      %{n: 0} ->
+        nil
+
+      %{n: nil} ->
+        nil
+
+      %{n: n, adp: adp, sd: sd, min: min, max: max} ->
+        %{n: n, adp: adp * 1.0, sd: sd_or_zero(sd), min: min * 1.0, max: max * 1.0}
+    end
+  end
+
+  defp sd_or_zero(nil), do: 0.0
+  defp sd_or_zero(sd), do: sd * 1.0
+
+  @doc """
+  Per-manager ADP summary for one player: one row per `picked_by` that has
+  ever taken him, each with the same `n`/`adp`/`sd`/`min`/`max` shape as
+  `league_adp_summary/1` plus the literal picks used
+  (`round.draft_slot @ pick_no`), per plan §4e ("store every individual
+  pick... so the UI can show receipts").
+  """
+  @spec manager_adp_summary(String.t()) :: [
+          %{
+            user_id: integer,
+            n: non_neg_integer,
+            adp: float,
+            sd: float,
+            min: float,
+            max: float,
+            picks: [%{round: integer | nil, draft_slot: integer | nil, pick_no: integer}]
+          }
+        ]
+  def manager_adp_summary(player_id) do
+    rows =
+      from(p in ObservedPick,
+        join: d in ObservedDraft,
+        on: d.id == p.draft_id,
+        where: p.player_id == ^player_id and not is_nil(p.picked_by),
+        order_by: [asc: p.picked_by],
+        select: %{
+          user_id: p.picked_by,
+          norm: fragment("((? - 1)::float / ? * 12) + 1", p.pick_no, d.teams),
+          round: p.round,
+          draft_slot: p.draft_slot,
+          pick_no: p.pick_no
+        }
+      )
+      |> Repo.all()
+
+    rows
+    |> Enum.group_by(& &1.user_id)
+    |> Enum.map(fn {user_id, entries} ->
+      norms = Enum.map(entries, & &1.norm)
+      n = length(norms)
+      mean = Enum.sum(norms) / n
+
+      variance =
+        Enum.reduce(norms, 0.0, fn v, acc -> acc + (v - mean) * (v - mean) end) / n
+
+      %{
+        user_id: user_id,
+        n: n,
+        adp: mean,
+        sd: :math.sqrt(variance),
+        min: Enum.min(norms),
+        max: Enum.max(norms),
+        picks:
+          Enum.map(entries, fn e ->
+            %{round: e.round, draft_slot: e.draft_slot, pick_no: e.pick_no}
+          end)
+      }
+    end)
+    |> Enum.sort_by(& &1.user_id)
+  end
+
+  @doc """
+  `%{picked_by => count of distinct drafts}` across every stored pick —
+  "how many drafts have we observed this manager in at all", the `seen_m`
+  input to the estimator's manager multiplier (§6). Managers with `nil`
+  `picked_by` (not a tracked leaguemate) are excluded.
+  """
+  @spec manager_drafts_seen() :: %{integer => non_neg_integer}
+  def manager_drafts_seen do
+    from(p in ObservedPick,
+      where: not is_nil(p.picked_by),
+      group_by: p.picked_by,
+      select: {p.picked_by, count(p.draft_id, :distinct)}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+end

--- a/lib/sleeper_player_api/intel/draft_participant.ex
+++ b/lib/sleeper_player_api/intel/draft_participant.ex
@@ -1,0 +1,22 @@
+defmodule SleeperPlayerApi.Intel.DraftParticipant do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SleeperPlayerApi.Intel.{ObservedDraft, SleeperUser}
+
+  @primary_key false
+  schema "draft_participants" do
+    belongs_to :draft, ObservedDraft, references: :id
+    belongs_to :user, SleeperUser, references: :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(draft_participant, attrs) do
+    draft_participant
+    |> cast(attrs, [:draft_id, :user_id])
+    |> validate_required([:draft_id, :user_id])
+    |> unique_constraint([:draft_id, :user_id])
+  end
+end

--- a/lib/sleeper_player_api/intel/estimator.ex
+++ b/lib/sleeper_player_api/intel/estimator.ex
@@ -1,0 +1,564 @@
+defmodule SleeperPlayerApi.Intel.Estimator do
+  @moduledoc """
+  Pure survival estimator for "how long will this rookie last" in a leaguemate
+  draft-intel feature.
+
+  No Ecto, no Repo, no HTTP — every function here takes plain Elixir data
+  structures (maps/lists) and returns numbers. A DB-backed adapter builds the
+  inputs; this module never reaches for them itself. That split is what makes
+  this testable without Postgres.
+
+  This moduledoc is the durable copy of the formulas that were originally
+  reverse-engineered (by fitting against a known-good fixture output) in a
+  gitignored spec doc. The spec doc is a working note; **this is the
+  reference** going forward.
+
+  ## Vocabulary
+
+  | Term | Meaning |
+  | --- | --- |
+  | Corpus | The completed rookie drafts observed across all leaguemates. |
+  | Normalized pick | A pick number rescaled to a 12-team equivalent. All maths happens in this space. |
+  | League ADP | Mean normalized pick across the corpus, for one player. |
+  | Market ADP / rank | Rank within the rookie class by FantasyCalc trade value. |
+  | Manager ADP | One manager's own mean normalized pick for a player. |
+  | Gap | `leagueAdp - marketPick`. Positive = your circle lets him slide. |
+  | Base hazard | League-wide probability the player goes at pick `n`, given still available. |
+  | Adjusted hazard | Base hazard scaled by the multiplier for whoever owns pick `n`. |
+  | Survival | Probability he is still on the board at a pick, conditional on being available now. |
+
+  ## 1. Inputs
+
+  A **draft** is represented as a plain map:
+
+      %{
+        l_d: float,          # normalized last pick ACTUALLY MADE in this draft
+                              # (norm(max pick_no, teams) — not teams * rounds)
+        picks: [
+          %{norm: float, player_id: String.t(), manager: String.t() | nil}
+        ]
+      }
+
+  `manager` is the leaguemate's display name (or `nil` if the picking user
+  isn't one of the tracked leaguemates — those picks still count for the
+  base hazard, they just can't contribute to any manager's seen/took counts).
+
+  ## 2. Normalization
+
+      norm(pick_no, teams) = (pick_no - 1) / teams * 12 + 1
+
+  Fractional; deliberately not rounded — rounding normalized picks to
+  integers measurably hurts the fit (mean error 0.00024 -> 0.00305 in
+  testing). The hazard grid is the integers `1..80` by default (adequate for
+  4-round/12-team drafts; pass a wider grid for bigger formats).
+
+  ## 3. League ADP and spread
+
+  Over the set of normalized picks for player X across drafts where he was
+  taken:
+
+      n   = count
+      adp = mean
+      sd  = POPULATION standard deviation   # divide by n, NOT n - 1
+      min, max = extremes
+
+  `sd` must be the *population* deviation. Sample deviation (`n - 1`) is off
+  by ~0.1 on almost every player — small enough to look like rounding — and
+  it feeds the kernel bandwidth below, so the error propagates into the
+  hazard curve. Elixir's stdlib has no stdev function; `population_stdev/1`
+  is hand-rolled and unit-tested against known values.
+
+  ## 4. Base hazard — Kaplan-Meier with a smeared numerator
+
+  Bandwidth, per player, from that player's own spread:
+
+      bw = max(0.6, min(1.5, 0.4 * sd))
+
+  For each grid pick `n`:
+
+                     sum over drafts where X was taken:  K(n; e_d, bw)
+      density d(n) = ------------------------------------------------
+                              (each event contributes total mass 1)
+
+      risk    r(n) = count of { d : L_d >= n AND (X not taken in d OR e_d >= n) }
+
+      hazard  h(n) = d(n) / r(n)     (0 when r(n) = 0)
+
+  where the kernel is a Gaussian normalized over the *whole grid* so each
+  observed event contributes exactly 1.0 of total mass:
+
+      gauss(n, e, bw) = exp(-0.5 * ((n - e) / bw) ** 2)
+      K(n; e, bw)     = gauss(n, e, bw) / sum_{m in grid} gauss(m, e, bw)
+
+  See `density_curve/3` for the smeared numerator and `risk_curve/3` for the
+  **unsmeared** risk set — read the comment on `risk_curve/3` before touching
+  it, the asymmetry is deliberate.
+
+  ## 5. Survival
+
+  Both curves are conditional on the player being available at the current
+  pick, and are products over the picks from `current_pick` up to (not
+  including) the target pick:
+
+      baseSurvival(N) = product_{k = current_pick}^{N-1} (1 - h(k))
+      adjSurvival(N)  = product_{k = current_pick}^{N-1} (1 - h(k) * mult(owner(k), X))
+
+  So `baseSurvival(current_pick) = adjSurvival(current_pick) = 1.0` by
+  construction (empty product). `owner(k)` is the trade-resolved owner of
+  pick `k` — resolution itself is out of scope here, callers pass in the
+  already-resolved `pick -> manager` board.
+
+  ## 6. Manager multiplier
+
+  Per-draft base rate that a given manager takes player X, league-wide:
+
+      base(X) = (n_X / D) / 12
+
+  `n_X` = drafts in which X was taken at all, `D` = corpus size. The `/12` is
+  the 12-team normalization.
+
+  Then, for manager `m` with `seen_m` drafts observed:
+
+      seen_m = 0   ->  mult = 1.0   (exactly; league average — no data, no opinion)
+
+      otherwise:
+        rate   = took_{m,X} / seen_m
+        lambda = seen_m / (seen_m + 8)     # shrinkage of the observed RATE toward base(X)
+        w      = seen_m / (seen_m + 12)    # confidence weight on the MULTIPLIER itself
+        shrunk = lambda * rate + (1 - lambda) * base(X)
+        mult   = 1 + w * (shrunk / base(X) - 1)
+
+  These are **two different constants applied in series** — `lambda` uses
+  `+8`, `w` uses `+12`. Do not unify them into one shrinkage; they were
+  recovered independently by fitting the zero-take rows (where `mult`
+  collapses to `1 - w * lambda`, independent of the player) across
+  `seen in {1, 3, 4, 5, 23, 24, 30}`.
+
+  ## 7. Threats
+
+  For target pick `N`, the threat list is every pick `k` in
+  `[current_pick, N)` whose owner is a known leaguemate, in pick order:
+
+      threats[k] = %{manager: owner(k), pick: k,
+                      prob: h(k) * mult(owner(k), X),
+                      drafts: seen_owner, tookCount: took_{owner,X}}
+
+  `drafts` and `tookCount` are the sample-size receipts every figure must
+  carry — they are not optional decoration.
+
+  ## 8. Market layer
+
+      marketPick = rank within the ROOKIE CLASS by FantasyCalc `value`, descending
+      adpGap     = round(leagueAdp - marketPick, 1)
+
+  Rookie class, not the full player pool — ranking the full pool gives
+  numbers that are internally consistent and completely wrong. A player has
+  no `marketPick` (and so no `adpGap`) if the market-value feed doesn't flag
+  him as part of the class at all.
+  """
+
+  @default_grid_max 80
+
+  # ---------------------------------------------------------------------
+  # 2. Normalization
+  # ---------------------------------------------------------------------
+
+  @doc """
+  `norm(pick_no, teams) = (pick_no - 1) / teams * 12 + 1`
+
+  Rescales an absolute pick number to its 12-team-equivalent position.
+  Deliberately fractional — do not round the result.
+  """
+  @spec normalize_pick(number, number) :: float
+  def normalize_pick(pick_no, teams) do
+    (pick_no - 1) / teams * 12 + 1
+  end
+
+  # ---------------------------------------------------------------------
+  # 3. League ADP and spread
+  # ---------------------------------------------------------------------
+
+  @doc """
+  Population standard deviation (divide by `n`, not `n - 1`).
+
+  Elixir's stdlib has no stdev function. This one is population, deliberately
+  — sample deviation is off by ~0.1 on almost every player in the reference
+  corpus, which is small enough to look like rounding error but is wrong
+  16/16 against the known-good fixture, because it feeds the kernel
+  bandwidth in `bandwidth/1` and the error propagates from there.
+  """
+  @spec population_stdev([number]) :: float
+  def population_stdev([]), do: 0.0
+
+  def population_stdev(values) do
+    n = length(values)
+    mean = Enum.sum(values) / n
+    variance = Enum.reduce(values, 0.0, fn v, acc -> acc + (v - mean) * (v - mean) end) / n
+    :math.sqrt(variance)
+  end
+
+  @doc """
+  League ADP summary for one player: `n`, `adp` (mean), `sd` (population),
+  `min`, `max` — over the normalized picks at which he was actually taken.
+
+  `events` is the list of normalized pick numbers (see `normalize_pick/2`)
+  across every corpus draft in which the player was drafted. Returns `nil`
+  for an empty list — a player absent from the corpus has no ADP, on
+  purpose (see moduledoc "Not pinned" territory; callers decide what to do
+  with `nil`).
+  """
+  @spec adp_summary([number]) ::
+          %{
+            n: non_neg_integer,
+            adp: float,
+            sd: float,
+            min: float,
+            max: float
+          }
+          | nil
+  def adp_summary([]), do: nil
+
+  def adp_summary(events) do
+    n = length(events)
+
+    %{
+      n: n,
+      adp: Enum.sum(events) / n,
+      sd: population_stdev(events),
+      min: Enum.min(events) * 1.0,
+      max: Enum.max(events) * 1.0
+    }
+  end
+
+  # ---------------------------------------------------------------------
+  # 4. Base hazard
+  # ---------------------------------------------------------------------
+
+  @doc """
+  Kernel bandwidth for a player's density smear, from that player's own
+  population sd: `max(0.6, min(1.5, 0.4 * sd))`.
+  """
+  @spec bandwidth(number) :: float
+  def bandwidth(sd) do
+    (0.4 * sd)
+    |> min(1.5)
+    |> max(0.6)
+  end
+
+  @doc """
+  Every normalized pick at which `player_id` was taken, across all `drafts`,
+  flattened (order not meaningful). Feeds `adp_summary/1` and the density
+  curve.
+  """
+  @spec player_events([map], String.t()) :: [float]
+  def player_events(drafts, player_id) do
+    for draft <- drafts,
+        pick <- draft.picks,
+        pick.player_id == player_id,
+        do: pick.norm
+  end
+
+  @doc """
+  The smeared numerator: for each grid point `n`, the sum of every observed
+  event's Gaussian kernel mass at `n`, where each event's kernel is
+  normalized over the *whole grid* so it contributes exactly 1.0 of total
+  mass. This is the §3g "dead station" fix — a single observed pick smears
+  its probability mass across nearby picks instead of voting for one exact
+  integer.
+  """
+  @spec density_curve([number], number, Enumerable.t()) :: %{integer => float}
+  def density_curve(events, bw, grid \\ default_grid()) do
+    grid_list = Enum.to_list(grid)
+
+    base = for n <- grid_list, into: %{}, do: {n, 0.0}
+
+    Enum.reduce(events, base, fn e, density ->
+      weights = for n <- grid_list, do: {n, gauss(n, e, bw)}
+      total = weights |> Enum.map(&elem(&1, 1)) |> Enum.sum()
+
+      Enum.reduce(weights, density, fn {n, w}, acc ->
+        contribution = if total == 0, do: 0.0, else: w / total
+        Map.update!(acc, n, &(&1 + contribution))
+      end)
+    end)
+  end
+
+  defp gauss(n, e, bw) do
+    z = (n - e) / bw
+    :math.exp(-0.5 * z * z)
+  end
+
+  @doc """
+  The risk set at each grid pick `n`: the count of drafts still "in play" for
+  this player at that pick.
+
+  **This is intentionally NOT smeared, even though the numerator is.** A
+  draft leaves the risk set *hard*, at the exact unsmeared pick the player
+  was actually taken (`e_d`) — not fractionally, as the kernel mass drains
+  away in `density_curve/3`.
+
+  This looks like an inconsistency (why smear one side and not the other?)
+  and it WILL look like a bug to someone reading this later. It is not one.
+  Fractional risk-set decay was tried and measured: it produces plausible
+  numbers that are wrong in the direction that flatters (survival reads too
+  high), concentrated exactly on players whose ADP falls before the pick
+  being evaluated — the same failure signature as a known censoring bug in
+  the plan this was ported from. Mean error against the reference fixture:
+  0.0082 fractional vs 0.00024 hard. Do not "fix" this into a fractional
+  decay; that is the regression, not an improvement. See
+  `estimator_test.exs` for the pinned regression test.
+
+  A draft counts toward the risk set at `n` when its last-made pick
+  (`l_d`) hasn't ended the draft before `n` yet, AND the player either
+  wasn't taken in that draft at all, or was taken at or after `n`.
+  """
+  @spec risk_curve([map], String.t(), Enumerable.t()) :: %{integer => non_neg_integer}
+  def risk_curve(drafts, player_id, grid \\ default_grid()) do
+    per_draft_events =
+      for draft <- drafts do
+        events = for pick <- draft.picks, pick.player_id == player_id, do: pick.norm
+        {draft.l_d, events}
+      end
+
+    for n <- Enum.to_list(grid), into: %{} do
+      count =
+        Enum.count(per_draft_events, fn {l_d, events} ->
+          l_d >= n and (events == [] or Enum.any?(events, &(&1 >= n)))
+        end)
+
+      {n, count}
+    end
+  end
+
+  @doc """
+  Base hazard curve `h(n) = d(n) / r(n)` (0 when the risk set is empty) for
+  every grid pick, for one player, derived straight from `drafts`.
+
+  Convenience wrapper around `density_curve/3` and `risk_curve/3` that also
+  derives the bandwidth from the player's own population sd — the thing
+  most callers actually want.
+  """
+  @spec base_hazard([map], String.t(), Enumerable.t()) :: %{integer => float}
+  def base_hazard(drafts, player_id, grid \\ default_grid()) do
+    events = player_events(drafts, player_id)
+    sd = events |> population_stdev()
+    bw = bandwidth(sd)
+
+    density = density_curve(events, bw, grid)
+    risk = risk_curve(drafts, player_id, grid)
+
+    for {n, r} <- risk, into: %{} do
+      h = if r == 0, do: 0.0, else: Map.fetch!(density, n) / r
+      {n, h}
+    end
+  end
+
+  defp default_grid, do: 1..@default_grid_max
+
+  # ---------------------------------------------------------------------
+  # 5. Survival
+  # ---------------------------------------------------------------------
+
+  @doc """
+  `baseSurvival(N) = product_{k=current_pick}^{N-1} (1 - h(k))`
+
+  Conditional on the player being available at `current_pick`; equals `1.0`
+  when `target_pick <= current_pick` (empty product).
+  """
+  @spec base_survival(%{integer => float}, integer, integer) :: float
+  def base_survival(hazard, current_pick, target_pick) do
+    Enum.reduce(current_pick..(target_pick - 1)//1, 1.0, fn k, acc ->
+      acc * (1 - Map.get(hazard, k, 0.0))
+    end)
+  end
+
+  @doc """
+  `adjSurvival(N) = product_{k=current_pick}^{N-1} (1 - h(k) * mult(owner(k), X))`
+
+  `mult_fun` is `(pick_number -> multiplier_float)` — already resolved
+  against a board, so this function doesn't need to know about managers,
+  ownership, or trade resolution at all.
+  """
+  @spec adjusted_survival(%{integer => float}, integer, integer, (integer -> float)) :: float
+  def adjusted_survival(hazard, current_pick, target_pick, mult_fun) do
+    Enum.reduce(current_pick..(target_pick - 1)//1, 1.0, fn k, acc ->
+      h = Map.get(hazard, k, 0.0)
+      acc * (1 - h * mult_fun.(k))
+    end)
+  end
+
+  # ---------------------------------------------------------------------
+  # 6. Manager multiplier
+  # ---------------------------------------------------------------------
+
+  @doc """
+  League-wide base rate that any given manager takes player `X` in a draft:
+  `(n_X / D) / 12`, where `n_X` is how many corpus drafts took `X` at all
+  and `D` is the corpus size.
+  """
+  @spec base_rate([map], String.t()) :: float
+  def base_rate(drafts, player_id) do
+    d = length(drafts)
+    n_x = length(player_events(drafts, player_id))
+    if d == 0, do: 0.0, else: n_x / d / 12
+  end
+
+  @doc """
+  Number of corpus drafts in which `manager` is observed to have
+  participated at all (derived from `picked_by` on the picks, not league
+  membership).
+  """
+  @spec manager_seen([map], String.t()) :: non_neg_integer
+  def manager_seen(drafts, manager) do
+    Enum.count(drafts, fn draft ->
+      Enum.any?(draft.picks, &(&1.manager == manager))
+    end)
+  end
+
+  @doc """
+  Number of those drafts in which `manager` drafted `player_id`.
+  """
+  @spec manager_took([map], String.t(), String.t()) :: non_neg_integer
+  def manager_took(drafts, manager, player_id) do
+    Enum.count(drafts, fn draft ->
+      Enum.any?(draft.picks, &(&1.manager == manager and &1.player_id == player_id))
+    end)
+  end
+
+  @doc """
+  The manager multiplier, given already-derived `seen`, `took`, and
+  `base_rate` — the pure arithmetic core of §6, independent of how those
+  three numbers were counted. This is what the "seen = 0 -> 1.0 exactly"
+  and "two different shrinkage constants" regression tests exercise
+  directly.
+
+      seen = 0  ->  1.0                                    (league average; no opinion)
+      otherwise:
+        rate   = took / seen
+        lambda = seen / (seen + 8)     # shrinks the RATE toward base_rate
+        w      = seen / (seen + 12)    # confidence weight on the MULTIPLIER
+        shrunk = lambda * rate + (1 - lambda) * base_rate
+        mult   = 1 + w * (shrunk / base_rate - 1)
+
+  `lambda` and `w` are deliberately different constants (`+8` vs `+12`),
+  applied in series — do not unify them into a single shrinkage factor.
+
+  If `base_rate` is `0.0` (a player no leaguemate in the corpus has ever
+  taken — see moduledoc / spec "not pinned" #1), this returns `1.0` rather
+  than dividing by zero. That's a documented choice, not a recovered
+  behaviour: there is no reference value to fit it against.
+  """
+  @spec multiplier(non_neg_integer, non_neg_integer, float) :: float
+  def multiplier(0, _took, _base_rate), do: 1.0
+
+  def multiplier(_seen, _took, base_rate) when base_rate == 0.0, do: 1.0
+
+  def multiplier(seen, took, base_rate) do
+    rate = took / seen
+    lambda = seen / (seen + 8)
+    w = seen / (seen + 12)
+    shrunk = lambda * rate + (1 - lambda) * base_rate
+    1 + w * (shrunk / base_rate - 1)
+  end
+
+  @doc """
+  Convenience wrapper: derives `seen`, `took`, and `base_rate` from `drafts`
+  and calls `multiplier/3`. Prefer `multiplier/3` directly in tight loops
+  (e.g. computing threats for many picks against the same player) since it
+  avoids re-deriving `base_rate` and re-scanning `drafts` on every call.
+  """
+  @spec manager_multiplier([map], String.t(), String.t()) :: float
+  def manager_multiplier(drafts, manager, player_id) do
+    seen = manager_seen(drafts, manager)
+    took = manager_took(drafts, manager, player_id)
+    base = base_rate(drafts, player_id)
+    multiplier(seen, took, base)
+  end
+
+  # ---------------------------------------------------------------------
+  # 7. Threats
+  # ---------------------------------------------------------------------
+
+  @doc """
+  The threat list for target pick `target_pick`: every pick `k` in
+  `[current_pick, target_pick)` whose owner (per `board`, a `%{pick_number
+  => manager}` map) is a known leaguemate, in pick order.
+
+  `hazard` is the base hazard curve (see `base_hazard/3`). `known_managers`
+  is used to decide whether a board owner is a tracked leaguemate at all —
+  picks owned by someone outside that set are excluded from the list (they
+  still affect survival via `mult_fun`, just not the itemized threat
+  receipts).
+
+  `mult_fun` is `(manager -> multiplier_float)`.
+  """
+  @spec threats(
+          %{integer => float},
+          integer,
+          integer,
+          %{integer => String.t()},
+          MapSet.t(String.t()),
+          (String.t() -> float),
+          (String.t() -> non_neg_integer),
+          (String.t() -> non_neg_integer)
+        ) :: [map]
+  def threats(
+        hazard,
+        current_pick,
+        target_pick,
+        board,
+        known_managers,
+        mult_fun,
+        seen_fun,
+        took_fun
+      ) do
+    for k <- current_pick..(target_pick - 1)//1,
+        manager = Map.get(board, k),
+        manager != nil,
+        MapSet.member?(known_managers, manager) do
+      mult = mult_fun.(manager)
+      h = Map.get(hazard, k, 0.0)
+
+      %{
+        manager: manager,
+        pick: k,
+        prob: h * mult,
+        drafts: seen_fun.(manager),
+        tookCount: took_fun.(manager)
+      }
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 8. Market layer
+  # ---------------------------------------------------------------------
+
+  @doc """
+  Rank of each entry within `rookie_class_entries` by descending `value`
+  (ties keep encounter order), 1-indexed — `marketPick` in §8. Callers are
+  responsible for filtering `entries` down to the rookie class first (see
+  moduledoc — this is not overall rank, and ranking the full pool gives
+  numbers that are internally consistent and completely wrong).
+
+  `entries` is a list of `{player_id, value}` pairs.
+  """
+  @spec rookie_class_rank([{String.t(), number}]) :: %{String.t() => pos_integer}
+  def rookie_class_rank(entries) do
+    entries
+    |> Enum.sort_by(fn {_id, value} -> -value end)
+    |> Enum.with_index(1)
+    |> Enum.map(fn {{id, _value}, rank} -> {id, rank} end)
+    |> Map.new()
+  end
+
+  @doc """
+  `adpGap = round(leagueAdp - marketPick, 1)`. Returns `nil` when
+  `market_pick` is `nil` (player not part of the resolved rookie class).
+  """
+  @spec adp_gap(number, pos_integer | nil) :: float | nil
+  def adp_gap(_league_adp, nil), do: nil
+
+  def adp_gap(league_adp, market_pick) do
+    Float.round(league_adp - market_pick * 1.0, 1)
+  end
+end

--- a/lib/sleeper_player_api/intel/observed_draft.ex
+++ b/lib/sleeper_player_api/intel/observed_draft.ex
@@ -1,0 +1,39 @@
+defmodule SleeperPlayerApi.Intel.ObservedDraft do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :id, autogenerate: false}
+  schema "observed_drafts" do
+    field :league_id, :integer
+    field :season, :string
+    field :status, :string
+    field :draft_type, :string
+    field :player_type, :integer
+    field :teams, :integer
+    field :rounds, :integer
+    field :start_time, :integer
+    field :slot_to_roster_id, :map
+    field :picks_fetched_at, :utc_datetime
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(observed_draft, attrs) do
+    observed_draft
+    |> cast(attrs, [
+      :id,
+      :league_id,
+      :season,
+      :status,
+      :draft_type,
+      :player_type,
+      :teams,
+      :rounds,
+      :start_time,
+      :slot_to_roster_id,
+      :picks_fetched_at
+    ])
+    |> validate_required([:id])
+  end
+end

--- a/lib/sleeper_player_api/intel/observed_pick.ex
+++ b/lib/sleeper_player_api/intel/observed_pick.ex
@@ -1,0 +1,27 @@
+defmodule SleeperPlayerApi.Intel.ObservedPick do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SleeperPlayerApi.Intel.ObservedDraft
+
+  @primary_key false
+  schema "observed_picks" do
+    belongs_to :draft, ObservedDraft, references: :id
+    field :pick_no, :integer
+    field :round, :integer
+    field :draft_slot, :integer
+    field :roster_id, :integer
+    field :player_id, :string
+    field :picked_by, :integer
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(observed_pick, attrs) do
+    observed_pick
+    |> cast(attrs, [:draft_id, :pick_no, :round, :draft_slot, :roster_id, :player_id, :picked_by])
+    |> validate_required([:draft_id, :pick_no])
+    |> unique_constraint([:draft_id, :pick_no])
+  end
+end

--- a/lib/sleeper_player_api/intel/observed_traded_pick.ex
+++ b/lib/sleeper_player_api/intel/observed_traded_pick.ex
@@ -1,0 +1,26 @@
+defmodule SleeperPlayerApi.Intel.ObservedTradedPick do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SleeperPlayerApi.Intel.ObservedDraft
+
+  @primary_key false
+  schema "observed_traded_picks" do
+    belongs_to :draft, ObservedDraft, references: :id
+    field :season, :string
+    field :round, :integer
+    field :roster_id, :integer
+    field :previous_owner_id, :integer
+    field :owner_id, :integer
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(observed_traded_pick, attrs) do
+    observed_traded_pick
+    |> cast(attrs, [:draft_id, :season, :round, :roster_id, :previous_owner_id, :owner_id])
+    |> validate_required([:draft_id, :season, :round, :roster_id])
+    |> unique_constraint([:draft_id, :season, :round, :roster_id])
+  end
+end

--- a/lib/sleeper_player_api/intel/player_value.ex
+++ b/lib/sleeper_player_api/intel/player_value.ex
@@ -1,0 +1,35 @@
+defmodule SleeperPlayerApi.Intel.PlayerValue do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "player_values" do
+    field :player_id, :integer
+    field :source, :string
+    field :value, :float
+    field :overall_rank, :integer
+    field :position_rank, :integer
+    field :roster_percent, :float
+    field :trade_frequency, :float
+    field :as_of, :utc_datetime
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(player_value, attrs) do
+    player_value
+    |> cast(attrs, [
+      :player_id,
+      :source,
+      :value,
+      :overall_rank,
+      :position_rank,
+      :roster_percent,
+      :trade_frequency,
+      :as_of
+    ])
+    |> validate_required([:player_id, :source])
+    |> unique_constraint([:player_id, :source])
+  end
+end

--- a/lib/sleeper_player_api/intel/sleeper_user.ex
+++ b/lib/sleeper_player_api/intel/sleeper_user.ex
@@ -1,0 +1,21 @@
+defmodule SleeperPlayerApi.Intel.SleeperUser do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :id, autogenerate: false}
+  schema "sleeper_users" do
+    field :username, :string
+    field :display_name, :string
+    field :avatar, :string
+    field :last_crawled_at, :utc_datetime
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(sleeper_user, attrs) do
+    sleeper_user
+    |> cast(attrs, [:id, :username, :display_name, :avatar, :last_crawled_at])
+    |> validate_required([:id])
+  end
+end

--- a/priv/repo/migrations/20260805215400_create_sleeper_users.exs
+++ b/priv/repo/migrations/20260805215400_create_sleeper_users.exs
@@ -1,0 +1,15 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateSleeperUsers do
+  use Ecto.Migration
+
+  def change do
+    create table(:sleeper_users, primary_key: false) do
+      add :id, :bigint, primary_key: true
+      add :username, :string
+      add :display_name, :string
+      add :avatar, :string
+      add :last_crawled_at, :utc_datetime
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20260805215402_create_observed_drafts.exs
+++ b/priv/repo/migrations/20260805215402_create_observed_drafts.exs
@@ -1,0 +1,25 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedDrafts do
+  use Ecto.Migration
+
+  def change do
+    create table(:observed_drafts, primary_key: false) do
+      add :id, :bigint, primary_key: true
+      add :league_id, :bigint
+      add :season, :string
+      add :status, :string
+      add :draft_type, :string
+      add :player_type, :integer
+      add :teams, :integer
+      add :rounds, :integer
+      add :start_time, :bigint
+      add :slot_to_roster_id, :map
+      add :picks_fetched_at, :utc_datetime
+
+      timestamps()
+    end
+
+    create index(:observed_drafts, [:league_id])
+    create index(:observed_drafts, [:status])
+    create index(:observed_drafts, [:season])
+  end
+end

--- a/priv/repo/migrations/20260805215403_create_observed_picks.exs
+++ b/priv/repo/migrations/20260805215403_create_observed_picks.exs
@@ -1,0 +1,24 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedPicks do
+  use Ecto.Migration
+
+  def change do
+    create table(:observed_picks, primary_key: false) do
+      add :draft_id,
+          references(:observed_drafts, column: :id, type: :bigint, on_delete: :delete_all),
+          null: false
+
+      add :pick_no, :integer, null: false
+      add :round, :integer
+      add :draft_slot, :integer
+      add :roster_id, :integer
+      add :player_id, :string
+      add :picked_by, :bigint
+
+      timestamps()
+    end
+
+    create unique_index(:observed_picks, [:draft_id, :pick_no])
+    create index(:observed_picks, [:player_id])
+    create index(:observed_picks, [:picked_by])
+  end
+end

--- a/priv/repo/migrations/20260805215405_create_observed_traded_picks.exs
+++ b/priv/repo/migrations/20260805215405_create_observed_traded_picks.exs
@@ -1,0 +1,22 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedTradedPicks do
+  use Ecto.Migration
+
+  def change do
+    create table(:observed_traded_picks, primary_key: false) do
+      add :draft_id,
+          references(:observed_drafts, column: :id, type: :bigint, on_delete: :delete_all),
+          null: false
+
+      add :season, :string
+      add :round, :integer
+      add :roster_id, :integer
+      add :previous_owner_id, :integer
+      add :owner_id, :integer
+
+      timestamps()
+    end
+
+    create unique_index(:observed_traded_picks, [:draft_id, :season, :round, :roster_id])
+    create index(:observed_traded_picks, [:draft_id])
+  end
+end

--- a/priv/repo/migrations/20260805215406_create_player_values.exs
+++ b/priv/repo/migrations/20260805215406_create_player_values.exs
@@ -1,0 +1,21 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreatePlayerValues do
+  use Ecto.Migration
+
+  def change do
+    create table(:player_values, primary_key: false) do
+      add :player_id, :bigint, null: false
+      add :source, :string, null: false
+      add :value, :float
+      add :overall_rank, :integer
+      add :position_rank, :integer
+      add :roster_percent, :float
+      add :trade_frequency, :float
+      add :as_of, :utc_datetime
+
+      timestamps()
+    end
+
+    create unique_index(:player_values, [:player_id, :source])
+    create index(:player_values, [:source])
+  end
+end

--- a/priv/repo/migrations/20260805215408_create_draft_participants.exs
+++ b/priv/repo/migrations/20260805215408_create_draft_participants.exs
@@ -1,0 +1,20 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateDraftParticipants do
+  use Ecto.Migration
+
+  def change do
+    create table(:draft_participants, primary_key: false) do
+      add :draft_id,
+          references(:observed_drafts, column: :id, type: :bigint, on_delete: :delete_all),
+          null: false
+
+      add :user_id,
+          references(:sleeper_users, column: :id, type: :bigint, on_delete: :delete_all),
+          null: false
+
+      timestamps()
+    end
+
+    create unique_index(:draft_participants, [:draft_id, :user_id])
+    create index(:draft_participants, [:user_id])
+  end
+end

--- a/test/sleeper_player_api/intel/estimator_test.exs
+++ b/test/sleeper_player_api/intel/estimator_test.exs
@@ -1,0 +1,495 @@
+defmodule SleeperPlayerApi.Intel.EstimatorTest do
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApi.Intel.Estimator
+  alias SleeperPlayerApi.IntelCorpus
+
+  @tolerance 0.0005
+
+  # ---------------------------------------------------------------------
+  # 2. Normalization
+  # ---------------------------------------------------------------------
+
+  describe "normalize_pick/2" do
+    test "rescales an absolute pick to its 12-team-equivalent position" do
+      assert Estimator.normalize_pick(1, 12) == 1.0
+      assert Estimator.normalize_pick(13, 12) == 13.0
+      # a 10-team league's pick 10 (last of round 1) maps past 12-team's pick 12
+      assert_in_delta Estimator.normalize_pick(10, 10), 11.8, @tolerance
+    end
+
+    test "does not round — fractional results are the point" do
+      # 8-team league, pick 5: (5-1)/8*12+1 = 7.0 exactly, but pick 6 is fractional
+      assert_in_delta Estimator.normalize_pick(6, 8), 8.5, @tolerance
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 3. Population standard deviation — the trap
+  # ---------------------------------------------------------------------
+
+  describe "population_stdev/1 — trap: population, not sample" do
+    test "matches the textbook population sd, not the sample (n-1) sd" do
+      values = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+
+      # population sd (divide by n) for this classic example is exactly 2.0
+      assert_in_delta Estimator.population_stdev(values), 2.0, 1.0e-9
+
+      # the sample sd (divide by n-1) would be ~2.1381 — visibly different,
+      # and it's what you get if you reach for a stdlib/Enum-based stdev
+      # helper without checking which denominator it uses.
+      sample_sd = :math.sqrt(Enum.reduce(values, 0.0, fn v, acc -> acc + (v - 5.0) ** 2 end) / 7)
+      refute_in_delta Estimator.population_stdev(values), sample_sd, 1.0e-9
+    end
+
+    test "empty list is 0.0, not NaN" do
+      assert Estimator.population_stdev([]) == 0.0
+    end
+  end
+
+  describe "adp_summary/1" do
+    test "n, adp, sd, min, max over normalized events" do
+      summary = Estimator.adp_summary([10.0, 12.0, 14.0])
+
+      assert summary.n == 3
+      assert_in_delta summary.adp, 12.0, @tolerance
+      assert_in_delta summary.sd, Estimator.population_stdev([10.0, 12.0, 14.0]), 1.0e-9
+      assert summary.min == 10.0
+      assert summary.max == 14.0
+    end
+
+    test "nil for a player absent from the corpus" do
+      assert Estimator.adp_summary([]) == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 4. Base hazard — the hard risk-set decrement trap
+  # ---------------------------------------------------------------------
+
+  describe "risk_curve/3 — trap: the risk set leaves HARD, not fractionally" do
+    test "a draft leaves the risk set at the exact pick the player was taken" do
+      # Two synthetic drafts, both still "going" (l_d = 5.0) at the pick
+      # we're evaluating:
+      #   draft 1: player X taken at normalized pick 2.0
+      #   draft 2: player X never taken, draft ran to normalized pick 5.0
+      drafts = [
+        %{l_d: 5.0, picks: [%{norm: 2.0, player_id: "X", manager: nil}]},
+        %{l_d: 5.0, picks: [%{norm: 4.0, player_id: "Y", manager: nil}]}
+      ]
+
+      risk = Estimator.risk_curve(drafts, "X", 1..6)
+
+      # DO NOT "fix" this to something like 1.3 or 1.7 by fractionally
+      # decaying draft 1's membership as the Gaussian kernel mass drains
+      # away near pick 2. Draft 1 took X at pick 2, so it is hard-out of
+      # the risk set for every n >= 3 — full stop, no partial credit.
+      # This is exactly the behaviour `docs/leaguemate-intel-estimator.md`
+      # §4 calls out as "the central trap": smearing this too (instead of
+      # just the density numerator) gives plausible-looking numbers that
+      # are measurably wrong (mean error 0.0082 vs 0.00024 hard, in the
+      # reference fit).
+      assert risk[1] == 2
+      assert risk[2] == 2
+      assert risk[3] == 1
+      assert risk[4] == 1
+      assert risk[5] == 1
+      assert risk[6] == 0
+    end
+
+    test "a draft that already ended leaves the risk set at l_d + 1, regardless of the player" do
+      drafts = [%{l_d: 3.0, picks: []}]
+
+      risk = Estimator.risk_curve(drafts, "unseen-player", 1..5)
+
+      assert risk[3] == 1
+      assert risk[4] == 0
+    end
+  end
+
+  describe "density_curve/3" do
+    test "each observed event contributes exactly 1.0 of total mass across the grid" do
+      density = Estimator.density_curve([10.0], 1.0, 1..80)
+
+      total = density |> Map.values() |> Enum.sum()
+      assert_in_delta total, 1.0, 1.0e-9
+    end
+
+    test "multiple events sum their contributed mass" do
+      density = Estimator.density_curve([10.0, 20.0], 1.0, 1..80)
+
+      total = density |> Map.values() |> Enum.sum()
+      assert_in_delta total, 2.0, 1.0e-9
+    end
+  end
+
+  describe "bandwidth/1" do
+    test "clamps to [0.6, 1.5] around 0.4 * sd" do
+      assert Estimator.bandwidth(0.0) == 0.6
+      assert Estimator.bandwidth(100.0) == 1.5
+      assert_in_delta Estimator.bandwidth(5.0), 2.0 |> min(1.5), @tolerance
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 5. Survival
+  # ---------------------------------------------------------------------
+
+  describe "base_survival/3 and adjusted_survival/4" do
+    test "survival at current_pick is 1.0 by construction (empty product)" do
+      hazard = %{35 => 0.5, 36 => 0.5}
+      assert Estimator.base_survival(hazard, 35, 35) == 1.0
+      assert Estimator.adjusted_survival(hazard, 35, 35, fn _ -> 1.0 end) == 1.0
+    end
+
+    test "base_survival multiplies (1 - hazard) across the open interval" do
+      hazard = %{35 => 0.5, 36 => 0.25}
+      assert_in_delta Estimator.base_survival(hazard, 35, 37), 0.5 * 0.75, 1.0e-9
+    end
+
+    test "adjusted_survival scales each station's hazard by that pick's multiplier" do
+      hazard = %{35 => 0.5, 36 => 0.25}
+
+      mult_fun = fn
+        35 -> 2.0
+        36 -> 1.0
+      end
+
+      # station 35: hazard effectively min(1.0, 0.5*2.0) per the raw formula (1 - 1.0) = 0.0
+      assert_in_delta Estimator.adjusted_survival(hazard, 35, 37, mult_fun), 0.0, 1.0e-9
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 6. Manager multiplier — the two-constants trap and the seen=0 trap
+  # ---------------------------------------------------------------------
+
+  describe "multiplier/3 — trap: mult == 1.0 exactly when seen == 0" do
+    test "an unobserved manager always gets the league average, regardless of base_rate" do
+      assert Estimator.multiplier(0, 0, 0.05) == 1.0
+      assert Estimator.multiplier(0, 0, 0.9) == 1.0
+      # even a nonsensical took count can't matter when seen is 0
+      assert Estimator.multiplier(0, 5, 0.05) == 1.0
+    end
+
+    test "base_rate == 0.0 also short-circuits to 1.0 instead of dividing by zero" do
+      assert Estimator.multiplier(10, 0, 0.0) == 1.0
+    end
+  end
+
+  describe "multiplier/3 — trap: lambda uses +8, w uses +12, and they are NOT the same constant" do
+    test "zero-take rows collapse to 1 - w*lambda, independent of the player" do
+      # Reference anchors (docs/leaguemate-intel-estimator.md §6). With
+      # took = 0, `shrunk / base_rate` reduces to `(1 - lambda)`, so the
+      # result is independent of base_rate entirely — that's what makes
+      # these rows usable as constant-recovery anchors in the first place.
+      # Using base_rate: 0.05 here is arbitrary and irrelevant to the result.
+      assert_in_delta Estimator.multiplier(1, 0, 0.05), 0.991, @tolerance
+      assert_in_delta Estimator.multiplier(30, 0, 0.05), 0.436, @tolerance
+    end
+
+    test "using k=12 for BOTH constants (the wrong reading of the plan) is measurably different" do
+      wrong_multiplier = fn seen, took, base_rate ->
+        rate = if seen == 0, do: 0.0, else: took / seen
+        lambda = seen / (seen + 12)
+        w = seen / (seen + 12)
+        shrunk = lambda * rate + (1 - lambda) * base_rate
+        1 + w * (shrunk / base_rate - 1)
+      end
+
+      correct = Estimator.multiplier(30, 0, 0.05)
+      wrong = wrong_multiplier.(30, 0, 0.05)
+
+      assert_in_delta correct, 0.436, @tolerance
+      # off by several points of multiplier at 30 drafts, per the spec
+      assert abs(correct - wrong) > 0.03
+    end
+  end
+
+  describe "manager_multiplier/3 — against corpus reference anchors" do
+    setup do
+      {:ok, drafts: IntelCorpus.drafts()}
+    end
+
+    test "cja9689 (seen 1, took 0) -> 0.991", %{drafts: drafts} do
+      assert_in_delta Estimator.manager_multiplier(drafts, "cja9689", "13306"), 0.991, @tolerance
+    end
+
+    test "atekipp (seen 3, took 0) -> collapsed formula value", %{drafts: drafts} do
+      # NOTE: docs/leaguemate-intel-estimator.md §6's anchor table lists this
+      # row as 0.946. The formula (verified end-to-end against all 1,904
+      # fixture values at max deviation 0.000498, see estimator_test.exs
+      # "golden test" below) actually gives 0.9454545... which rounds to
+      # 0.945, not 0.946. Since the seen=3/took=0 case collapses to
+      # `1 - w*lambda` independent of which player or base_rate is used
+      # (see the pure-formula trap test above), there is no ambiguity in
+      # what "correct" means here — this reads as a one-digit typo in the
+      # spec doc rather than a different intended formula. Asserting the
+      # value the implementation actually (and verifiably) produces.
+      assert_in_delta Estimator.manager_multiplier(drafts, "atekipp", "13306"), 0.9455, @tolerance
+    end
+
+    test "baconstains (seen 30, took 0) -> 0.436", %{drafts: drafts} do
+      assert_in_delta Estimator.manager_multiplier(drafts, "baconstains", "13306"),
+                      0.436,
+                      @tolerance
+    end
+
+    test "any manager unobserved in the corpus -> 1.000 exactly", %{drafts: drafts} do
+      assert Estimator.manager_multiplier(drafts, "nobody-ever-drafted-here", "13306") == 1.0
+    end
+
+    test "babaghanoush123 on Taylen Green (seen 24, took 13) reproduces the fixture threat, h*mult",
+         %{drafts: drafts} do
+      # The spec's anchor table quotes mult = 5.144 for this row; the
+      # formula gives 5.142857... (rounds to 5.143). The two disagree by
+      # more than the golden tolerance in isolation, but what actually
+      # ships is h(k) * mult(k), and *that* product reproduces the
+      # fixture's threat probability (0.454 at pick 46) within tolerance —
+      # see the golden test below. Treating the anchor table's literal
+      # mult value as a documentation rounding artifact, same as atekipp.
+      hazard = Estimator.base_hazard(drafts, "13306")
+      mult = Estimator.manager_multiplier(drafts, "babaghanoush123", "13306")
+      assert_in_delta mult, 5.142857, 0.001
+      assert_in_delta hazard[46] * mult, 0.454, @tolerance
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 7. Threats
+  # ---------------------------------------------------------------------
+
+  describe "threats/8" do
+    test "lists every pick in [current_pick, target_pick) owned by a known leaguemate, in order" do
+      hazard = %{35 => 0.2, 36 => 0.3, 37 => 0.4}
+      board = %{35 => "alice", 36 => "bob", 37 => "stranger"}
+      known = MapSet.new(["alice", "bob"])
+
+      result =
+        Estimator.threats(
+          hazard,
+          35,
+          38,
+          board,
+          known,
+          fn _manager -> 1.0 end,
+          fn _manager -> 10 end,
+          fn _manager -> 2 end
+        )
+
+      assert Enum.map(result, & &1.manager) == ["alice", "bob"]
+      assert Enum.map(result, & &1.pick) == [35, 36]
+      assert Enum.map(result, & &1.prob) == [0.2, 0.3]
+      assert Enum.all?(result, &(&1.drafts == 10 and &1.tookCount == 2))
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 8. Market layer
+  # ---------------------------------------------------------------------
+
+  describe "rookie_class_rank/1 and adp_gap/2 — against the reference corpus" do
+    setup do
+      {:ok, ranks: IntelCorpus.rookie_class_entries() |> Estimator.rookie_class_rank()}
+    end
+
+    test "Brazzell 26.7 - 31 = -4.3", %{ranks: ranks} do
+      assert ranks["13353"] == 31
+      assert Estimator.adp_gap(26.7, ranks["13353"]) == -4.3
+    end
+
+    test "Claiborne 33.0 - 24 = +9.0", %{ranks: ranks} do
+      assert ranks["13347"] == 24
+      assert Estimator.adp_gap(33.0, ranks["13347"]) == 9.0
+    end
+
+    test "Delp 33.9 - 34 = -0.1", %{ranks: ranks} do
+      assert ranks["13319"] == 34
+      assert Estimator.adp_gap(33.9, ranks["13319"]) == -0.1
+    end
+
+    test "Kacmarek 38.8 - 50 = -11.2", %{ranks: ranks} do
+      assert ranks["13434"] == 50
+      assert Estimator.adp_gap(38.8, ranks["13434"]) == -11.2
+    end
+
+    test "a player with no maybeDraftInfo (not cleanly flagged as rookie class) has no rank", %{
+      ranks: ranks
+    } do
+      # Justin Joly: has a FantasyCalc value but no draft-class metadata —
+      # excluded from the rookie class, same as the fixture (marketPick:
+      # null). See docs/leaguemate-intel-estimator.md §10 item 4.
+      refute Map.has_key?(ranks, "13400")
+      assert Estimator.adp_gap(38.0, ranks["13400"]) == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # 9. The golden test
+  # ---------------------------------------------------------------------
+
+  describe "golden test — reproduces fixture.json end to end" do
+    setup do
+      fixture = IntelCorpus.fixture()
+
+      {:ok,
+       drafts: IntelCorpus.drafts(),
+       known_managers: IntelCorpus.known_managers(),
+       fixture: fixture,
+       board: IntelCorpus.board_from_fixture(fixture)}
+    end
+
+    test "every baseSurvival, adjSurvival, and threat prob across all 16 targets x 14 picks is within 0.0005 of the fixture",
+         %{drafts: drafts, known_managers: known_managers, fixture: fixture, board: board} do
+      current_pick = fixture["currentPick"]
+
+      deviations = %{base: [], adj: [], threat: []}
+
+      deviations =
+        Enum.reduce(fixture["targets"], deviations, fn target, deviations ->
+          player_id = target["id"]
+
+          events = Estimator.player_events(drafts, player_id)
+          summary = Estimator.adp_summary(events)
+
+          # The ADP block in the fixture is rounded to 1 decimal place
+          # (unlike baseSurvival/adjSurvival/threats, which are rounded to
+          # 3), so it needs a correspondingly looser tolerance — half of
+          # its own rounding quantum, same principle as @tolerance.
+          assert summary.n == target["n"], "n mismatch for #{target["name"]}"
+          assert_in_delta summary.adp, target["leagueAdp"], 0.051
+          assert_in_delta summary.sd, target["sd"], 0.051
+          assert_in_delta summary.min, target["min"], 0.051
+          assert_in_delta summary.max, target["max"], 0.051
+
+          hazard = Estimator.base_hazard(drafts, player_id)
+
+          base_rate = Estimator.base_rate(drafts, player_id)
+
+          mult_fun = fn manager ->
+            seen = Estimator.manager_seen(drafts, manager)
+            took = Estimator.manager_took(drafts, manager, player_id)
+            Estimator.multiplier(seen, took, base_rate)
+          end
+
+          Enum.reduce(target["byPick"], deviations, fn {pick_str, expected}, deviations ->
+            target_pick = String.to_integer(pick_str)
+
+            base_survival = Estimator.base_survival(hazard, current_pick, target_pick)
+
+            board_mult_fun = fn k -> mult_fun.(Map.get(board, k)) end
+
+            adj_survival =
+              Estimator.adjusted_survival(hazard, current_pick, target_pick, board_mult_fun)
+
+            threats =
+              Estimator.threats(
+                hazard,
+                current_pick,
+                target_pick,
+                board,
+                known_managers,
+                mult_fun,
+                fn manager -> Estimator.manager_seen(drafts, manager) end,
+                fn manager -> Estimator.manager_took(drafts, manager, player_id) end
+              )
+
+            assert_in_delta base_survival,
+                            expected["baseSurvival"],
+                            @tolerance,
+                            "baseSurvival mismatch for #{target["name"]} @ pick #{target_pick}"
+
+            assert_in_delta adj_survival,
+                            expected["adjSurvival"],
+                            @tolerance,
+                            "adjSurvival mismatch for #{target["name"]} @ pick #{target_pick}"
+
+            expected_threats = expected["threats"]
+
+            assert length(threats) == length(expected_threats),
+                   "threat count mismatch for #{target["name"]} @ pick #{target_pick}"
+
+            Enum.zip(threats, expected_threats)
+            |> Enum.each(fn {actual, expected_threat} ->
+              assert actual.manager == expected_threat["manager"]
+              assert actual.pick == expected_threat["pick"]
+              assert actual.drafts == expected_threat["drafts"]
+              assert actual.tookCount == expected_threat["tookCount"]
+
+              assert_in_delta actual.prob,
+                              expected_threat["prob"],
+                              @tolerance,
+                              "threat prob mismatch for #{target["name"]} @ pick #{target_pick}, owner #{actual.manager}"
+            end)
+
+            %{
+              base: [abs(base_survival - expected["baseSurvival"]) | deviations.base],
+              adj: [abs(adj_survival - expected["adjSurvival"]) | deviations.adj],
+              threat:
+                Enum.zip(threats, expected_threats)
+                |> Enum.map(fn {a, e} -> abs(a.prob - e["prob"]) end)
+                |> Kernel.++(deviations.threat)
+            }
+          end)
+        end)
+
+      max_base = Enum.max(deviations.base)
+      max_adj = Enum.max(deviations.adj)
+      max_threat = Enum.max(deviations.threat)
+
+      # NOTE: docs/leaguemate-intel-estimator.md §9 states "224 baseSurvival,
+      # 224 adjSurvival, 1,456 threat probabilities" (16 targets x 14
+      # picks). The fixture actually shipped with 15 picks per target
+      # (35..49, not 35..48) — 16 x 15 = 240 base/adj entries and 1,680
+      # threat entries. Asserting against what the fixture actually
+      # contains rather than the spec doc's arithmetic, since the fixture
+      # is the stated source of truth ("Expected output: fixture.json").
+      expected_base_count =
+        Enum.reduce(fixture["targets"], 0, fn t, acc -> acc + map_size(t["byPick"]) end)
+
+      expected_threat_count =
+        Enum.reduce(fixture["targets"], 0, fn t, acc ->
+          acc + Enum.reduce(t["byPick"], 0, fn {_k, v}, acc2 -> acc2 + length(v["threats"]) end)
+        end)
+
+      assert length(deviations.base) == expected_base_count
+      assert length(deviations.adj) == expected_base_count
+      assert length(deviations.threat) == expected_threat_count
+
+      IO.puts("""
+
+      Golden test deviations (tolerance #{@tolerance}):
+        baseSurvival: max #{Float.round(max_base, 6)} over #{length(deviations.base)} values
+        adjSurvival:  max #{Float.round(max_adj, 6)} over #{length(deviations.adj)} values
+        threats:      max #{Float.round(max_threat, 6)} over #{length(deviations.threat)} values
+      """)
+    end
+
+    test "Oscar Delp reads 59% at pick 39 against an observed 45% — a documented model property, not a bug",
+         %{drafts: drafts, known_managers: known_managers, fixture: fixture, board: board} do
+      current_pick = fixture["currentPick"]
+      player_id = "13319"
+
+      hazard = Estimator.base_hazard(drafts, player_id)
+      base_rate = Estimator.base_rate(drafts, player_id)
+
+      mult_fun = fn k ->
+        manager = Map.get(board, k)
+        seen = Estimator.manager_seen(drafts, manager)
+        took = Estimator.manager_took(drafts, manager, player_id)
+        Estimator.multiplier(seen, took, base_rate)
+      end
+
+      _ = known_managers
+
+      adj_survival = Estimator.adjusted_survival(hazard, current_pick, 39, mult_fun)
+
+      # This is the known-high number the spec calls out: the fixture has
+      # it at 0.589 (~59%) against an observed 45%. If a future change to
+      # the bandwidth cap or kernel moves this toward 0.45, that's a
+      # deliberate model change under §4d — not a silent "fix". Pin it here
+      # so it can't drift by accident.
+      assert_in_delta adj_survival, 0.589, @tolerance
+    end
+  end
+end

--- a/test/sleeper_player_api/intel/estimator_test.exs
+++ b/test/sleeper_player_api/intel/estimator_test.exs
@@ -207,6 +207,7 @@ defmodule SleeperPlayerApi.Intel.EstimatorTest do
   end
 
   describe "manager_multiplier/3 — against corpus reference anchors" do
+    @describetag :corpus
     setup do
       {:ok, drafts: IntelCorpus.drafts()}
     end
@@ -289,6 +290,7 @@ defmodule SleeperPlayerApi.Intel.EstimatorTest do
   # ---------------------------------------------------------------------
 
   describe "rookie_class_rank/1 and adp_gap/2 — against the reference corpus" do
+    @describetag :corpus
     setup do
       {:ok, ranks: IntelCorpus.rookie_class_entries() |> Estimator.rookie_class_rank()}
     end
@@ -329,6 +331,7 @@ defmodule SleeperPlayerApi.Intel.EstimatorTest do
   # ---------------------------------------------------------------------
 
   describe "golden test — reproduces fixture.json end to end" do
+    @describetag :corpus
     setup do
       fixture = IntelCorpus.fixture()
 

--- a/test/sleeper_player_api/intel_test.exs
+++ b/test/sleeper_player_api/intel_test.exs
@@ -1,0 +1,285 @@
+defmodule SleeperPlayerApi.IntelTest do
+  use SleeperPlayerApi.DataCase, async: true
+
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.IntelCorpus
+  alias SleeperPlayerApi.Intel.{Estimator, ObservedDraft, ObservedPick}
+
+  @corpus_dir Path.expand("../support/corpus", __DIR__)
+
+  # ---------------------------------------------------------------------
+  # Small inline fixtures — no corpus needed, always run
+  # ---------------------------------------------------------------------
+
+  describe "upserts + drafts_corpus/1 against a hand-built fixture" do
+    test "shapes a stored draft into exactly the estimator's input structure" do
+      Intel.upsert_observed_drafts([%{id: 1, teams: 12, status: "complete"}])
+
+      Intel.upsert_observed_picks(1, [
+        %{pick_no: 1, round: 1, draft_slot: 1, roster_id: 1, player_id: "P1", picked_by: 100},
+        %{pick_no: 2, round: 1, draft_slot: 2, roster_id: 2, player_id: "P2", picked_by: nil}
+      ])
+
+      assert [draft] = Intel.drafts_corpus(%{100 => "alice"})
+
+      assert_in_delta draft.l_d, Estimator.normalize_pick(2, 12), 1.0e-9
+
+      assert draft.picks == [
+               %{norm: Estimator.normalize_pick(1, 12), player_id: "P1", manager: "alice"},
+               %{norm: Estimator.normalize_pick(2, 12), player_id: "P2", manager: nil}
+             ]
+    end
+
+    test "a draft with no stored picks is skipped, not crashed on" do
+      Intel.upsert_observed_drafts([%{id: 2, teams: 12, status: "pre_draft"}])
+
+      assert Intel.drafts_corpus(%{}) == []
+    end
+
+    test "unmapped picked_by (not a tracked leaguemate) still counts toward the draft, manager: nil" do
+      Intel.upsert_observed_drafts([%{id: 3, teams: 12, status: "complete"}])
+      Intel.upsert_observed_picks(3, [%{pick_no: 1, player_id: "P1", picked_by: 999}])
+
+      assert [%{picks: [%{manager: nil}]}] = Intel.drafts_corpus(%{100 => "alice"})
+    end
+
+    test "upserts are idempotent and update in place on conflict, not duplicate" do
+      Intel.upsert_observed_drafts([%{id: 4, teams: 10, status: "drafting"}])
+      Intel.upsert_observed_picks(4, [%{pick_no: 1, player_id: "P1", picked_by: 5}])
+
+      # A re-crawl of an in-progress draft (plan §3c) overwrites in place.
+      Intel.upsert_observed_drafts([%{id: 4, teams: 10, status: "complete"}])
+      Intel.upsert_observed_picks(4, [%{pick_no: 1, player_id: "P9", picked_by: 5}])
+
+      assert %{status: "complete"} = Repo.get!(ObservedDraft, 4)
+
+      assert [%{player_id: "P9"}] =
+               Repo.all(from(p in ObservedPick, where: p.draft_id == 4))
+    end
+
+    test "upsert_draft_participants/2 is idempotent on the (draft_id, user_id) pair" do
+      Intel.upsert_sleeper_users([
+        %{id: 10, display_name: "alice"},
+        %{id: 11, display_name: "bob"}
+      ])
+
+      Intel.upsert_observed_drafts([%{id: 5, teams: 12, status: "complete"}])
+
+      Intel.upsert_draft_participants(5, [10, 11])
+      Intel.upsert_draft_participants(5, [10, 11, 10])
+
+      rows =
+        Repo.all(from(dp in SleeperPlayerApi.Intel.DraftParticipant, where: dp.draft_id == 5))
+
+      assert length(rows) == 2
+    end
+
+    test "upsert_observed_traded_picks/2 stores ownership rows keyed on (draft_id, season, round, roster_id)" do
+      Intel.upsert_observed_drafts([%{id: 6, teams: 12, status: "complete"}])
+
+      Intel.upsert_observed_traded_picks(6, [
+        %{season: "2026", round: 1, roster_id: 1, previous_owner_id: 1, owner_id: 2}
+      ])
+
+      # Re-crawling with a new owner overwrites the same logical row.
+      Intel.upsert_observed_traded_picks(6, [
+        %{season: "2026", round: 1, roster_id: 1, previous_owner_id: 1, owner_id: 3}
+      ])
+
+      assert [%{owner_id: 3}] =
+               Repo.all(
+                 from(tp in SleeperPlayerApi.Intel.ObservedTradedPick, where: tp.draft_id == 6)
+               )
+    end
+
+    test "upsert_player_values/1 upserts on (player_id, source)" do
+      Intel.upsert_player_values([
+        %{player_id: 100, source: "fantasycalc", value: 5000.0, overall_rank: 3}
+      ])
+
+      Intel.upsert_player_values([
+        %{player_id: 100, source: "fantasycalc", value: 5200.0, overall_rank: 2}
+      ])
+
+      assert [%{value: 5200.0, overall_rank: 2}] =
+               Repo.all(
+                 from(pv in SleeperPlayerApi.Intel.PlayerValue,
+                   where: pv.player_id == 100 and pv.source == "fantasycalc"
+                 )
+               )
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Corpus round-trip — the point of this step
+  # ---------------------------------------------------------------------
+
+  describe "corpus round-trip through Postgres" do
+    @describetag :corpus
+
+    setup do
+      seed_corpus_from_json!()
+      :ok
+    end
+
+    test "drafts_corpus/1 is byte-identical to IntelCorpus.drafts/0 once both are canonically sorted" do
+      uid_to_manager =
+        IntelCorpus.user_id_to_manager()
+        |> Map.new(fn {uid, manager} -> {String.to_integer(uid), manager} end)
+
+      from_json = IntelCorpus.drafts() |> canonicalize()
+      from_db = Intel.drafts_corpus(uid_to_manager) |> canonicalize()
+
+      assert from_db == from_json
+    end
+
+    test "league_adp_summary/1 (SQL GROUP BY) matches Estimator.adp_summary/1 (pure Elixir) on the same corpus" do
+      drafts = IntelCorpus.drafts()
+
+      for player_id <- sample_player_ids() do
+        expected = drafts |> Estimator.player_events(player_id) |> Estimator.adp_summary()
+        actual = Intel.league_adp_summary(player_id)
+
+        case expected do
+          nil ->
+            assert actual == nil, "expected no ADP summary for #{player_id}"
+
+          _ ->
+            assert actual.n == expected.n, "n mismatch for #{player_id}"
+            assert_in_delta actual.adp, expected.adp, 0.001
+            assert_in_delta actual.sd, expected.sd, 0.001
+            assert_in_delta actual.min, expected.min, 0.001
+            assert_in_delta actual.max, expected.max, 0.001
+        end
+      end
+    end
+
+    test "manager_adp_summary/1 counts and per-manager ADP match Estimator.manager_seen/took over the same picks" do
+      uid_to_manager = IntelCorpus.user_id_to_manager()
+      player_id = "13306"
+
+      per_manager = Intel.manager_adp_summary(player_id)
+
+      babaghanoush_uid =
+        uid_to_manager
+        |> Enum.find(fn {_uid, name} -> name == "babaghanoush123" end)
+        |> elem(0)
+        |> String.to_integer()
+
+      assert %{n: 13} =
+               Enum.find(per_manager, fn row -> row.user_id == babaghanoush_uid end)
+    end
+
+    test "manager_drafts_seen/0 matches Estimator.manager_seen/2 for each tracked manager" do
+      drafts = IntelCorpus.drafts()
+      seen_by_manager = Intel.manager_drafts_seen()
+      uid_to_manager = IntelCorpus.user_id_to_manager()
+
+      for {uid, manager} <- uid_to_manager do
+        expected = Estimator.manager_seen(drafts, manager)
+        actual = Map.get(seen_by_manager, String.to_integer(uid), 0)
+        assert actual == expected, "seen mismatch for #{manager}"
+      end
+    end
+
+    # The point of this whole step: the DB is an adapter into the estimator, and
+    # the estimator's numbers are already locked against the reference fixture.
+    # Structural equality (above) implies this, but assert the actual validated
+    # number through the Postgres path anyway — if a future schema or query
+    # change ever distorts the corpus, this fails with a recognisable value
+    # rather than a diff of two large structures.
+    test "survival computed through the Postgres path reproduces the fixture" do
+      uid_to_manager =
+        IntelCorpus.user_id_to_manager()
+        |> Map.new(fn {uid, manager} -> {String.to_integer(uid), manager} end)
+
+      drafts = Intel.drafts_corpus(uid_to_manager)
+      hazard = Estimator.base_hazard(drafts, "13353")
+
+      # Chris Brazzell, fixture byPick["39"].baseSurvival = 0.447 / ["48"] = 0.162
+      assert_in_delta Estimator.base_survival(hazard, 35, 39), 0.447, 0.0005
+      assert_in_delta Estimator.base_survival(hazard, 35, 48), 0.162, 0.0005
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------
+
+  defp canonicalize(drafts) do
+    drafts
+    |> Enum.map(fn draft ->
+      %{
+        l_d: Float.round(draft.l_d, 6),
+        picks: draft.picks |> Enum.map(&round_pick/1) |> Enum.sort()
+      }
+    end)
+    |> Enum.sort()
+  end
+
+  defp round_pick(pick), do: %{pick | norm: Float.round(pick.norm, 6)}
+
+  defp sample_player_ids do
+    # Names for these ids are in docs/leaguemate-intel.md §4a/§4e-bis.
+    ["13306", "13319", "13353", "13347", "13434", "13287"]
+  end
+
+  defp seed_corpus_from_json! do
+    raw_drafts = read_json!("rookie_drafts.json")
+    raw_picks_by_draft = read_json!("rookie_picks.json")
+    users = read_json!("lmusers.json")
+
+    Intel.upsert_sleeper_users(
+      Enum.map(users, fn u ->
+        %{id: String.to_integer(u["user_id"]), display_name: u["display_name"]}
+      end)
+    )
+
+    Intel.upsert_observed_drafts(
+      for {draft_id, draft} <- raw_drafts do
+        %{
+          id: String.to_integer(draft_id),
+          league_id: draft["league_id"] && String.to_integer(draft["league_id"]),
+          season: draft["season"],
+          status: draft["status"],
+          draft_type: draft["type"],
+          teams: draft["settings"]["teams"],
+          rounds: draft["settings"]["rounds"]
+        }
+      end
+    )
+
+    for {draft_id, _draft} <- raw_drafts do
+      picks = Map.get(raw_picks_by_draft, draft_id, [])
+
+      entries =
+        for pick <- picks do
+          %{
+            pick_no: pick["pick_no"],
+            round: pick["round"],
+            draft_slot: pick["draft_slot"],
+            roster_id: pick["roster_id"],
+            player_id: pick["player_id"],
+            picked_by: parse_picked_by(pick["picked_by"])
+          }
+        end
+
+      Intel.upsert_observed_picks(String.to_integer(draft_id), entries)
+    end
+  end
+
+  # A few corpus picks carry `picked_by: ""` rather than `null` — an
+  # auto-picked slot with no resolvable owner. Both mean "not a tracked
+  # leaguemate" to `IntelCorpus.user_id_to_manager/0` (no map has a "" key
+  # either), so both collapse to `nil` here for the same effect.
+  defp parse_picked_by(nil), do: nil
+  defp parse_picked_by(""), do: nil
+  defp parse_picked_by(id), do: String.to_integer(id)
+
+  defp read_json!(filename) do
+    @corpus_dir
+    |> Path.join(filename)
+    |> File.read!()
+    |> Jason.decode!()
+  end
+end

--- a/test/support/intel_corpus.ex
+++ b/test/support/intel_corpus.ex
@@ -1,0 +1,116 @@
+defmodule SleeperPlayerApi.IntelCorpus do
+  @moduledoc """
+  Test-only loader that shapes the harvested JSON corpus under
+  `test/support/corpus/` into the plain-map inputs
+  `SleeperPlayerApi.Intel.Estimator` expects.
+
+  The corpus directory is gitignored (it's a compiled snapshot of real
+  league data) — see `.gitignore` and `docs/leaguemate-intel-estimator.md`
+  in the sibling `my-sleeper-app` repo for provenance. This module only
+  exists to keep that shaping logic out of the test bodies themselves.
+  """
+
+  @corpus_dir Path.join([__DIR__, "corpus"])
+
+  @doc """
+  All corpus drafts, shaped for the estimator:
+
+      %{l_d: float, picks: [%{norm: float, player_id: String.t(), manager: String.t() | nil}]}
+
+  `l_d` is the normalized LAST PICK ACTUALLY MADE in the draft (not
+  `teams * rounds` capacity) — see estimator moduledoc §1/§4.
+
+  `manager` is the leaguemate's display name when the picking user is one of
+  the tracked leaguemates (per `lmusers.json`), otherwise `nil` — those
+  picks still count toward the base hazard, they just can't be attributed to
+  a manager's seen/took counts.
+  """
+  @spec drafts() :: [map]
+  def drafts do
+    rookie_drafts = read_json!("rookie_drafts.json")
+    rookie_picks = read_json!("rookie_picks.json")
+    uid_to_manager = user_id_to_manager()
+
+    for {draft_id, draft} <- rookie_drafts do
+      teams = draft["settings"]["teams"]
+      picks = Map.get(rookie_picks, draft_id, [])
+
+      shaped_picks =
+        for pick <- picks do
+          %{
+            norm: normalize(pick["pick_no"], teams),
+            player_id: pick["player_id"],
+            manager: Map.get(uid_to_manager, pick["picked_by"])
+          }
+        end
+
+      max_pick_no = picks |> Enum.map(& &1["pick_no"]) |> Enum.max()
+
+      %{l_d: normalize(max_pick_no, teams), picks: shaped_picks}
+    end
+  end
+
+  defp normalize(pick_no, teams), do: (pick_no - 1) / teams * 12 + 1
+
+  @doc """
+  `%{user_id => display_name}` for the tracked leaguemates (`lmusers.json`).
+  """
+  @spec user_id_to_manager() :: %{String.t() => String.t()}
+  def user_id_to_manager do
+    "lmusers.json"
+    |> read_json!()
+    |> Map.new(fn user -> {user["user_id"], user["display_name"]} end)
+  end
+
+  @doc "The set of tracked leaguemate display names."
+  @spec known_managers() :: MapSet.t(String.t())
+  def known_managers do
+    user_id_to_manager() |> Map.values() |> MapSet.new()
+  end
+
+  @doc """
+  FantasyCalc entries for the rookie class only — `maybeDraftInfo.year ==
+  2026` — as `{player_id, value}` pairs, ready for
+  `SleeperPlayerApi.Intel.Estimator.rookie_class_rank/1`.
+
+  A player with no `maybeDraftInfo` at all (FantasyCalc doesn't cleanly flag
+  rookie class membership) is excluded, same as the fixture this is
+  reproduced against.
+  """
+  @spec rookie_class_entries() :: [{String.t(), number}]
+  def rookie_class_entries do
+    "fc2.json"
+    |> read_json!()
+    |> Enum.filter(fn entry ->
+      match?(%{"maybeDraftInfo" => %{"year" => 2026}}, entry["player"])
+    end)
+    |> Enum.map(fn entry -> {entry["player"]["sleeperId"], entry["value"]} end)
+  end
+
+  @doc """
+  The golden fixture (`fixture.json`) — the known-good output the golden
+  test reproduces.
+  """
+  @spec fixture() :: map
+  def fixture, do: read_json!("fixture.json")
+
+  @doc """
+  `%{pick_number => manager}` straight from the fixture's own `board` array.
+
+  Trade resolution (turning `d13_now.json` + `d13_traded.json` into a
+  resolved board) is a separate concern being ported later — this is a
+  deliberate shortcut for the golden test, not a stand-in implementation of
+  it. See `docs/leaguemate-intel-estimator.md` §9.
+  """
+  @spec board_from_fixture(map) :: %{integer => String.t()}
+  def board_from_fixture(fixture) do
+    Map.new(fixture["board"], fn entry -> {entry["pick"], entry["manager"]} end)
+  end
+
+  defp read_json!(filename) do
+    @corpus_dir
+    |> Path.join(filename)
+    |> File.read!()
+    |> Jason.decode!()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,27 @@
-ExUnit.start()
+# The leaguemate-intel golden tests run against `test/support/corpus/`, which is
+# gitignored (this repo is public; the corpus is a compiled behavioural profile
+# of real, named leaguemates). It is therefore absent on any checkout but a
+# developer's own — including the deploy VM, where `CI=true mix test` gates the
+# whole deploy and `set -e` would abort it on a missing-file error.
+#
+# So: skip the corpus-backed tests when the corpus isn't there, loudly. Every
+# pure unit test — including all four estimator trap regressions — is untagged
+# and still runs, so the constants that matter stay protected in CI.
+corpus_present? =
+  File.exists?(Path.join([__DIR__, "support", "corpus", "rookie_drafts.json"]))
+
+exclude =
+  if corpus_present? do
+    []
+  else
+    IO.puts("""
+
+    NOTE: test/support/corpus is absent — skipping :corpus-tagged tests
+    (the leaguemate-intel golden test). Pure unit tests still run.
+    """)
+
+    [:corpus]
+  end
+
+ExUnit.start(exclude: exclude)
 Ecto.Adapters.SQL.Sandbox.mode(SleeperPlayerApi.Repo, :manual)


### PR DESCRIPTION
Plan §3f step 1 of the leaguemate-intel feature. No HTTP, no crawler, no
controllers, no scheduled job — those are steps 2-3.

## What's here

| | |
| --- | --- |
| `Intel.Estimator` | Pure survival maths. No Ecto, no HTTP. |
| Six tables + schemas | `sleeper_users`, `observed_drafts`, `observed_picks`, `observed_traded_picks`, `player_values`, `draft_participants`. |
| `Intel` context | Batched upserts, corpus queries, and the `GROUP BY` aggregates that belong in SQL. |

60 tests, 0 failures.

## The estimator was reverse-engineered, not ported

Its original implementation was never saved — only its output survived, in
the frontend prototype's `fixture.json`. This reconstruction reproduces all
2,160 of those values at max deviation 0.000498, against a tolerance of
0.0005 (half the fixture's 3-decimal rounding quantum).

Two behaviours are load-bearing and look like bugs on sight. Both carry
comments and pinned regression tests:

- **The Gaussian kernel smooths the hazard numerator only.** The
  Kaplan-Meier risk set is decremented hard, at the unsmeared pick.
  Fractional decay gives 0.0082 mean error vs 0.00024, erring high on
  exactly the players whose ADP precedes the current pick.
- **The two shrinkage constants differ** — the rate uses `n/(n+8)`, the
  multiplier confidence weight uses `n/(n+12)`, applied in series.

Population standard deviation is also load-bearing (it feeds the kernel
bandwidth), which is why the SQL aggregate uses `stddev_pop` rather than
`stddev`.

## Migrations are additive

Six `create table`s, no destructive changes, so the deploy's unbacked
`mix ecto.migrate` step is safe here.

## The corpus is gitignored, deliberately

This repo is public, and the corpus is a compiled behavioural profile of 13
real, named leaguemates — each datum individually public via the Sleeper
API, but the aggregate isn't ours to publish. Consequence: the corpus is
absent on the deploy VM, where `CI=true mix test` gates the deploy under
`set -e`. Corpus-backed tests are tagged `:corpus` and excluded when it's
missing (verified: 60/0 either way). Every pure trap regression stays
untagged, so the constants above are still protected without it.

Not addressed: `mix format --check-formatted` fails on `sleeper_test.exs`,
which is unformatted on `main` already and untouched here.