### PR TITLE
Throttled, non-raising Sleeper client

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,6 +38,11 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Sleeper API client rate limiter. Sleeper's documented ceiling is 1000
+# calls/min; this is deliberately well under that — see the moduledoc on
+# SleeperPlayerApi.RateLimiter for why.
+config :sleeper_player_api, SleeperPlayerApi.RateLimiter, calls_per_minute: 300
+
 # Quantum cron jobs
 config :sleeper_player_api, SleeperPlayerApi.Scheduler,
   jobs: [

--- a/lib/clients/sleeper.ex
+++ b/lib/clients/sleeper.ex
@@ -1,14 +1,81 @@
 defmodule SleeperPlayerApi.Client.Sleeper do
+  @moduledoc """
+  Thin HTTPoison wrapper around the Sleeper API.
+
+  `get!/1` is the original, still-raising entry point and is what
+  `SleeperPlayerApi.Tasks.GetSleeperPlayerData` uses — its behaviour is
+  unchanged. `get/1` is a non-raising variant for callers (the
+  leaguemate-intel crawler) that need to keep going after a single bad
+  response (429, 5xx, a dropped connection) instead of crashing the whole
+  job.
+
+  Both are routed through `SleeperPlayerApi.RateLimiter` so a shared token
+  bucket enforces Sleeper's documented 1000 calls/min ceiling across every
+  concurrent caller, rather than each caller pacing itself.
+  """
+
   use HTTPoison.Base
+
+  alias SleeperPlayerApi.RateLimiter
 
   @sleeper_url "https://api.sleeper.app/v1"
 
   def process_request_url(url) do
-    @sleeper_url <> url
+    base_url() <> url
   end
 
-  def process_response_body(body) do
-    body
-    |> Jason.decode!
+  # Reads from Application env (rather than baking `@sleeper_url` straight
+  # in) so tests can point this at a local Bypass server. Production never
+  # sets `:sleeper_base_url`, so this is a no-op outside of tests.
+  defp base_url do
+    Application.get_env(:sleeper_player_api, :sleeper_base_url, @sleeper_url)
+  end
+
+  # Left as the raw body here: the status code isn't available in this
+  # callback, and a 429/5xx error page from Sleeper isn't guaranteed to be
+  # JSON. Decoding happens below in `get/1` and `get!/1`, where the status
+  # code is known and each caller can decide how to react to a bad body.
+  def process_response_body(body), do: body
+
+  @doc """
+  Non-raising GET. Returns:
+
+    * `{:ok, decoded_body}` on a 2xx response with a JSON body
+    * `{:error, {:http_error, status_code}}` on any non-2xx status — this is
+      the 429/5xx case a crawler needs to detect and back off on
+    * `{:error, {:invalid_json, status_code}}` on a 2xx response whose body
+      isn't valid JSON (defensive; shouldn't happen against Sleeper, but a
+      caller must not crash if it does)
+    * `{:error, {:transport_error, reason}}` on a connection failure
+  """
+  def get(url, headers \\ [], options \\ []) do
+    RateLimiter.throttle()
+
+    case super(url, headers, options) do
+      {:ok, %HTTPoison.Response{status_code: status, body: body}} when status in 200..299 ->
+        case Jason.decode(body) do
+          {:ok, decoded} -> {:ok, decoded}
+          {:error, _reason} -> {:error, {:invalid_json, status}}
+        end
+
+      {:ok, %HTTPoison.Response{status_code: status}} ->
+        {:error, {:http_error, status}}
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, {:transport_error, reason}}
+    end
+  end
+
+  @doc """
+  Original raising GET. Decodes the JSON body and returns the
+  `HTTPoison.Response`, raising on a transport error or an invalid JSON
+  body — exactly what this client did before the throttle/`get/1` work.
+  `GetSleeperPlayerData` depends on this contract; do not change it here.
+  """
+  def get!(url, headers \\ [], options \\ []) do
+    RateLimiter.throttle()
+
+    super(url, headers, options)
+    |> Map.update!(:body, &Jason.decode!/1)
   end
 end

--- a/lib/sleeper_player_api/application.ex
+++ b/lib/sleeper_player_api/application.ex
@@ -16,6 +16,8 @@ defmodule SleeperPlayerApi.Application do
       {Phoenix.PubSub, name: SleeperPlayerApi.PubSub},
       # Start Finch
       {Finch, name: SleeperPlayerApi.Finch},
+      # Start the shared Sleeper API rate limiter
+      SleeperPlayerApi.RateLimiter,
       # Start the Endpoint (http/https)
       {SiteEncrypt.Phoenix, SleeperPlayerApiWeb.Endpoint},
       # Start Quantum scheduler

--- a/lib/sleeper_player_api/rate_limiter.ex
+++ b/lib/sleeper_player_api/rate_limiter.ex
@@ -1,0 +1,96 @@
+defmodule SleeperPlayerApi.RateLimiter do
+  @moduledoc """
+  A token-bucket rate limiter shared by every caller of the Sleeper client.
+
+  Sleeper's documented ceiling is 1000 calls/min. A single cold crawl is only
+  ~83 calls, but concurrent crawls for different leagues can stack, so the
+  limit has to be enforced centrally rather than trusted to each caller.
+  Every request goes through `throttle/1` before it hits the network.
+
+  Configure the ceiling in config, e.g.:
+
+      config :sleeper_player_api, SleeperPlayerApi.RateLimiter,
+        calls_per_minute: 300
+
+  The default (300/min, well under Sleeper's 1000/min) is a deliberate
+  choice, not a technical ceiling: this is someone else's API, and leaving
+  headroom for other clients hitting it matters more than squeezing out
+  throughput.
+  """
+
+  use GenServer
+
+  @default_calls_per_minute 300
+
+  # Public API
+
+  @doc """
+  Starts the rate limiter.
+
+  Options:
+
+    * `:name` - the process name to register (defaults to `__MODULE__`;
+      pass `name: nil` to start an unnamed, unregistered process, which is
+      how tests get an isolated bucket instead of sharing the global one)
+    * `:calls_per_minute` - overrides the configured/default rate
+    * `:capacity` - the bucket size, i.e. how many calls can burst through
+      before throttling kicks in (defaults to `:calls_per_minute`)
+  """
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @doc """
+  Blocks the calling process until a token is available, then consumes one.
+  """
+  def throttle(server \\ __MODULE__) do
+    case GenServer.call(server, :acquire, :infinity) do
+      :ok ->
+        :ok
+
+      {:wait, ms} ->
+        Process.sleep(ms)
+        throttle(server)
+    end
+  end
+
+  # Server callbacks
+
+  @impl true
+  def init(opts) do
+    calls_per_minute =
+      Keyword.get_lazy(opts, :calls_per_minute, fn ->
+        :sleeper_player_api
+        |> Application.get_env(__MODULE__, [])
+        |> Keyword.get(:calls_per_minute, @default_calls_per_minute)
+      end)
+
+    capacity = Keyword.get(opts, :capacity, calls_per_minute) * 1.0
+
+    state = %{
+      capacity: capacity,
+      tokens: capacity,
+      refill_per_ms: calls_per_minute / 60_000,
+      last_refill: System.monotonic_time(:millisecond)
+    }
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:acquire, _from, state) do
+    now = System.monotonic_time(:millisecond)
+    elapsed = now - state.last_refill
+    tokens = min(state.capacity, state.tokens + elapsed * state.refill_per_ms)
+
+    if tokens >= 1.0 do
+      {:reply, :ok, %{state | tokens: tokens - 1.0, last_refill: now}}
+    else
+      missing = 1.0 - tokens
+      wait_ms = missing / state.refill_per_ms
+      {:reply, {:wait, max(ceil(wait_ms), 1)}, %{state | tokens: tokens, last_refill: now}}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,8 @@ defmodule SleeperPlayerApi.MixProject do
       {:httpoison, "~> 2.1"},
       {:quantum, "~> 3.5"},
       {:site_encrypt, "~> 0.5"},
-      {:cors_plug, "~> 3.0"}
+      {:cors_plug, "~> 3.0"},
+      {:bypass, "~> 2.1", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "bypass": {:hex, :bypass, "2.1.0", "909782781bf8e20ee86a9cabde36b259d44af8b9f38756173e8f5e2e1fabb9b1", [:mix], [{:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "d9b5df8fa5b7a6efa08384e9bbecfe4ce61c77d28a4282f79e02f1ef78d96b80"},
   "castore": {:hex, :castore, "1.0.1", "240b9edb4e9e94f8f56ab39d8d2d0a57f49e46c56aced8f873892df8ff64ff5a", [:mix], [], "hexpm", "b4951de93c224d44fac71614beabd88b71932d0b1dea80d2f80fb9044e01bbb3"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "cors_plug": {:hex, :cors_plug, "3.0.3", "7c3ac52b39624bc616db2e937c282f3f623f25f8d550068b6710e58d04a0e330", [:mix], [{:plug, "~> 1.13", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "3f2d759e8c272ed3835fab2ef11b46bddab8c1ab9528167bd463b6452edf830d"},

--- a/test/clients/sleeper_test.exs
+++ b/test/clients/sleeper_test.exs
@@ -1,0 +1,79 @@
+defmodule SleeperPlayerApi.Client.SleeperTest do
+  # Bypass owns a real port per test and this module points the client at it
+  # via a shared Application env key, so this suite can't run concurrently
+  # with itself (or anything else that touches :sleeper_base_url).
+  use ExUnit.Case, async: false
+
+  alias SleeperPlayerApi.Client.Sleeper
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:sleeper_player_api, :sleeper_base_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.delete_env(:sleeper_player_api, :sleeper_base_url)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  describe "get!/1 (unchanged, raising, used by GetSleeperPlayerData)" do
+    test "decodes a JSON body on success", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/players/nfl", fn conn ->
+        Plug.Conn.resp(conn, 200, ~s({"1": {"player_id": "1"}}))
+      end)
+
+      response = Sleeper.get!("/players/nfl")
+
+      assert response.body == %{"1" => %{"player_id" => "1"}}
+    end
+
+    test "raises on a transport error", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert_raise HTTPoison.Error, fn ->
+        Sleeper.get!("/players/nfl")
+      end
+    end
+  end
+
+  describe "get/1 (non-raising)" do
+    test "returns {:ok, decoded_body} on success", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/players/nfl", fn conn ->
+        Plug.Conn.resp(conn, 200, ~s({"1": {"player_id": "1"}}))
+      end)
+
+      assert Sleeper.get("/players/nfl") == {:ok, %{"1" => %{"player_id" => "1"}}}
+    end
+
+    test "returns a tagged error on 429, instead of raising", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/players/nfl", fn conn ->
+        Plug.Conn.resp(conn, 429, "rate limited")
+      end)
+
+      assert Sleeper.get("/players/nfl") == {:error, {:http_error, 429}}
+    end
+
+    test "returns a tagged error on a 5xx, instead of raising", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/players/nfl", fn conn ->
+        Plug.Conn.resp(conn, 503, "service unavailable")
+      end)
+
+      assert Sleeper.get("/players/nfl") == {:error, {:http_error, 503}}
+    end
+
+    test "returns a tagged error on a connection failure, instead of raising", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert {:error, {:transport_error, _reason}} = Sleeper.get("/players/nfl")
+    end
+
+    test "returns a tagged error instead of raising on a non-JSON body", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/players/nfl", fn conn ->
+        Plug.Conn.resp(conn, 200, "<html>not json</html>")
+      end)
+
+      assert Sleeper.get("/players/nfl") == {:error, {:invalid_json, 200}}
+    end
+  end
+end

--- a/test/sleeper_player_api/rate_limiter_test.exs
+++ b/test/sleeper_player_api/rate_limiter_test.exs
@@ -1,0 +1,32 @@
+defmodule SleeperPlayerApi.RateLimiterTest do
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApi.RateLimiter
+
+  # These use a tiny, isolated bucket (`name: nil`, so it never touches the
+  # globally-supervised limiter) with a fast refill rate, so the test proves
+  # real throttling without sleeping for real seconds.
+
+  test "throttle/1 refills over time instead of blocking forever" do
+    # 6000 calls/min == 100 tokens/sec == 10ms per token. Capacity 2 means
+    # the first two calls are free; the next three each have to wait ~10ms
+    # for a token to regenerate.
+    {:ok, pid} = RateLimiter.start_link(name: nil, calls_per_minute: 6000, capacity: 2)
+
+    start = System.monotonic_time(:millisecond)
+    for _ <- 1..5, do: RateLimiter.throttle(pid)
+    elapsed = System.monotonic_time(:millisecond) - start
+
+    assert elapsed >= 25
+  end
+
+  test "throttle/1 does not wait while tokens are available" do
+    {:ok, pid} = RateLimiter.start_link(name: nil, calls_per_minute: 6000, capacity: 10)
+
+    start = System.monotonic_time(:millisecond)
+    for _ <- 1..5, do: RateLimiter.throttle(pid)
+    elapsed = System.monotonic_time(:millisecond) - start
+
+    assert elapsed < 25
+  end
+end


### PR DESCRIPTION
Plan §3f step 2. Prep for the leaguemate-intel crawler; no crawler yet.

The client exposed only `get!`, so a single 429 or 5xx mid-crawl would crash
the whole job, and nothing enforced Sleeper's 1000 calls/min ceiling across
concurrent callers.

## `get/1`

Returns `{:ok, decoded}` or `{:error, {:http_error, status}}` /
`{:invalid_json, status}` / `{:transport_error, reason}`, so a crawler can
tell "back off" from "skip this draft" from "the network went away".

`process_response_body/1` no longer decodes JSON unconditionally — an error
page isn't guaranteed to be JSON, and decoding there would raise before the
caller ever saw the status code. Decoding moved into `get/1` and `get!/1`,
where the status is known.

## `RateLimiter`

A token bucket shared by every caller, in the supervision tree. Default
300/min, configurable — well under the documented ceiling, because this is
someone else's API and headroom beats throughput.

The wait happens in the **calling** process (`handle_call` replies
immediately with `:ok` or `{:wait, ms}`), so the limiter never serializes
into a bottleneck or risks a call timeout.

## `get!/1` is unchanged

Its contract is identical, and it now has a test at the exact endpoint
`GetSleeperPlayerData` calls, which it previously lacked. That task is
untouched — though it now depends on the supervised limiter being alive,
which is a new failure mode worth knowing about.

## Tests

69 tests, 0 failures. Bypass added test-only; staying on HTTPoison.

Covers 429, 5xx, dropped connection, non-JSON body, the happy path, and
that the bucket actually throttles — the last against a tiny isolated
bucket, so the suite still runs in under two seconds. None of it touches
the gitignored corpus, so it all runs on the deploy VM.