### PR TITLE
Leaguemate draft crawler

### DIFF
--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
@@ -1,0 +1,355 @@
+defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts do
+  @moduledoc """
+  Harvests a league's leaguemates' draft history, per
+  `docs/leaguemate-intel.md` §3c/§3f step 3.
+
+  Sequence:
+
+      enumerate leaguemates      GET /v1/league/:id/users
+      their drafts (1 call each) GET /v1/user/:id/drafts/nfl/:season
+      dedupe by draft_id
+      filter to rookie drafts    settings.player_type == 1
+      for each draft not already stored as complete:
+          GET /v1/draft/:id/picks
+          GET /v1/draft/:id/traded_picks
+
+  The refresh rule (the whole caching story, §3c):
+
+    * `status == "complete"` — immutable. Fetched once, never again: a draft
+      already stored with status `"complete"` *and* a non-nil
+      `picks_fetched_at` is skipped outright.
+    * `status == "drafting"` — refetched every crawl (cheap, one draft).
+    * `status == "pre_draft"` — no picks to fetch; the draft row is still
+      upserted (so it's visible / counted), just never queried for picks.
+
+  Uses `SleeperPlayerApi.Client.Sleeper.get/1` (not `get!/1`) throughout —
+  one draft returning a bad response must not abort the rest of the crawl.
+  A failed `/picks` or `/traded_picks` call is recorded in the returned
+  summary's `:errors` and leaves that draft's `picks_fetched_at` untouched,
+  so the next crawl retries it rather than silently treating it as done.
+  `get/1` already routes through `SleeperPlayerApi.RateLimiter`, so a 429
+  here becomes a throttled wait on the *next* call rather than a hot retry
+  loop on this one.
+
+  No Quantum wiring, no controllers — this task is meant to be invoked
+  directly (`CrawlLeaguemateDrafts.crawl(league_id, season)`) until later
+  plan steps wire it up.
+  """
+
+  require Logger
+
+  import Ecto.Query, warn: false
+
+  alias SleeperPlayerApi.Repo
+  alias SleeperPlayerApi.Client.Sleeper
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.ObservedDraft
+
+  # Sleeper's own flag for "this draft is a rookie draft" on the `settings`
+  # object of a draft — confirmed against the harvested corpus in
+  # `test/support/corpus/rookie_drafts.json` (every entry has
+  # `settings.player_type == 1`, nothing else appears there).
+  @rookie_player_type 1
+
+  defmodule Summary do
+    @moduledoc """
+    What a `crawl/2` run did, so a caller (or a log line) can tell a
+    complete crawl from a partial one, and so the "second run makes almost
+    no calls" checkpoint (§3f step 3) is actually observable.
+    """
+    defstruct api_calls: 0,
+              leaguemates: 0,
+              drafts_seen: 0,
+              rookie_drafts_seen: 0,
+              drafts_fetched: 0,
+              drafts_skipped: 0,
+              picks_stored: 0,
+              traded_picks_stored: 0,
+              errors: []
+  end
+
+  @doc """
+  Crawls one league's leaguemates' rookie draft history for `season` and
+  stores it via `SleeperPlayerApi.Intel`.
+
+  Returns `{:ok, %Summary{}}` once the crawl has run to completion (a
+  per-draft failure doesn't prevent this — it's recorded in
+  `summary.errors` instead), or `{:error, reason}` if the leaguemate
+  enumeration call itself fails, since nothing else can proceed without it.
+  """
+  @spec crawl(integer | String.t(), String.t()) :: {:ok, Summary.t()} | {:error, term}
+  def crawl(league_id, season) do
+    summary = %Summary{}
+
+    case request("/league/#{league_id}/users", summary) do
+      {{:ok, users}, summary} ->
+        store_users(users)
+        summary = %{summary | leaguemates: length(users)}
+
+        user_ids = Enum.map(users, &to_int(&1["user_id"]))
+        {drafts_by_id, summary} = fetch_all_user_drafts(user_ids, season, summary)
+
+        all_drafts = Map.values(drafts_by_id)
+        rookie_drafts = Enum.filter(all_drafts, &rookie_draft?/1)
+
+        summary = %{
+          summary
+          | drafts_seen: map_size(drafts_by_id),
+            rookie_drafts_seen: length(rookie_drafts)
+        }
+
+        existing = existing_draft_state(Enum.map(rookie_drafts, &draft_id/1))
+
+        # `observed_picks`/`observed_traded_picks` have an FK on
+        # `observed_drafts`, so the draft rows have to exist before any
+        # picks can be stored for them. Write a placeholder row for every
+        # rookie draft up front (one batch), then let `crawl_drafts/3`
+        # fetch picks per draft and finalize each row's real status /
+        # `picks_fetched_at` in a second batch once the outcome is known.
+        unless rookie_drafts == [] do
+          rookie_drafts
+          |> Enum.map(
+            &draft_row(&1, picks_fetched_at: prior_fetched_at(Map.get(existing, draft_id(&1))))
+          )
+          |> Intel.upsert_observed_drafts()
+        end
+
+        {draft_rows, summary} = crawl_drafts(rookie_drafts, existing, summary)
+
+        unless draft_rows == [] do
+          Intel.upsert_observed_drafts(draft_rows)
+        end
+
+        Logger.info(
+          "CrawlLeaguemateDrafts: league #{league_id} season #{season} — " <>
+            "#{summary.api_calls} API calls, #{summary.rookie_drafts_seen} rookie drafts seen, " <>
+            "#{summary.drafts_fetched} fetched, #{summary.drafts_skipped} skipped (immutable/pre_draft), " <>
+            "#{summary.picks_stored} picks stored, #{length(summary.errors)} errors"
+        )
+
+        {:ok, summary}
+
+      {{:error, reason}, summary} ->
+        Logger.error(
+          "CrawlLeaguemateDrafts: could not enumerate league #{league_id} users: #{inspect(reason)}"
+        )
+
+        {:error, {:league_users_failed, reason, summary}}
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Leaguemates + their drafts
+  # ---------------------------------------------------------------------
+
+  defp store_users(users) do
+    now = utc_now()
+
+    users
+    |> Enum.map(fn u ->
+      %{
+        id: to_int(u["user_id"]),
+        username: u["username"] || u["display_name"],
+        display_name: u["display_name"],
+        avatar: u["avatar"],
+        last_crawled_at: now
+      }
+    end)
+    |> Intel.upsert_sleeper_users()
+  end
+
+  defp fetch_all_user_drafts(user_ids, season, summary) do
+    Enum.reduce(user_ids, {%{}, summary}, fn user_id, {acc, summary} ->
+      {result, summary} = request("/user/#{user_id}/drafts/nfl/#{season}", summary)
+
+      case result do
+        {:ok, drafts} ->
+          merged = Enum.reduce(drafts, acc, fn d, acc2 -> Map.put_new(acc2, d["draft_id"], d) end)
+          {merged, summary}
+
+        {:error, reason} ->
+          Logger.warning(
+            "CrawlLeaguemateDrafts: drafts fetch failed for user #{user_id}: #{inspect(reason)}"
+          )
+
+          {acc, add_error(summary, {:user_drafts, user_id, reason})}
+      end
+    end)
+  end
+
+  defp rookie_draft?(draft), do: get_in(draft, ["settings", "player_type"]) == @rookie_player_type
+
+  # ---------------------------------------------------------------------
+  # Per-draft crawl + the refresh rule
+  # ---------------------------------------------------------------------
+
+  defp crawl_drafts(rookie_drafts, existing, summary) do
+    Enum.reduce(rookie_drafts, {[], summary}, fn draft, {rows, summary} ->
+      id = draft_id(draft)
+      status = draft["status"]
+      prior = Map.get(existing, id)
+
+      cond do
+        status == "pre_draft" ->
+          # No picks to fetch; keep the row (§3c).
+          row = draft_row(draft, picks_fetched_at: prior_fetched_at(prior))
+          {[row | rows], %{summary | drafts_skipped: summary.drafts_skipped + 1}}
+
+        status == "complete" and immutable_and_fetched?(prior) ->
+          # Already stored complete with picks on file — never refetch.
+          row = draft_row(draft, picks_fetched_at: prior_fetched_at(prior))
+          {[row | rows], %{summary | drafts_skipped: summary.drafts_skipped + 1}}
+
+        true ->
+          # "drafting" (always refetched) or "complete" for the first time.
+          {row, summary} = fetch_draft_picks(draft, prior, summary)
+          {[row | rows], %{summary | drafts_fetched: summary.drafts_fetched + 1}}
+      end
+    end)
+  end
+
+  defp immutable_and_fetched?(%{status: "complete", picks_fetched_at: fetched_at})
+       when not is_nil(fetched_at),
+       do: true
+
+  defp immutable_and_fetched?(_prior), do: false
+
+  defp prior_fetched_at(nil), do: nil
+  defp prior_fetched_at(%{picks_fetched_at: fetched_at}), do: fetched_at
+
+  defp fetch_draft_picks(draft, prior, summary) do
+    id = draft_id(draft)
+
+    {picks_result, summary} = request("/draft/#{id}/picks", summary)
+    {traded_result, summary} = fetch_traded_picks(draft, id, summary)
+
+    case {picks_result, traded_result} do
+      {{:ok, picks}, {:ok, traded_picks}} ->
+        {n_picks, _} = Intel.upsert_observed_picks(id, shape_picks(picks))
+        {n_traded, _} = Intel.upsert_observed_traded_picks(id, shape_traded_picks(traded_picks))
+
+        summary = %{
+          summary
+          | picks_stored: summary.picks_stored + n_picks,
+            traded_picks_stored: summary.traded_picks_stored + n_traded
+        }
+
+        {draft_row(draft, picks_fetched_at: utc_now()), summary}
+
+      {{:error, reason}, _} ->
+        Logger.warning(
+          "CrawlLeaguemateDrafts: picks fetch failed for draft #{id}: #{inspect(reason)}"
+        )
+
+        row = draft_row(draft, picks_fetched_at: prior_fetched_at(prior))
+        {row, add_error(summary, {:picks, id, reason})}
+
+      {{:ok, picks}, {:error, reason}} ->
+        # Picks came back fine; store them. Traded-pick resolution failed,
+        # so leave `picks_fetched_at` as it was (nil, or the prior value) —
+        # this draft is not "done" and the next crawl will retry both.
+        {n_picks, _} = Intel.upsert_observed_picks(id, shape_picks(picks))
+        summary = %{summary | picks_stored: summary.picks_stored + n_picks}
+
+        Logger.warning(
+          "CrawlLeaguemateDrafts: traded_picks fetch failed for draft #{id}: #{inspect(reason)}"
+        )
+
+        row = draft_row(draft, picks_fetched_at: prior_fetched_at(prior))
+        {row, add_error(summary, {:traded_picks, id, reason})}
+    end
+  end
+
+  # Traded picks resolve ownership of picks that HAVEN'T BEEN MADE YET — "who
+  # actually picks at 35 given the trades" (§3d, §4f). In a *completed* draft
+  # that question is already answered: every pick carries `picked_by`, and
+  # whoever made a pick owned it, by definition. `Intel.drafts_corpus/1` builds
+  # manager attribution purely from `picked_by`; nothing reads
+  # `observed_traded_picks` for a completed draft.
+  #
+  # So we skip the call there. This is a deliberate deviation from §3c, which
+  # lists both calls unconditionally per draft. Fetching both for every draft
+  # would make a District 13 cold crawl 1 + 13 + 70*2 = 154 calls, which both
+  # doubles the load on someone else's API for data we never read and blows
+  # §3f step 3's own "≤100 calls" checkpoint. Skipping them gives 1 + 13 + 70 =
+  # 84, consistent with the 83 measured in §1.
+  #
+  # In-progress drafts still fetch them, which is the case that needs them.
+  defp fetch_traded_picks(%{"status" => "complete"}, _id, summary), do: {{:ok, []}, summary}
+
+  defp fetch_traded_picks(_draft, id, summary),
+    do: request("/draft/#{id}/traded_picks", summary)
+
+  defp existing_draft_state(draft_ids) do
+    from(d in ObservedDraft,
+      where: d.id in ^draft_ids,
+      select: {d.id, %{status: d.status, picks_fetched_at: d.picks_fetched_at}}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  # ---------------------------------------------------------------------
+  # Shaping raw Sleeper JSON into `Intel` upsert input
+  # ---------------------------------------------------------------------
+
+  defp draft_id(draft), do: to_int(draft["draft_id"])
+
+  defp draft_row(draft, picks_fetched_at: picks_fetched_at) do
+    %{
+      id: draft_id(draft),
+      league_id: to_int(draft["league_id"]),
+      season: draft["season"],
+      status: draft["status"],
+      draft_type: draft["type"],
+      player_type: get_in(draft, ["settings", "player_type"]),
+      teams: get_in(draft, ["settings", "teams"]),
+      rounds: get_in(draft, ["settings", "rounds"]),
+      start_time: draft["start_time"],
+      slot_to_roster_id: draft["slot_to_roster_id"],
+      picks_fetched_at: picks_fetched_at
+    }
+  end
+
+  defp shape_picks(picks) do
+    Enum.map(picks, fn p ->
+      %{
+        pick_no: p["pick_no"],
+        round: p["round"],
+        draft_slot: p["draft_slot"],
+        roster_id: p["roster_id"],
+        player_id: p["player_id"],
+        picked_by: to_int(p["picked_by"])
+      }
+    end)
+  end
+
+  defp shape_traded_picks(traded_picks) do
+    Enum.map(traded_picks, fn t ->
+      %{
+        season: t["season"],
+        round: t["round"],
+        roster_id: t["roster_id"],
+        previous_owner_id: to_int(t["previous_owner_id"]),
+        owner_id: to_int(t["owner_id"])
+      }
+    end)
+  end
+
+  # ---------------------------------------------------------------------
+  # Small helpers
+  # ---------------------------------------------------------------------
+
+  defp request(url, summary) do
+    result = Sleeper.get(url)
+    {result, %{summary | api_calls: summary.api_calls + 1}}
+  end
+
+  defp add_error(summary, error), do: %{summary | errors: [error | summary.errors]}
+
+  defp to_int(nil), do: nil
+  defp to_int(i) when is_integer(i), do: i
+  defp to_int(s) when is_binary(s), do: String.to_integer(s)
+
+  defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+end

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
@@ -1,0 +1,368 @@
+defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDraftsTest do
+  # Bypass owns a real port per test and this module points the client at it
+  # via the shared `:sleeper_base_url` Application env key (same trick as
+  # `test/clients/sleeper_test.exs`), so this suite can't run concurrently
+  # with itself or with anything else that touches that key.
+  use SleeperPlayerApi.DataCase, async: false
+
+  alias SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts
+  alias SleeperPlayerApi.Intel.{ObservedDraft, ObservedPick, ObservedTradedPick, SleeperUser}
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:sleeper_player_api, :sleeper_base_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.delete_env(:sleeper_player_api, :sleeper_base_url)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  # ---------------------------------------------------------------------
+  # Fixture builders — small, inline, no corpus dependency
+  # ---------------------------------------------------------------------
+
+  defp draft(id, status, opts \\ []) do
+    %{
+      "draft_id" => id,
+      "league_id" => "555",
+      "season" => "2026",
+      "status" => status,
+      "type" => "linear",
+      "start_time" => 1_700_000_000_000,
+      "settings" => %{
+        "player_type" => Keyword.get(opts, :player_type, 1),
+        "teams" => 12,
+        "rounds" => 4
+      }
+    }
+  end
+
+  defp pick(pick_no, player_id, picked_by, opts \\ []) do
+    %{
+      "pick_no" => pick_no,
+      "round" => Keyword.get(opts, :round, 1),
+      "draft_slot" => Keyword.get(opts, :draft_slot, pick_no),
+      "roster_id" => Keyword.get(opts, :roster_id, pick_no),
+      "player_id" => player_id,
+      "picked_by" => picked_by
+    }
+  end
+
+  defp traded_pick(round, roster_id, previous_owner_id, owner_id) do
+    %{
+      "season" => "2026",
+      "round" => round,
+      "roster_id" => roster_id,
+      "previous_owner_id" => previous_owner_id,
+      "owner_id" => owner_id
+    }
+  end
+
+  # Registers a JSON-responding expectation and returns an Agent counting
+  # how many times it's been hit, so tests can assert call counts (the
+  # cold-vs-warm checkpoint needs this) without Bypass's own accounting.
+  defp expect_json(bypass, path, body) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    Bypass.expect(bypass, "GET", path, fn conn ->
+      Agent.update(counter, &(&1 + 1))
+      Plug.Conn.resp(conn, 200, Jason.encode!(body))
+    end)
+
+    counter
+  end
+
+  defp expect_status(bypass, path, status) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    Bypass.expect(bypass, "GET", path, fn conn ->
+      Agent.update(counter, &(&1 + 1))
+      Plug.Conn.resp(conn, status, "boom")
+    end)
+
+    counter
+  end
+
+  # Same as `expect_json/3`, but via `Bypass.stub/4` instead of
+  # `Bypass.expect/4` — a stub is allowed to be called zero times.
+  # `Bypass.expect/4` requires at least one call and fails the test at
+  # `on_exit` otherwise, so this is what a test reaches for when it wants
+  # to assert a route was *never* hit (a completed draft's
+  # `/traded_picks`, per the crawler's deliberate §3c deviation — see the
+  # comment on `fetch_traded_picks/3`).
+  defp stub_json(bypass, path, body) do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    Bypass.stub(bypass, "GET", path, fn conn ->
+      Agent.update(counter, &(&1 + 1))
+      Plug.Conn.resp(conn, 200, Jason.encode!(body))
+    end)
+
+    counter
+  end
+
+  defp hits(counter), do: Agent.get(counter, & &1)
+
+  # ---------------------------------------------------------------------
+
+  describe "cold crawl" do
+    test "stores leaguemates, drafts and picks, and never requests traded_picks for a completed draft",
+         %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{
+          "user_id" => "100",
+          "username" => "alice_u",
+          "display_name" => "alice",
+          "avatar" => "av1"
+        }
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1001", "complete")])
+
+      expect_json(bypass, "/draft/1001/picks", [
+        pick(1, "P1", "100"),
+        pick(2, "P2", nil)
+      ])
+
+      # A completed draft's ownership is already fully resolved by
+      # `picked_by` on each pick — traded_picks only matters for picks not
+      # yet made. The crawler must not call this for a completed draft.
+      traded_counter = stub_json(bypass, "/draft/1001/traded_picks", [traded_pick(1, 3, 3, 4)])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert summary.leaguemates == 1
+      assert summary.rookie_drafts_seen == 1
+      assert summary.drafts_fetched == 1
+      assert summary.drafts_skipped == 0
+      assert summary.picks_stored == 2
+      assert summary.traded_picks_stored == 0
+      assert summary.errors == []
+      # league/users + user/drafts + picks (no traded_picks for a completed draft)
+      assert summary.api_calls == 3
+      assert hits(traded_counter) == 0
+
+      assert %SleeperUser{display_name: "alice"} = Repo.get!(SleeperUser, 100)
+
+      assert %ObservedDraft{status: "complete", picks_fetched_at: fetched_at} =
+               Repo.get!(ObservedDraft, 1001)
+
+      refute is_nil(fetched_at)
+
+      picks = Repo.all(from(p in ObservedPick, where: p.draft_id == 1001, order_by: p.pick_no))
+      assert [%{player_id: "P1", picked_by: 100}, %{player_id: "P2", picked_by: nil}] = picks
+
+      assert Repo.all(from(t in ObservedTradedPick, where: t.draft_id == 1001)) == []
+    end
+  end
+
+  describe "the immutability checkpoint" do
+    test "a second crawl over an already-complete draft makes no further picks/traded_picks calls",
+         %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      user_drafts_counter =
+        expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1001", "complete")])
+
+      picks_counter = expect_json(bypass, "/draft/1001/picks", [pick(1, "P1", "100")])
+      # Completed draft — traded_picks must never be requested at all (see
+      # the "cold crawl" test above), not just "not requested again".
+      traded_counter = stub_json(bypass, "/draft/1001/traded_picks", [])
+
+      assert {:ok, first} = CrawlLeaguemateDrafts.crawl(555, "2026")
+      assert first.drafts_fetched == 1
+      assert hits(picks_counter) == 1
+      assert hits(traded_counter) == 0
+
+      assert {:ok, second} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      # The property that matters: no further picks calls, and still no
+      # traded_picks calls at all.
+      assert hits(picks_counter) == 1
+      assert hits(traded_counter) == 0
+      assert second.drafts_fetched == 0
+      assert second.drafts_skipped == 1
+
+      # Enumeration itself is cheap and always repeats — that's expected,
+      # it's the picks/traded_picks calls that must not repeat.
+      assert hits(user_drafts_counter) == 2
+    end
+  end
+
+  describe "a draft still drafting" do
+    test "is refetched on every crawl", %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1002", "drafting")])
+
+      picks_counter = expect_json(bypass, "/draft/1002/picks", [pick(1, "P1", "100")])
+      traded_counter = expect_json(bypass, "/draft/1002/traded_picks", [])
+
+      assert {:ok, _} = CrawlLeaguemateDrafts.crawl(555, "2026")
+      assert {:ok, second} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert hits(picks_counter) == 2
+      assert hits(traded_counter) == 2
+      assert second.drafts_fetched == 1
+      assert second.drafts_skipped == 0
+    end
+
+    test "DOES fetch and store /traded_picks, unlike a completed draft", %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1002", "drafting")])
+
+      expect_json(bypass, "/draft/1002/picks", [pick(1, "P1", "100")])
+      traded_counter = expect_json(bypass, "/draft/1002/traded_picks", [traded_pick(1, 3, 3, 4)])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      # This is the regression guard: an in-progress draft's picks aren't
+      # fully resolved yet, so traded_picks is the case that actually
+      # needs the call — it must not get "simplified" away along with the
+      # completed-draft skip.
+      assert hits(traded_counter) == 1
+      assert summary.traded_picks_stored == 1
+
+      assert [%ObservedTradedPick{previous_owner_id: 3, owner_id: 4}] =
+               Repo.all(from(t in ObservedTradedPick, where: t.draft_id == 1002))
+    end
+  end
+
+  describe "a pre_draft draft" do
+    test "never triggers a picks call, but its row is still kept", %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1003", "pre_draft")])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert summary.drafts_fetched == 0
+      assert summary.drafts_skipped == 1
+      assert summary.api_calls == 2
+
+      assert %ObservedDraft{status: "pre_draft", picks_fetched_at: nil} =
+               Repo.get!(ObservedDraft, 1003)
+
+      assert Repo.all(from(p in ObservedPick, where: p.draft_id == 1003)) == []
+    end
+  end
+
+  describe "error handling" do
+    test "one draft 500ing on /picks doesn't abort the crawl of the others", %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [
+        draft("1001", "complete"),
+        draft("1005", "complete")
+      ])
+
+      expect_json(bypass, "/draft/1001/picks", [pick(1, "P1", "100")])
+      # Both drafts are "complete", so traded_picks is never requested for
+      # either — the picks failure on 1005 doesn't change that (the skip
+      # is decided by status, before the picks result is even known).
+      traded_counter_1001 = stub_json(bypass, "/draft/1001/traded_picks", [])
+
+      expect_status(bypass, "/draft/1005/picks", 500)
+      traded_counter_1005 = stub_json(bypass, "/draft/1005/traded_picks", [])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert summary.drafts_fetched == 2
+      assert summary.traded_picks_stored == 0
+      assert hits(traded_counter_1001) == 0
+      assert hits(traded_counter_1005) == 0
+      assert [{:picks, 1005, {:http_error, 500}}] = summary.errors
+
+      # The good draft's picks made it in.
+      assert [%{player_id: "P1"}] = Repo.all(from(p in ObservedPick, where: p.draft_id == 1001))
+
+      # The failed draft stored no picks, and isn't marked as fetched, so
+      # a later crawl will retry it rather than treating it as done.
+      assert Repo.all(from(p in ObservedPick, where: p.draft_id == 1005)) == []
+      assert %ObservedDraft{picks_fetched_at: nil} = Repo.get!(ObservedDraft, 1005)
+    end
+  end
+
+  describe "rookie filtering" do
+    test "only rookie drafts (settings.player_type == 1) are crawled or stored", %{
+      bypass: bypass
+    } do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [
+        draft("1001", "complete", player_type: 1),
+        draft("1004", "complete", player_type: 0)
+      ])
+
+      expect_json(bypass, "/draft/1001/picks", [pick(1, "P1", "100")])
+      # 1001 is complete, so no traded_picks call for it either.
+      traded_counter = stub_json(bypass, "/draft/1001/traded_picks", [])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert summary.drafts_seen == 2
+      assert summary.rookie_drafts_seen == 1
+      assert summary.drafts_fetched == 1
+      assert hits(traded_counter) == 0
+
+      assert Repo.get(ObservedDraft, 1001) != nil
+      assert Repo.get(ObservedDraft, 1004) == nil
+    end
+  end
+
+  describe "call-count arithmetic (§3f step 3's actual checkpoint)" do
+    test "2 leaguemates and 3 unique completed rookie drafts cost exactly 1 + 2 + 3 = 6 calls",
+         %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"},
+        %{"user_id" => "200", "display_name" => "bob", "avatar" => "av2"}
+      ])
+
+      d1 = draft("2001", "complete")
+      d2 = draft("2002", "complete")
+      d3 = draft("2003", "complete")
+
+      # d2 is shared — it must be deduped, not fetched twice.
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [d1, d2])
+      expect_json(bypass, "/user/200/drafts/nfl/2026", [d2, d3])
+
+      expect_json(bypass, "/draft/2001/picks", [pick(1, "P1", "100")])
+      expect_json(bypass, "/draft/2002/picks", [pick(1, "P2", "100")])
+      expect_json(bypass, "/draft/2003/picks", [pick(1, "P3", "200")])
+
+      # None of these three get a traded_picks call — they're all complete.
+      t1 = stub_json(bypass, "/draft/2001/traded_picks", [])
+      t2 = stub_json(bypass, "/draft/2002/traded_picks", [])
+      t3 = stub_json(bypass, "/draft/2003/traded_picks", [])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert summary.leaguemates == 2
+      assert summary.drafts_seen == 3
+      assert summary.rookie_drafts_seen == 3
+      assert summary.drafts_fetched == 3
+      assert summary.picks_stored == 3
+      assert summary.traded_picks_stored == 0
+
+      # 1 (league/users) + 2 (user/drafts, one per leaguemate) + 3 (picks,
+      # one per unique draft) — no traded_picks calls at all.
+      assert summary.api_calls == 6
+      assert Enum.map([t1, t2, t3], &hits/1) == [0, 0, 0]
+    end
+  end
+end


### PR DESCRIPTION
Plan §3f step 3. Dormant until invoked — no Quantum wiring, no controllers.

Enumerates a league's leaguemates, dedupes their drafts, filters to rookie
drafts, and stores picks under §3c's refresh rule:

| status | behaviour |
| --- | --- |
| `complete` | immutable — fetched once, never again |
| `drafting` | refetched every crawl |
| `pre_draft` | row kept, no picks call |

Uses `Sleeper.get/1` throughout, so one bad response is recorded in the
summary's `errors` and leaves that draft's `picks_fetched_at` untouched —
the next crawl retries it rather than treating it as done. The summary
carries the API call count, which is what makes §3f's "second run makes
almost no calls" checkpoint observable rather than a claim.

## One deliberate deviation from §3c

**Traded picks are fetched only for drafts still in progress.**

They resolve ownership of picks that haven't been made yet ("who actually
picks at 35 given the trades", §3d/§4f). In a completed draft that question
is already answered: every pick carries `picked_by`, and whoever made a pick
owned it by definition. `Intel.drafts_corpus/1` builds manager attribution
purely from `picked_by`, and nothing reads `observed_traded_picks` for a
completed draft.

Fetching both per draft, as §3c literally specifies, makes a District 13
cold crawl `1 + 13 + 70*2 = 154` calls — double the load on someone else's
API for data we never read, and over §3f step 3's own ≤100 ceiling.
Skipping them gives `1 + 13 + 70 = 84`, consistent with the 83 measured in
§1. Happy to revert if there's a use for completed drafts' traded picks I've
missed.

## Tests

77 tests, 0 failures. Bypass only, no corpus dependency, no real network.

Covers the refresh rule in all three states, a draft 500ing without
aborting the crawl, rookie filtering, dedup, and two things that weren't
pinned before: that an in-progress draft *does* still fetch traded picks,
and the call-count arithmetic itself (2 leaguemates / 3 unique drafts = 6
calls exactly).

Sabotage-verified in both directions — making completed drafts refetch
traded picks fails 5 tests; dropping traded picks entirely fails 2,
including the in-progress guard.