### PR TITLE
Trade-resolved /availability endpoint

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -17,12 +17,17 @@ defmodule SleeperPlayerApi.Intel do
       `test/support/intel_corpus.ex` builds from JSON, so the estimator is
       indifferent to which one fed it.
 
-  No HTTP, no crawler, no controllers here — see plan §3f step 1.
+  `availability/2` (plan §3f step 4) is the one exception to "no HTTP" —
+  resolving trade-aware pick ownership needs a live `/league/:id/rosters`
+  call (see its doc) and, for an in-progress draft, a refresh through
+  `SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts.refresh_draft/1`.
   """
 
   import Ecto.Query, warn: false
 
   alias SleeperPlayerApi.Repo
+  alias SleeperPlayerApi.Client.Sleeper
+  alias SleeperPlayerApi.Intel.{Estimator, Availability}
 
   alias SleeperPlayerApi.Intel.{
     SleeperUser,
@@ -66,6 +71,7 @@ defmodule SleeperPlayerApi.Intel do
       conflict_target: [:id],
       replace: [
         :league_id,
+        :league_name,
         :season,
         :status,
         :draft_type,
@@ -208,20 +214,42 @@ defmodule SleeperPlayerApi.Intel do
   determinism; `IntelCorpus.drafts/0` preserves JSON array order, which is
   already pick order, so the two are directly comparable once sorted the
   same way.
+
+  Only `status == "complete"` drafts are included — the estimator's own
+  vocabulary (`docs/leaguemate-intel-estimator.md` §0) defines the corpus
+  as "the *completed* rookie drafts observed", and an in-progress draft's
+  `l_d` moves every time it's refetched, which would make the corpus (and
+  therefore every survival number computed from it) shift under a caller's
+  feet mid-request. This was unfiltered before `/availability` needed it —
+  nothing consumed it in a way that could tell the difference yet — so this
+  is a real behaviour change, not a no-op refactor; see the PR/report for
+  the plan gap this closes.
+
+  `opts[:exclude_draft_id]` additionally drops one specific draft from the
+  corpus — for `/availability`, that's the very draft being analyzed. A
+  live in-progress draft has `status == "drafting"` so §-filter above
+  already excludes it, but the option exists for the moment that draft
+  finishes: without it, a completed live draft would count itself as
+  evidence for its own trade-resolved board, which is circular.
   """
-  @spec drafts_corpus(%{integer => String.t()}) :: [map]
-  def drafts_corpus(user_id_to_manager \\ %{}) do
+  @spec drafts_corpus(%{integer => String.t()}, keyword) :: [map]
+  def drafts_corpus(user_id_to_manager \\ %{}, opts \\ []) do
+    exclude_draft_id = Keyword.get(opts, :exclude_draft_id)
+
     teams_by_draft =
-      from(d in ObservedDraft, select: {d.id, d.teams})
+      from(d in ObservedDraft, where: d.status == "complete", select: {d.id, d.teams})
       |> Repo.all()
       |> Map.new()
 
     picks_by_draft =
-      from(p in ObservedPick, order_by: [asc: p.draft_id, asc: p.pick_no])
+      from(p in ObservedPick,
+        where: p.draft_id in ^Map.keys(teams_by_draft),
+        order_by: [asc: p.draft_id, asc: p.pick_no]
+      )
       |> Repo.all()
       |> Enum.group_by(& &1.draft_id)
 
-    for {draft_id, picks} <- picks_by_draft, picks != [] do
+    for {draft_id, picks} <- picks_by_draft, picks != [], draft_id != exclude_draft_id do
       teams = Map.fetch!(teams_by_draft, draft_id)
 
       shaped_picks =
@@ -373,4 +401,291 @@ defmodule SleeperPlayerApi.Intel do
     |> Repo.all()
     |> Map.new()
   end
+
+  # ---------------------------------------------------------------------
+  # `/availability` adapter (plan §3e / §3f step 4)
+  # ---------------------------------------------------------------------
+
+  @doc """
+  A single stored draft, or `nil` if it's never been crawled at all.
+  """
+  @spec get_observed_draft(integer | String.t()) :: ObservedDraft.t() | nil
+  def get_observed_draft(draft_id), do: Repo.get(ObservedDraft, to_int(draft_id))
+
+  @doc """
+  Every stored pick of one draft, ascending by `pick_no` — "what's already
+  been made", the input to resolving `currentPick` and excluding drafted
+  players from `targets`.
+  """
+  @spec draft_picks(integer) :: [%{pick_no: integer, player_id: String.t() | nil}]
+  def draft_picks(draft_id) do
+    from(p in ObservedPick,
+      where: p.draft_id == ^draft_id,
+      order_by: [asc: p.pick_no],
+      select: %{pick_no: p.pick_no, player_id: p.player_id}
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  One draft's traded-pick ledger as `%{{round, original_roster_id} =>
+  new_roster_id}` — exactly the shape
+  `SleeperPlayerApi.Intel.PickOwnership.resolve_roster/5` expects.
+  """
+  @spec draft_traded_picks(integer) :: %{{integer, integer} => integer}
+  def draft_traded_picks(draft_id) do
+    from(t in ObservedTradedPick, where: t.draft_id == ^draft_id)
+    |> Repo.all()
+    |> Map.new(fn t -> {{t.round, t.roster_id}, t.owner_id} end)
+  end
+
+  @doc """
+  `%{sleeper_user_id => display_name}` for every stored leaguemate — the
+  `user_id_to_manager` input `drafts_corpus/2` and
+  `SleeperPlayerApi.Intel.Availability` both take.
+  """
+  @spec manager_names_by_id() :: %{integer => String.t()}
+  def manager_names_by_id do
+    from(u in SleeperUser, select: {u.id, u.display_name})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  Live `roster_id -> owner sleeper_user_id` for a league, via `GET
+  /league/:id/rosters`. Deliberately not stored: plan §3a has no table for
+  it, roster ownership only matters for resolving *this request's*
+  trade-resolved board, and it changes rarely enough that a live fetch (one
+  call) is simpler than adding a table plus a staleness story for it. A
+  roster with no `owner_id` (an empty/orphaned roster) is dropped rather
+  than crashing the map build.
+  """
+  @spec fetch_roster_owners(integer | String.t()) :: {:ok, %{integer => integer}} | {:error, term}
+  def fetch_roster_owners(league_id) do
+    case Sleeper.get("/league/#{league_id}/rosters") do
+      {:ok, rosters} ->
+        owners =
+          rosters
+          |> Enum.filter(& &1["owner_id"])
+          |> Map.new(fn r -> {r["roster_id"], to_int(r["owner_id"])} end)
+
+        {:ok, owners}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  `%{player_id => %{name, position}}` for a set of Sleeper player ids,
+  joined from the `players` table (populated by the nightly
+  `GetSleeperPlayerData` job, per plan §3f step 4 "should come from the
+  existing players table — join, don't re-fetch"). A player id with no
+  matching row is simply absent from the result; callers treat that as
+  `name: nil, position: nil`.
+  """
+  @spec player_lookup([String.t()]) :: %{
+          String.t() => %{name: String.t() | nil, position: String.t() | nil}
+        }
+  def player_lookup(player_ids) do
+    from(p in SleeperPlayerApi.Sleeper.Player,
+      left_join: pos in SleeperPlayerApi.Sleeper.Position,
+      on: pos.id == p.position_id,
+      where: p.player_id in ^player_ids,
+      select: {p.player_id, %{name: p.full_name, position: pos.abbreviation}}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @fantasy_positions ~w(QB RB WR TE)
+
+  @doc """
+  Which of `player_ids` play a standard fantasy-relevant position
+  (#{inspect(@fantasy_positions)}), per the `players` table.
+
+  Feeds `SleeperPlayerApi.Intel.Availability`'s `eligible_ids` — a corpus
+  rookie draft's pick pool isn't exclusively skill positions (IDP/deep
+  bench flyers get picked too), and without this filter a thin-sample
+  non-fantasy player can out-rank every real target purely on raw ADP (see
+  the report on this step for the concrete example this was found against).
+  """
+  @spec fantasy_position_ids([String.t()]) :: MapSet.t(String.t())
+  def fantasy_position_ids(player_ids) do
+    from(p in SleeperPlayerApi.Sleeper.Player,
+      join: pos in SleeperPlayerApi.Sleeper.Position,
+      on: pos.id == p.position_id,
+      where: p.player_id in ^player_ids and pos.abbreviation in ^@fantasy_positions,
+      select: p.player_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  @doc """
+  Every stored pick of a `"complete"` draft for any of `player_ids`,
+  formatted `"round.slot@overall"` (plan §4e "store every individual
+  pick... so the UI can show receipts") and grouped by `{manager,
+  player_id}`, ascending by `pick_no` within each group.
+
+  A second, small query rather than folding into `drafts_corpus/2`: the
+  estimator-shaped corpus deliberately carries only the normalized pick
+  (`Estimator` doesn't need `round`/`draft_slot`/`pick_no`), so this is the
+  one place that reads them back out for display.
+  """
+  @spec manager_pick_strings([String.t()], %{integer => String.t()}) :: %{
+          {String.t(), String.t()} => [String.t()]
+        }
+  def manager_pick_strings(player_ids, user_id_to_manager) do
+    from(p in ObservedPick,
+      join: d in ObservedDraft,
+      on: d.id == p.draft_id,
+      where: d.status == "complete" and p.player_id in ^player_ids and not is_nil(p.picked_by),
+      order_by: [asc: p.pick_no],
+      select: %{
+        player_id: p.player_id,
+        picked_by: p.picked_by,
+        round: p.round,
+        draft_slot: p.draft_slot,
+        pick_no: p.pick_no
+      }
+    )
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn row, acc ->
+      case Map.get(user_id_to_manager, row.picked_by) do
+        nil ->
+          acc
+
+        manager ->
+          formatted = "#{row.round}.#{row.draft_slot}@#{row.pick_no}"
+          Map.update(acc, {manager, row.player_id}, [formatted], &(&1 ++ [formatted]))
+      end
+    end)
+  end
+
+  @doc """
+  The `/availability` endpoint's context entry point (plan §3f step 4).
+  Trade-resolves `draft_id`'s remaining picks and, for every corpus player
+  still on the board, its Kaplan-Meier survival curve conditioned on that
+  board — see `SleeperPlayerApi.Intel.Availability` for the response shape
+  and `SleeperPlayerApi.Intel.PickOwnership` for the resolution itself.
+
+  `opts`:
+
+    * `:user_id` (required) — whose remaining picks are "mine"
+    * `:at_pick` — analyze as if the draft were currently at this pick
+      instead of its actual next open one (plan §3g hypotheticals).
+      Defaults to the draft's actual next pick.
+    * `:limit` — how many corpus players become `targets` (default 20)
+
+  Refreshes the draft's own picks/traded_picks first when it isn't stored
+  yet or its stored status is `"drafting"`, via
+  `SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts.refresh_draft/1` — reusing
+  the crawler's own fetch path rather than a second one, per the plan's
+  scope note. A `"complete"` draft is immutable and is never refetched. If
+  a refresh attempt fails but the draft was already stored, the stale
+  stored copy is used rather than failing the whole request.
+
+  Returns `{:ok, response}`, `{:error, :draft_not_found}` if `draft_id`
+  isn't stored and can't be fetched from Sleeper either, or `{:error,
+  reason}` from `Availability.build/1` (an unresolvable draft type — see
+  its moduledoc on why that's a hard failure rather than a degraded
+  response).
+  """
+  @spec availability(integer | String.t(), keyword) :: {:ok, map} | {:error, term}
+  def availability(draft_id, opts \\ []) do
+    draft_id = to_int(draft_id)
+    my_user_id = opts |> Keyword.fetch!(:user_id) |> to_int()
+    at_pick = opts[:at_pick]
+    limit = Keyword.get(opts, :limit, 20)
+
+    with :ok <- ensure_fresh(draft_id) do
+      case get_observed_draft(draft_id) do
+        nil -> {:error, :draft_not_found}
+        draft -> build_availability(draft, my_user_id, at_pick, limit)
+      end
+    end
+  end
+
+  defp ensure_fresh(draft_id) do
+    case get_observed_draft(draft_id) do
+      nil -> refresh(draft_id)
+      %ObservedDraft{status: "drafting"} -> refresh(draft_id)
+      %ObservedDraft{} -> :ok
+    end
+  end
+
+  defp refresh(draft_id) do
+    case SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts.refresh_draft(draft_id) do
+      {:ok, _summary} -> :ok
+      {:error, reason} -> if get_observed_draft(draft_id), do: :ok, else: {:error, reason}
+    end
+  end
+
+  defp build_availability(draft, my_user_id, at_pick, limit) do
+    picks_made = draft_picks(draft.id)
+    traded_picks = draft_traded_picks(draft.id)
+    slot_to_roster_id = normalize_slot_map(draft.slot_to_roster_id)
+
+    with {:ok, roster_to_user} <- fetch_roster_owners(draft.league_id) do
+      user_id_to_manager = manager_names_by_id()
+      corpus = drafts_corpus(user_id_to_manager, exclude_draft_id: draft.id)
+
+      already_picked =
+        picks_made |> Enum.map(& &1.player_id) |> Enum.reject(&is_nil/1) |> MapSet.new()
+
+      candidate_ids =
+        for d <- corpus, p <- d.picks, not MapSet.member?(already_picked, p.player_id) do
+          p.player_id
+        end
+        |> Enum.uniq()
+
+      Availability.build(%{
+        league_name: draft.league_name,
+        draft_id: draft.id,
+        teams: draft.teams,
+        rounds: draft.rounds,
+        draft_type: draft.draft_type,
+        slot_to_roster_id: slot_to_roster_id,
+        picks_made: picks_made,
+        traded_picks: traded_picks,
+        roster_to_user: roster_to_user,
+        user_id_to_manager: user_id_to_manager,
+        my_user_id: my_user_id,
+        at_pick: at_pick,
+        limit: limit,
+        corpus: corpus,
+        candidate_lookup: player_lookup(candidate_ids),
+        market_rank: Estimator.rookie_class_rank(market_rookie_class_entries()),
+        raw_picks: manager_pick_strings(candidate_ids, user_id_to_manager),
+        eligible_ids: fantasy_position_ids(candidate_ids)
+      })
+    end
+  end
+
+  # `player_values` (plan §2/§3a) is refreshed from FantasyCalc by plan §3f
+  # step 5, which this endpoint step deliberately doesn't build (scope
+  # note: "NOT /intel — that's step 5"). Until that refresh job runs, this
+  # is always empty, so `marketPick`/`adpGap` come back `nil` for every
+  # target — an honest "no market read yet", not a fabricated one.
+  # `maybeDraftInfo.year` (the rookie-class filter, estimator §8) isn't a
+  # `player_values` column either; extending that schema is step 5's job.
+  defp market_rookie_class_entries do
+    from(pv in PlayerValue,
+      where: pv.source == "fantasycalc",
+      select: {pv.player_id, pv.value}
+    )
+    |> Repo.all()
+    |> Enum.map(fn {player_id, value} -> {to_string(player_id), value} end)
+  end
+
+  defp normalize_slot_map(nil), do: %{}
+
+  defp normalize_slot_map(slot_to_roster_id) do
+    Map.new(slot_to_roster_id, fn {slot, roster_id} -> {to_int(slot), to_int(roster_id)} end)
+  end
+
+  defp to_int(nil), do: nil
+  defp to_int(i) when is_integer(i), do: i
+  defp to_int(s) when is_binary(s), do: String.to_integer(s)
 end

--- a/lib/sleeper_player_api/intel/availability.ex
+++ b/lib/sleeper_player_api/intel/availability.ex
@@ -1,0 +1,336 @@
+defmodule SleeperPlayerApi.Intel.Availability do
+  @moduledoc """
+  Builds the `/availability` response shape (plan `docs/leaguemate-intel.md`
+  §3e, §3f step 4), given already-gathered plain data. No Ecto, no HTTP —
+  `SleeperPlayerApi.Intel` is the adapter that fetches/stores that data;
+  this module (like `Estimator`) only shapes and computes.
+
+  The response shape is deliberately the fixture's shape
+  (`src/Prototypes/rankListIntel/fixture.json` in the `my-sleeper-app`
+  sibling repo) — see that file and
+  `docs/leaguemate-intel-estimator.md` for the field-by-field contract this
+  reproduces. All math is delegated to `SleeperPlayerApi.Intel.Estimator`;
+  this module's job is board resolution (via `PickOwnership`) and shaping
+  the estimator's output plus the corpus aggregates into the fixture's
+  exact structure.
+
+  ## Failure behaviour (§3e)
+
+  Pick ownership must always be resolvable for the response to mean
+  anything — a `PickOwnership` failure (an unsupported draft type) returns
+  `{:error, reason}` rather than a degraded response, because serving
+  survival numbers computed from unresolved ownership is the one thing the
+  plan says this feature must never do.
+
+  A missing/empty corpus is different: it's an honest "no reads yet", not a
+  correctness violation, so it still returns `{:ok, response}` with
+  `targets: []` and `corpusDrafts: 0` rather than erroring — the board
+  (trade resolution) doesn't depend on the corpus at all.
+  """
+
+  alias SleeperPlayerApi.Intel.{Estimator, PickOwnership}
+
+  @signal_threshold %{min_drafts: 8, min_times: 3}
+
+  @doc """
+  Builds the full response map (atom-keyed, snake_case — the JSON view is
+  responsible for the camelCase rename, same split as `PlayerJSON`).
+
+  `input` is:
+
+      %{
+        league_name: String.t(),
+        draft_id: integer,
+        teams: pos_integer,
+        rounds: pos_integer,
+        draft_type: String.t(),
+        slot_to_roster_id: %{integer => integer},
+        picks_made: [%{pick_no: integer, player_id: String.t() | nil}],
+        traded_picks: %{{integer, integer} => integer},
+        roster_to_user: %{integer => integer},
+        user_id_to_manager: %{integer => String.t()},
+        my_user_id: integer,
+        at_pick: integer | nil,
+        limit: pos_integer,
+        corpus: [Estimator draft map],       # already filtered to `status == "complete"`,
+                                              # excluding the draft being analyzed
+        candidate_lookup: %{String.t() => %{name: String.t() | nil, position: String.t() | nil}},
+        market_rank: %{String.t() => pos_integer},
+        raw_picks: %{{String.t(), String.t()} => [String.t()]},
+        eligible_ids: MapSet.t(String.t()) | nil    # optional; see "Which players become targets?" below
+      }
+
+  ## Which players become `targets`? (plan §3f step 4 — underspecified)
+
+  Base rule: corpus players not yet drafted in the live draft, ordered by
+  `leagueAdp` ascending, capped at `limit`. `eligible_ids`, when given,
+  additionally restricts the candidate pool to that set before ordering —
+  the adapter (`SleeperPlayerApi.Intel.availability/2`) uses this to drop
+  non-fantasy positions (a corpus rookie draft's pick pool isn't
+  exclusively QB/RB/WR/TE; an LB with a stray 5-draft sample otherwise
+  outranks every real target by raw ADP). `nil` (the default, and what
+  every test in `availability_test.exs` uses) means no restriction.
+
+  Returns `{:ok, response}` or `{:error, reason}` — see moduledoc.
+  """
+  @spec build(map) :: {:ok, map} | {:error, term}
+  def build(input) do
+    current_pick = input[:at_pick] || next_pick(input.picks_made)
+    last_pick = input.teams * input.rounds
+
+    with {:ok, board_rosters} <-
+           PickOwnership.resolve_board(
+             current_pick..last_pick,
+             input.teams,
+             input.draft_type,
+             input.slot_to_roster_id,
+             input.traded_picks
+           ) do
+      known_managers = input.user_id_to_manager |> Map.values() |> MapSet.new()
+
+      board =
+        Enum.map(board_rosters, fn %{pick: pick, roster_id: roster_id} ->
+          user_id = Map.get(input.roster_to_user, roster_id)
+          manager = user_id && Map.get(input.user_id_to_manager, user_id)
+
+          %{
+            pick: pick,
+            manager: manager,
+            mine: user_id != nil and user_id == input.my_user_id,
+            drafts: if(manager, do: Estimator.manager_seen(input.corpus, manager), else: 0)
+          }
+        end)
+
+      board_owner = Map.new(board, fn b -> {b.pick, b.manager} end)
+      my_picks = board |> Enum.filter(& &1.mine) |> Enum.map(& &1.pick)
+
+      picked_player_ids =
+        input.picks_made |> Enum.map(& &1.player_id) |> Enum.reject(&is_nil/1) |> MapSet.new()
+
+      targets =
+        build_targets(
+          input,
+          current_pick,
+          last_pick,
+          board_owner,
+          known_managers,
+          picked_player_ids
+        )
+
+      {:ok,
+       %{
+         league: input.league_name,
+         draft_id: input.draft_id,
+         current_pick: current_pick,
+         last_pick: last_pick,
+         teams: input.teams,
+         rounds: input.rounds,
+         my_picks: my_picks,
+         corpus_drafts: length(input.corpus),
+         board: board,
+         targets: targets,
+         signal_threshold: @signal_threshold,
+         traded_picks_applied: true,
+         hazard: hazard_description()
+       }}
+    end
+  end
+
+  defp next_pick([]), do: 1
+  defp next_pick(picks_made), do: (picks_made |> Enum.map(& &1.pick_no) |> Enum.max()) + 1
+
+  # ---------------------------------------------------------------------
+  # Target selection (plan §3f step 4 "which players become targets?" —
+  # underspecified; the choice made here: corpus players still on the
+  # board in the live draft, ordered by league ADP, capped at `limit`)
+  # ---------------------------------------------------------------------
+
+  defp build_targets(input, current_pick, last_pick, board_owner, known_managers, picked) do
+    if input.corpus == [] do
+      []
+    else
+      eligible_ids = Map.get(input, :eligible_ids)
+
+      candidate_ids =
+        for draft <- input.corpus,
+            pick <- draft.picks,
+            not MapSet.member?(picked, pick.player_id),
+            is_nil(eligible_ids) or MapSet.member?(eligible_ids, pick.player_id),
+            do: pick.player_id
+
+      candidate_ids
+      |> Enum.uniq()
+      |> Enum.map(fn player_id ->
+        events = Estimator.player_events(input.corpus, player_id)
+        {player_id, Estimator.adp_summary(events)}
+      end)
+      |> Enum.reject(fn {_id, summary} -> is_nil(summary) end)
+      |> Enum.sort_by(fn {_id, summary} -> summary.adp end)
+      |> Enum.take(input.limit)
+      |> Enum.map(fn {player_id, summary} ->
+        build_target(
+          input,
+          player_id,
+          summary,
+          current_pick,
+          last_pick,
+          board_owner,
+          known_managers
+        )
+      end)
+    end
+  end
+
+  defp build_target(
+         input,
+         player_id,
+         summary,
+         current_pick,
+         last_pick,
+         board_owner,
+         known_managers
+       ) do
+    hazard = Estimator.base_hazard(input.corpus, player_id)
+    base_rate = Estimator.base_rate(input.corpus, player_id)
+
+    mult_fun = fn manager ->
+      seen = Estimator.manager_seen(input.corpus, manager)
+      took = Estimator.manager_took(input.corpus, manager, player_id)
+      Estimator.multiplier(seen, took, base_rate)
+    end
+
+    board_mult_fun = fn pick -> mult_fun.(Map.get(board_owner, pick)) end
+
+    by_pick =
+      for pick <- current_pick..(last_pick + 1), into: %{} do
+        base_survival = Estimator.base_survival(hazard, current_pick, pick)
+        adj_survival = Estimator.adjusted_survival(hazard, current_pick, pick, board_mult_fun)
+
+        threats =
+          Estimator.threats(
+            hazard,
+            current_pick,
+            pick,
+            board_owner,
+            known_managers,
+            mult_fun,
+            fn manager -> Estimator.manager_seen(input.corpus, manager) end,
+            fn manager -> Estimator.manager_took(input.corpus, manager, player_id) end
+          )
+
+        {pick,
+         %{
+           adj_survival: round3(adj_survival),
+           base_survival: round3(base_survival),
+           threats: Enum.map(threats, &round_threat/1)
+         }}
+      end
+
+    market_pick = Map.get(input.market_rank, player_id)
+    adp_gap = Estimator.adp_gap(summary.adp, market_pick)
+
+    lookup = Map.get(input.candidate_lookup, player_id, %{})
+
+    %{
+      id: player_id,
+      name: Map.get(lookup, :name),
+      position: Map.get(lookup, :position),
+      league_adp: round1(summary.adp),
+      sd: round1(summary.sd),
+      n: summary.n,
+      min: round1(summary.min),
+      max: round1(summary.max),
+      by_pick: by_pick,
+      per_manager: per_manager(input, player_id),
+      market_pick: market_pick,
+      adp_gap: adp_gap,
+      notable: notable(input, player_id, board_owner, summary.adp)
+    }
+  end
+
+  defp round_threat(threat), do: %{threat | prob: round3(threat.prob)}
+
+  defp round3(nil), do: nil
+  defp round3(x), do: Float.round(x * 1.0, 3)
+
+  defp round1(nil), do: nil
+  defp round1(x), do: Float.round(x * 1.0, 1)
+
+  # ---------------------------------------------------------------------
+  # Per-manager ADP + "notable" (plan §3 Frontend / §4e-bis)
+  # ---------------------------------------------------------------------
+
+  defp per_manager(input, player_id) do
+    for manager <- Enum.sort(MapSet.to_list(known_managers(input))),
+        took = Estimator.manager_took(input.corpus, manager, player_id),
+        took > 0 do
+      seen = Estimator.manager_seen(input.corpus, manager)
+      events = manager_events(input.corpus, manager, player_id)
+      adp = Enum.sum(events) / length(events)
+
+      %{
+        manager: manager,
+        times: took,
+        of: seen,
+        adp: round1(adp),
+        picks: raw_picks_for(input, manager, player_id)
+      }
+    end
+    |> Enum.sort_by(& &1.manager)
+  end
+
+  defp known_managers(input), do: input.user_id_to_manager |> Map.values() |> MapSet.new()
+
+  defp manager_events(corpus, manager, player_id) do
+    for draft <- corpus,
+        pick <- draft.picks,
+        pick.player_id == player_id,
+        pick.manager == manager,
+        do: pick.norm
+  end
+
+  # `raw_picks` is the caller-supplied `%{{manager, player_id} => [String.t()]}`
+  # of already-formatted "round.slot@overall" strings — see
+  # `SleeperPlayerApi.Intel.manager_pick_strings/1`. Threaded through `input`
+  # because it needs `round`/`draft_slot`/`pick_no`, which the
+  # Estimator-shaped corpus deliberately doesn't carry.
+  defp raw_picks_for(input, manager, player_id) do
+    Map.get(input.raw_picks, {manager, player_id}, [])
+  end
+
+  defp notable(input, player_id, board_owner, league_adp) do
+    input
+    |> per_manager(player_id)
+    |> Enum.filter(fn m ->
+      m.of >= @signal_threshold.min_drafts and m.times >= @signal_threshold.min_times
+    end)
+    |> Enum.sort_by(&{-&1.times, -&1.of})
+    |> case do
+      [] ->
+        false
+
+      [top | _] ->
+        %{
+          manager: top.manager,
+          adp: top.adp,
+          times: top.times,
+          of: top.of,
+          still_to_pick: still_to_pick?(board_owner, top.manager),
+          delta: round1(top.adp - league_adp)
+        }
+    end
+  end
+
+  defp still_to_pick?(board_owner, manager) do
+    board_owner |> Map.values() |> Enum.any?(&(&1 == manager))
+  end
+
+  defp hazard_description do
+    %{
+      estimator: "kaplan-meier + gaussian-kernel events",
+      bandwidth: "max(0.6, min(1.5, 0.4*sd))",
+      censoring: "risk set excludes drafts shorter than the pick",
+      manager_weight: "n/(n+12) confidence weight on the shrunk multiplier"
+    }
+  end
+end

--- a/lib/sleeper_player_api/intel/observed_draft.ex
+++ b/lib/sleeper_player_api/intel/observed_draft.ex
@@ -5,6 +5,7 @@ defmodule SleeperPlayerApi.Intel.ObservedDraft do
   @primary_key {:id, :id, autogenerate: false}
   schema "observed_drafts" do
     field :league_id, :integer
+    field :league_name, :string
     field :season, :string
     field :status, :string
     field :draft_type, :string
@@ -24,6 +25,7 @@ defmodule SleeperPlayerApi.Intel.ObservedDraft do
     |> cast(attrs, [
       :id,
       :league_id,
+      :league_name,
       :season,
       :status,
       :draft_type,

--- a/lib/sleeper_player_api/intel/pick_ownership.ex
+++ b/lib/sleeper_player_api/intel/pick_ownership.ex
@@ -1,0 +1,105 @@
+defmodule SleeperPlayerApi.Intel.PickOwnership do
+  @moduledoc """
+  Trade-resolved pick ownership (plan `docs/leaguemate-intel.md` §3d, §4f).
+
+  Pure — no Ecto, no HTTP. Given a pick number and the draft's own settings
+  (teams, draft type, `slot_to_roster_id`) plus its traded-pick ledger,
+  resolves which roster actually owns that pick *right now*, folding in
+  every trade instead of trusting the original snake/linear draft order.
+
+      round      = ceil(pick_no / teams)
+      slot       = ((pick_no - 1) mod teams) + 1          # LINEAR
+      roster     = slot_to_roster_id[slot]
+      true_owner = traded_picks[{round, roster}] || roster
+
+  **Caveat the plan doesn't spell out**: that formula assumes a *linear*
+  draft. District 13 (the plan's own acceptance case, §4f) is `type:
+  "linear"`, but Sleeper also supports `"snake"`, where the slot order
+  reverses on even rounds. Applying the linear formula to a snake draft
+  would attribute picks to the wrong manager — the one thing §4f says this
+  feature must never do. Snake is cheap to handle explicitly, so it's
+  handled here; any other draft type (`"auction"`, or anything unrecognized)
+  fails loudly with `{:error, {:unsupported_draft_type, type}}` rather than
+  silently guessing.
+  """
+
+  @doc """
+  `round = ceil(pick_no / teams)`.
+  """
+  @spec round_of(pos_integer, pos_integer) :: pos_integer
+  def round_of(pick_no, teams), do: div(pick_no + teams - 1, teams)
+
+  @doc """
+  The draft slot (1-indexed) that's on the clock at `pick_no`, for a
+  `"linear"` or `"snake"` draft. `{:error, {:unsupported_draft_type,
+  type}}` for anything else — see moduledoc.
+  """
+  @spec slot_of(pos_integer, pos_integer, String.t()) ::
+          {:ok, pos_integer} | {:error, {:unsupported_draft_type, String.t()}}
+  def slot_of(pick_no, teams, "linear") do
+    {:ok, rem(pick_no - 1, teams) + 1}
+  end
+
+  def slot_of(pick_no, teams, "snake") do
+    position_in_round = rem(pick_no - 1, teams) + 1
+    round = round_of(pick_no, teams)
+
+    slot =
+      if rem(round, 2) == 1 do
+        position_in_round
+      else
+        teams - position_in_round + 1
+      end
+
+    {:ok, slot}
+  end
+
+  def slot_of(_pick_no, _teams, type), do: {:error, {:unsupported_draft_type, type}}
+
+  @doc """
+  Resolves the roster that owns `pick_no` *after* trades, per the formula in
+  the moduledoc.
+
+  `slot_to_roster_id` is `%{integer => integer}` (slot -> roster_id — note
+  Sleeper's own JSON has string keys; callers normalize before calling
+  this). `traded_picks` is `%{{round, original_roster_id} => new_roster_id}`
+  — a pick not present in that map is still owned by its original roster.
+  """
+  @spec resolve_roster(pos_integer, pos_integer, String.t(), %{integer => integer}, %{
+          {integer, integer} => integer
+        }) :: {:ok, integer} | {:error, {:unsupported_draft_type, String.t()}}
+  def resolve_roster(pick_no, teams, draft_type, slot_to_roster_id, traded_picks) do
+    with {:ok, slot} <- slot_of(pick_no, teams, draft_type) do
+      round = round_of(pick_no, teams)
+      original_roster = Map.fetch!(slot_to_roster_id, slot)
+      true_roster = Map.get(traded_picks, {round, original_roster}, original_roster)
+      {:ok, true_roster}
+    end
+  end
+
+  @doc """
+  Resolves every pick in `pick_range`, roster only (no manager names — the
+  caller joins roster -> user -> display name, since that mapping is a
+  league concern this module deliberately knows nothing about).
+
+  Returns `{:ok, [%{pick: integer, roster_id: integer}]}` or the same
+  `{:error, ...}` `slot_of/3` would give, short-circuiting on the first
+  unresolved pick (the draft type is one property of the whole draft, so if
+  it fails once it fails for every pick).
+  """
+  @spec resolve_board(Enumerable.t(), pos_integer, String.t(), %{integer => integer}, %{
+          {integer, integer} => integer
+        }) :: {:ok, [%{pick: integer, roster_id: integer}]} | {:error, term}
+  def resolve_board(pick_range, teams, draft_type, slot_to_roster_id, traded_picks) do
+    Enum.reduce_while(pick_range, {:ok, []}, fn pick_no, {:ok, acc} ->
+      case resolve_roster(pick_no, teams, draft_type, slot_to_roster_id, traded_picks) do
+        {:ok, roster_id} -> {:cont, {:ok, [%{pick: pick_no, roster_id: roster_id} | acc]}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, acc} -> {:ok, Enum.reverse(acc)}
+      error -> error
+    end
+  end
+end

--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
@@ -138,6 +138,56 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts do
     end
   end
 
+  @doc """
+  Refreshes ONE draft's picks/traded_picks on demand, regardless of its
+  currently stored status — the `/availability` endpoint's use case (plan
+  §3f step 4 scope note: fetching a live in-progress draft "may need
+  fetching on demand... reuse [the crawler's refresh rule], don't write a
+  second fetch path").
+
+  Fetches `GET /draft/:id` for the draft's current settings/status, then
+  hands off to the same private `fetch_draft_picks/3` that `crawl/2` uses —
+  so there's exactly one place in the codebase that knows how to fetch and
+  store a draft's picks, not two. Unlike `crawl/2`'s per-draft branch, this
+  always fetches (a caller reaching for a single-draft refresh already
+  wants fresh data right now); the "complete drafts are immutable, skip
+  them" short-circuit belongs to the many-drafts league crawl, not this
+  path — callers that only want to refresh actually-live drafts should
+  check `status` themselves before calling this (see
+  `SleeperPlayerApi.Intel.availability/2`).
+
+  Returns `{:ok, %Summary{}}` (same shape as `crawl/2`, `api_calls` counts
+  the calls this made) or `{:error, reason}` if even `/draft/:id` fails.
+  """
+  @spec refresh_draft(integer | String.t()) :: {:ok, Summary.t()} | {:error, term}
+  def refresh_draft(draft_id) do
+    summary = %Summary{}
+
+    case request("/draft/#{draft_id}", summary) do
+      {{:ok, draft}, summary} ->
+        id = draft_id(draft)
+        existing = existing_draft_state([id])
+        prior = Map.get(existing, id)
+
+        # `observed_picks` has an FK on `observed_drafts` — same ordering
+        # constraint `crawl/2` handles by pre-inserting a placeholder row
+        # before fetching any picks (see its own comment on this).
+        Intel.upsert_observed_drafts([draft_row(draft, picks_fetched_at: prior_fetched_at(prior))])
+
+        {row, summary} = fetch_draft_picks(draft, prior, summary)
+        Intel.upsert_observed_drafts([row])
+
+        {:ok, summary}
+
+      {{:error, reason}, summary} ->
+        Logger.warning(
+          "CrawlLeaguemateDrafts: refresh_draft(#{draft_id}) could not fetch /draft/#{draft_id}: #{inspect(reason)}"
+        )
+
+        {:error, {:draft_fetch_failed, reason, summary}}
+    end
+  end
+
   # ---------------------------------------------------------------------
   # Leaguemates + their drafts
   # ---------------------------------------------------------------------
@@ -299,6 +349,7 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts do
     %{
       id: draft_id(draft),
       league_id: to_int(draft["league_id"]),
+      league_name: get_in(draft, ["metadata", "name"]),
       season: draft["season"],
       status: draft["status"],
       draft_type: draft["type"],

--- a/lib/sleeper_player_api_web/controllers/availability_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/availability_controller.ex
@@ -1,0 +1,37 @@
+defmodule SleeperPlayerApiWeb.AvailabilityController do
+  use SleeperPlayerApiWeb, :controller
+
+  alias SleeperPlayerApi.Intel
+
+  action_fallback SleeperPlayerApiWeb.FallbackController
+
+  @doc """
+  `GET /api/v1/drafts/:draft_id/availability?user_id=<n>&at_pick=<n>&limit=<n>`
+
+  See `SleeperPlayerApi.Intel.availability/2` for the full contract —
+  `user_id` is required (whose remaining picks are "mine"), `at_pick` and
+  `limit` are optional.
+  """
+  def show(conn, %{"draft_id" => draft_id} = params) do
+    with {:ok, user_id} <- require_param(params, "user_id"),
+         opts <- [
+           user_id: user_id,
+           at_pick: to_int(params["at_pick"]),
+           limit: to_int(params["limit"])
+         ],
+         opts <- Enum.reject(opts, fn {_k, v} -> is_nil(v) end),
+         {:ok, availability} <- Intel.availability(draft_id, opts) do
+      render(conn, :show, availability: availability)
+    end
+  end
+
+  defp require_param(params, key) do
+    case params[key] do
+      nil -> {:error, {:missing_param, key}}
+      value -> {:ok, value}
+    end
+  end
+
+  defp to_int(nil), do: nil
+  defp to_int(value) when is_binary(value), do: String.to_integer(value)
+end

--- a/lib/sleeper_player_api_web/controllers/availability_json.ex
+++ b/lib/sleeper_player_api_web/controllers/availability_json.ex
@@ -1,0 +1,90 @@
+defmodule SleeperPlayerApiWeb.AvailabilityJSON do
+  @moduledoc """
+  Renders `SleeperPlayerApi.Intel.availability/2`'s response into the exact
+  shape `src/Prototypes/rankListIntel/fixture.json` (in the `my-sleeper-app`
+  sibling repo) already established — camelCase keys, even though Elixir is
+  snake_case throughout the context/estimator layer, per plan §3f step 4:
+  "keep the JSON keys camelCase exactly as the fixture has them... the
+  frontend swap is meant to be a fetch call, not a rewrite."
+  """
+
+  def show(%{availability: a}) do
+    %{
+      league: a.league,
+      draftId: a.draft_id,
+      currentPick: a.current_pick,
+      lastPick: a.last_pick,
+      teams: a.teams,
+      rounds: a.rounds,
+      myPicks: a.my_picks,
+      corpusDrafts: a.corpus_drafts,
+      board: Enum.map(a.board, &board_entry/1),
+      targets: Enum.map(a.targets, &target/1),
+      signalThreshold: %{
+        minDrafts: a.signal_threshold.min_drafts,
+        minTimes: a.signal_threshold.min_times
+      },
+      tradedPicksApplied: a.traded_picks_applied,
+      hazard: %{
+        estimator: a.hazard.estimator,
+        bandwidth: a.hazard.bandwidth,
+        censoring: a.hazard.censoring,
+        managerWeight: a.hazard.manager_weight
+      }
+    }
+  end
+
+  defp board_entry(b) do
+    %{pick: b.pick, manager: b.manager, mine: b.mine, drafts: b.drafts}
+  end
+
+  defp target(t) do
+    %{
+      id: t.id,
+      name: t.name,
+      position: t.position,
+      leagueAdp: t.league_adp,
+      sd: t.sd,
+      n: t.n,
+      min: t.min,
+      max: t.max,
+      byPick: by_pick(t.by_pick),
+      perManager: Enum.map(t.per_manager, &per_manager/1),
+      marketPick: t.market_pick,
+      adpGap: t.adp_gap,
+      notable: notable(t.notable)
+    }
+  end
+
+  defp by_pick(by_pick) do
+    Map.new(by_pick, fn {pick, entry} ->
+      {Integer.to_string(pick),
+       %{
+         adjSurvival: entry.adj_survival,
+         baseSurvival: entry.base_survival,
+         threats: Enum.map(entry.threats, &threat/1)
+       }}
+    end)
+  end
+
+  defp threat(t) do
+    %{manager: t.manager, pick: t.pick, prob: t.prob, drafts: t.drafts, tookCount: t.tookCount}
+  end
+
+  defp per_manager(m) do
+    %{manager: m.manager, times: m.times, of: m.of, adp: m.adp, picks: m.picks}
+  end
+
+  defp notable(false), do: false
+
+  defp notable(n) do
+    %{
+      manager: n.manager,
+      adp: n.adp,
+      times: n.times,
+      of: n.of,
+      stillToPick: n.still_to_pick,
+      delta: n.delta
+    }
+  end
+end

--- a/lib/sleeper_player_api_web/controllers/fallback_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/fallback_controller.ex
@@ -13,4 +13,43 @@ defmodule SleeperPlayerApiWeb.FallbackController do
     |> put_view(html: SleeperPlayerApiWeb.ErrorHTML, json: SleeperPlayerApiWeb.ErrorJSON)
     |> render(:"404")
   end
+
+  # `AvailabilityController` (plan §3f step 4): the draft id in the URL
+  # isn't in Sleeper at all (never crawled, and `/draft/:id` itself 404s).
+  def call(conn, {:error, :draft_not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(html: SleeperPlayerApiWeb.ErrorHTML, json: SleeperPlayerApiWeb.ErrorJSON)
+    |> render(:"404")
+  end
+
+  # A required query param is missing (`AvailabilityController` requires
+  # `user_id`).
+  def call(conn, {:error, {:missing_param, key}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: SleeperPlayerApiWeb.ErrorJSON)
+    |> Phoenix.Controller.json(%{errors: %{detail: "missing required param: #{key}"}})
+  end
+
+  # `SleeperPlayerApi.Intel.PickOwnership` couldn't resolve the draft's own
+  # order (not `"linear"`/`"snake"`) — per `Availability`'s moduledoc, this
+  # is a hard failure rather than a degraded response, because serving
+  # survival numbers computed from unresolved pick ownership is the one
+  # thing the plan says this feature must never do.
+  def call(conn, {:error, {:unsupported_draft_type, type}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: SleeperPlayerApiWeb.ErrorJSON)
+    |> Phoenix.Controller.json(%{errors: %{detail: "unsupported draft type: #{type}"}})
+  end
+
+  # Anything else an action returns as `{:error, reason}` — e.g. the
+  # `/league/:id/rosters` fetch in `Intel.availability/2` failing.
+  def call(conn, {:error, reason}) do
+    conn
+    |> put_status(:bad_gateway)
+    |> put_view(json: SleeperPlayerApiWeb.ErrorJSON)
+    |> Phoenix.Controller.json(%{errors: %{detail: inspect(reason)}})
+  end
 end

--- a/lib/sleeper_player_api_web/router.ex
+++ b/lib/sleeper_player_api_web/router.ex
@@ -20,6 +20,7 @@ defmodule SleeperPlayerApiWeb.Router do
     get "/players", PlayerController, :index
     get "/players/active", PlayerController, :active
     get "/players/:id", PlayerController, :show
+    get "/drafts/:draft_id/availability", AvailabilityController, :show
   end
 
   scope "/api/legacy", SleeperPlayerApiWeb do

--- a/priv/repo/migrations/20260806120000_add_league_name_to_observed_drafts.exs
+++ b/priv/repo/migrations/20260806120000_add_league_name_to_observed_drafts.exs
@@ -1,0 +1,20 @@
+defmodule SleeperPlayerApi.Repo.Migrations.AddLeagueNameToObservedDrafts do
+  use Ecto.Migration
+
+  @moduledoc """
+  `/availability` (plan §3f step 4) needs a human-readable league name for
+  the response's top-level `league` field
+  (`src/Prototypes/rankListIntel/fixture.json`'s `"league": "District 13
+  Dynasty League"`), and nothing in the §3a schema stores one. Sleeper's own
+  `/draft/:id` payload carries it at `metadata.name` (verified against the
+  corpus fixtures — a draft's own metadata mirrors its league's display
+  name), so it's cheap to capture at crawl time instead of an extra live
+  `GET /league/:id` call on every `/availability` request.
+  """
+
+  def change do
+    alter table(:observed_drafts) do
+      add :league_name, :string
+    end
+  end
+end

--- a/test/sleeper_player_api/intel/availability_test.exs
+++ b/test/sleeper_player_api/intel/availability_test.exs
@@ -1,0 +1,155 @@
+defmodule SleeperPlayerApi.Intel.AvailabilityTest do
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApi.Intel.Availability
+
+  defp base_input(overrides \\ %{}) do
+    Map.merge(
+      %{
+        league_name: "Test League",
+        draft_id: 1,
+        teams: 4,
+        rounds: 2,
+        draft_type: "linear",
+        slot_to_roster_id: %{1 => 1, 2 => 2, 3 => 3, 4 => 4},
+        picks_made: [],
+        traded_picks: %{},
+        roster_to_user: %{1 => 100, 2 => 200, 3 => 300, 4 => 400},
+        user_id_to_manager: %{100 => "alice", 200 => "bob", 300 => "carol", 400 => "dave"},
+        my_user_id: 100,
+        at_pick: nil,
+        limit: 20,
+        corpus: [],
+        candidate_lookup: %{},
+        market_rank: %{},
+        raw_picks: %{}
+      },
+      overrides
+    )
+  end
+
+  describe "board resolution" do
+    test "resolves every remaining pick, marks the caller's own, and defaults current_pick to 1 when nothing's been picked" do
+      assert {:ok, response} = Availability.build(base_input())
+
+      assert response.current_pick == 1
+      assert response.last_pick == 8
+      assert response.teams == 4
+      assert response.rounds == 2
+
+      assert response.board == [
+               %{pick: 1, manager: "alice", mine: true, drafts: 0},
+               %{pick: 2, manager: "bob", mine: false, drafts: 0},
+               %{pick: 3, manager: "carol", mine: false, drafts: 0},
+               %{pick: 4, manager: "dave", mine: false, drafts: 0},
+               %{pick: 5, manager: "alice", mine: true, drafts: 0},
+               %{pick: 6, manager: "bob", mine: false, drafts: 0},
+               %{pick: 7, manager: "carol", mine: false, drafts: 0},
+               %{pick: 8, manager: "dave", mine: false, drafts: 0}
+             ]
+
+      assert response.my_picks == [1, 5]
+    end
+
+    test "current_pick advances past picks already made" do
+      input =
+        base_input(%{picks_made: [%{pick_no: 1, player_id: "P1"}, %{pick_no: 2, player_id: "P2"}]})
+
+      assert {:ok, response} = Availability.build(input)
+      assert response.current_pick == 3
+    end
+
+    test "at_pick overrides the live current pick for hypotheticals (plan §3g)" do
+      input =
+        base_input(%{
+          picks_made: [%{pick_no: 1, player_id: "P1"}, %{pick_no: 2, player_id: "P2"}],
+          at_pick: 6
+        })
+
+      assert {:ok, response} = Availability.build(input)
+      assert response.current_pick == 6
+      assert response.board |> hd() |> Map.get(:pick) == 6
+    end
+
+    test "a traded pick's owner (and mine-ness) reflects the trade, not the original slot" do
+      input = base_input(%{traded_picks: %{{1, 2} => 1}})
+
+      assert {:ok, response} = Availability.build(input)
+      pick2 = Enum.find(response.board, &(&1.pick == 2))
+      assert pick2.manager == "alice"
+      assert pick2.mine == true
+    end
+
+    test "an unsupported draft type is a hard failure, not a degraded response (plan §3e)" do
+      input = base_input(%{draft_type: "auction"})
+      assert Availability.build(input) == {:error, {:unsupported_draft_type, "auction"}}
+    end
+
+    test "an owner whose roster maps to no known user still appears on the board with a nil manager" do
+      input = base_input(%{roster_to_user: %{1 => 100, 2 => 200, 3 => 300}})
+
+      assert {:ok, response} = Availability.build(input)
+      pick4 = Enum.find(response.board, &(&1.pick == 4))
+      assert pick4.manager == nil
+      assert pick4.mine == false
+      assert pick4.drafts == 0
+    end
+  end
+
+  describe "corpus-missing failure behaviour (plan §3e)" do
+    test "an empty corpus returns targets: [] and corpusDrafts: 0, never fabricated survival numbers" do
+      assert {:ok, response} = Availability.build(base_input())
+
+      assert response.targets == []
+      assert response.corpus_drafts == 0
+      # the board itself doesn't depend on the corpus at all
+      assert length(response.board) == 8
+    end
+  end
+
+  describe "targets — corpus players still on the board, ordered by league ADP" do
+    setup do
+      corpus = [
+        %{
+          l_d: 4.0,
+          picks: [
+            %{norm: 1.0, player_id: "X", manager: "alice"},
+            %{norm: 2.0, player_id: "Y", manager: "bob"},
+            %{norm: 3.0, player_id: "Z", manager: "carol"}
+          ]
+        }
+      ]
+
+      %{corpus: corpus}
+    end
+
+    test "excludes a player already drafted live, and orders the rest by leagueAdp ascending", %{
+      corpus: corpus
+    } do
+      input = base_input(%{corpus: corpus, picks_made: [%{pick_no: 1, player_id: "X"}]})
+
+      assert {:ok, response} = Availability.build(input)
+      ids = Enum.map(response.targets, & &1.id)
+      assert ids == ["Y", "Z"]
+    end
+
+    test "caps at the given limit", %{corpus: corpus} do
+      input = base_input(%{corpus: corpus, limit: 1})
+
+      assert {:ok, response} = Availability.build(input)
+      assert length(response.targets) == 1
+      assert hd(response.targets).id == "X"
+    end
+
+    test "byPick spans current_pick through last_pick + 1 inclusive", %{corpus: corpus} do
+      input = base_input(%{corpus: corpus, limit: 1})
+
+      assert {:ok, response} = Availability.build(input)
+      target = hd(response.targets)
+      keys = target.by_pick |> Map.keys() |> Enum.sort()
+      # current_pick 1 .. last_pick 8, +1 for the extra survival-after column
+      assert keys == Enum.to_list(1..9)
+      assert target.by_pick[1] == %{adj_survival: 1.0, base_survival: 1.0, threats: []}
+    end
+  end
+end

--- a/test/sleeper_player_api/intel/pick_ownership_test.exs
+++ b/test/sleeper_player_api/intel/pick_ownership_test.exs
@@ -1,0 +1,99 @@
+defmodule SleeperPlayerApi.Intel.PickOwnershipTest do
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApi.Intel.PickOwnership
+
+  describe "round_of/2 and slot_of/3 — linear" do
+    test "round is 1-indexed ceil(pick/teams)" do
+      assert PickOwnership.round_of(1, 12) == 1
+      assert PickOwnership.round_of(12, 12) == 1
+      assert PickOwnership.round_of(13, 12) == 2
+      assert PickOwnership.round_of(35, 12) == 3
+      assert PickOwnership.round_of(37, 12) == 4
+    end
+
+    test "linear slot never reverses across rounds" do
+      assert PickOwnership.slot_of(1, 12, "linear") == {:ok, 1}
+      assert PickOwnership.slot_of(12, 12, "linear") == {:ok, 12}
+      # round 2 starts back at slot 1, not 12 (that's snake's job)
+      assert PickOwnership.slot_of(13, 12, "linear") == {:ok, 1}
+      assert PickOwnership.slot_of(35, 12, "linear") == {:ok, 11}
+    end
+  end
+
+  describe "slot_of/3 — snake" do
+    test "reverses on even rounds" do
+      # round 1 (odd): forward
+      assert PickOwnership.slot_of(1, 12, "snake") == {:ok, 1}
+      assert PickOwnership.slot_of(12, 12, "snake") == {:ok, 12}
+      # round 2 (even): reversed — pick 13 is slot 12, pick 24 is slot 1
+      assert PickOwnership.slot_of(13, 12, "snake") == {:ok, 12}
+      assert PickOwnership.slot_of(24, 12, "snake") == {:ok, 1}
+      # round 3 (odd): forward again
+      assert PickOwnership.slot_of(25, 12, "snake") == {:ok, 1}
+    end
+  end
+
+  describe "slot_of/3 — unsupported draft type fails loudly" do
+    test "auction (and anything else) is a hard error, not a guess" do
+      assert PickOwnership.slot_of(5, 12, "auction") ==
+               {:error, {:unsupported_draft_type, "auction"}}
+    end
+  end
+
+  describe "resolve_roster/5" do
+    setup do
+      slot_to_roster_id = for slot <- 1..12, into: %{}, do: {slot, slot}
+      %{slot_to_roster_id: slot_to_roster_id}
+    end
+
+    test "no trade — pick resolves to the original slot's roster", %{
+      slot_to_roster_id: slot_to_roster_id
+    } do
+      assert PickOwnership.resolve_roster(1, 12, "linear", slot_to_roster_id, %{}) == {:ok, 1}
+    end
+
+    test "a traded pick resolves to the new roster, not the original slot's", %{
+      slot_to_roster_id: slot_to_roster_id
+    } do
+      # pick 1 is round 1, slot 1 -> original roster 1. Roster 1's round-1
+      # pick was traded to roster 9.
+      traded = %{{1, 1} => 9}
+
+      assert PickOwnership.resolve_roster(1, 12, "linear", slot_to_roster_id, traded) ==
+               {:ok, 9}
+    end
+
+    test "propagates the unsupported-type error", %{slot_to_roster_id: slot_to_roster_id} do
+      assert PickOwnership.resolve_roster(1, 12, "snek", slot_to_roster_id, %{}) ==
+               {:error, {:unsupported_draft_type, "snek"}}
+    end
+  end
+
+  describe "resolve_board/5 — the §4f acceptance case" do
+    test "atekipp owns both pick 35 and pick 37 once trades are applied" do
+      teams = 12
+      slot_to_roster_id = %{11 => 5, 1 => 9, 12 => 3, 2 => 2}
+
+      # round 3 roster 5's pick -> roster 9 (atekipp); round 4 roster 9's
+      # OWN pick stays roster 9 (atekipp already owned it); round 4 roster
+      # 2 stays roster 2; round 3 roster 3 stays roster 3.
+      traded = %{{3, 5} => 9}
+
+      assert {:ok, board} =
+               PickOwnership.resolve_board(35..38, teams, "linear", slot_to_roster_id, traded)
+
+      assert board == [
+               %{pick: 35, roster_id: 9},
+               %{pick: 36, roster_id: 3},
+               %{pick: 37, roster_id: 9},
+               %{pick: 38, roster_id: 2}
+             ]
+    end
+
+    test "short-circuits on the first unresolved pick rather than resolving a mixed board" do
+      assert PickOwnership.resolve_board(1..5, 12, "auction", %{}, %{}) ==
+               {:error, {:unsupported_draft_type, "auction"}}
+    end
+  end
+end

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -1,0 +1,321 @@
+defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
+  # Bypass owns a real port and this module points the client at it via the
+  # shared `:sleeper_base_url` Application env key (same trick as
+  # `test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs`), so
+  # this suite can't run concurrently with itself or anything else that
+  # touches that key.
+  use SleeperPlayerApiWeb.ConnCase, async: false
+
+  alias SleeperPlayerApi.Intel
+
+  @corpus_dir Path.expand("../../support/corpus", __DIR__)
+  @draft_id "1313425233306198016"
+  @league_id "1313425233297813504"
+  @ryangh_user_id "521035584588267520"
+
+  setup %{conn: conn} do
+    bypass = Bypass.open()
+    Application.put_env(:sleeper_player_api, :sleeper_base_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      Application.delete_env(:sleeper_player_api, :sleeper_base_url)
+    end)
+
+    {:ok, conn: put_req_header(conn, "accept", "application/json"), bypass: bypass}
+  end
+
+  describe "GET /api/v1/drafts/:draft_id/availability — District 13, §4f acceptance case" do
+    @describetag :corpus
+
+    setup %{bypass: bypass} do
+      seed_corpus_from_json!()
+      seed_target_players!()
+      stub_district_13(bypass)
+      :ok
+    end
+
+    test "resolves the trade-resolved board: atekipp owns both pick 35 and pick 37", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&limit=60"
+        )
+
+      body = json_response(conn, 200)
+
+      assert body["league"] == "District 13 Dynasty League"
+      assert body["draftId"] == String.to_integer(@draft_id)
+      assert body["currentPick"] == 35
+      assert body["lastPick"] == 48
+      assert body["teams"] == 12
+      assert body["rounds"] == 4
+      assert body["myPicks"] == [39]
+      assert body["corpusDrafts"] == 70
+      assert body["tradedPicksApplied"] == true
+
+      board = Enum.map(body["board"], &{&1["pick"], &1["manager"]})
+
+      # The naive `draft_order`/`slot_to_roster_id` version could never
+      # produce this (§4f) — atekipp holds two of the four picks before
+      # pick 39 only because of the traded 3rd-round pick.
+      assert board == [
+               {35, "atekipp"},
+               {36, "cja9689"},
+               {37, "atekipp"},
+               {38, "cunglomerate"},
+               {39, "ryangh"},
+               {40, "baconstains"},
+               {41, "pavelito0010"},
+               {42, "GetForked"},
+               {43, "pavelito0010"},
+               {44, "N8TEDAGR38T"},
+               {45, "atekipp"},
+               {46, "babaghanoush123"},
+               {47, "skeefe"},
+               {48, "cja9689"}
+             ]
+
+      pick39 = Enum.find(body["board"], &(&1["pick"] == 39))
+      assert pick39["mine"] == true
+    end
+
+    test "byPick numbers match the fixture within 0.0005 — proves the whole stack", %{conn: conn} do
+      fixture = read_json!("fixture.json")
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&limit=60"
+        )
+
+      body = json_response(conn, 200)
+
+      targets_by_id = Map.new(body["targets"], &{&1["id"], &1})
+
+      deviations =
+        Enum.flat_map(fixture["targets"], fn expected_target ->
+          actual_target = Map.fetch!(targets_by_id, expected_target["id"])
+
+          Enum.map(expected_target["byPick"], fn {pick_str, expected} ->
+            actual = Map.fetch!(actual_target["byPick"], pick_str)
+
+            assert_in_delta actual["baseSurvival"],
+                            expected["baseSurvival"],
+                            0.0005,
+                            "baseSurvival mismatch for #{expected_target["name"]} @ #{pick_str}"
+
+            assert_in_delta actual["adjSurvival"],
+                            expected["adjSurvival"],
+                            0.0005,
+                            "adjSurvival mismatch for #{expected_target["name"]} @ #{pick_str}"
+
+            assert length(actual["threats"]) == length(expected["threats"]),
+                   "threat count mismatch for #{expected_target["name"]} @ #{pick_str}"
+
+            Enum.zip(actual["threats"], expected["threats"])
+            |> Enum.each(fn {a, e} ->
+              assert a["manager"] == e["manager"]
+              assert a["pick"] == e["pick"]
+
+              assert_in_delta a["prob"],
+                              e["prob"],
+                              0.0005,
+                              "threat prob mismatch for #{expected_target["name"]} @ #{pick_str}, owner #{a["manager"]}"
+            end)
+
+            [
+              abs(actual["baseSurvival"] - expected["baseSurvival"]),
+              abs(actual["adjSurvival"] - expected["adjSurvival"])
+            ]
+          end)
+        end)
+        |> List.flatten()
+
+      max_deviation = Enum.max(deviations)
+
+      IO.puts("""
+
+      Endpoint-vs-fixture deviations (tolerance 0.0005):
+        max #{Float.round(max_deviation, 6)} over #{length(deviations)} baseSurvival/adjSurvival values
+      """)
+
+      assert max_deviation <= 0.0005
+    end
+  end
+
+  describe "GET /api/v1/drafts/:draft_id/availability — no crawled corpus at all" do
+    # Reads `lmusers.json` (below) to seed leaguemate names, so it needs the
+    # same `:corpus` gate as the acceptance-case block above.
+    @describetag :corpus
+
+    setup %{bypass: bypass} do
+      # Leaguemates are still known (`sleeper_users`, from a prior
+      # `/league/:id/users` crawl) so board manager names resolve — it's
+      # specifically the *corpus* of completed rookie drafts that's
+      # missing, which is the failure behaviour §3e is about.
+      seed_users_only!()
+      stub_district_13(bypass)
+      :ok
+    end
+
+    test "still resolves the board (trade resolution doesn't need the corpus), but targets is empty — never a fabricated survival read",
+         %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}")
+      body = json_response(conn, 200)
+
+      assert body["corpusDrafts"] == 0
+      assert body["targets"] == []
+      assert Enum.find(body["board"], &(&1["pick"] == 35))["manager"] == "atekipp"
+    end
+  end
+
+  describe "GET /api/v1/drafts/:draft_id/availability — validation" do
+    test "missing user_id is a 422, not a crash", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/drafts/#{@draft_id}/availability")
+      assert json_response(conn, 422)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Bypass stubs — the live draft-refresh + roster-ownership fetch path
+  # ---------------------------------------------------------------------
+
+  defp stub_district_13(bypass) do
+    respond_json(bypass, "GET", "/draft/#{@draft_id}", read_json!("d13.json"))
+    respond_json(bypass, "GET", "/draft/#{@draft_id}/picks", read_json!("d13_now.json"))
+    respond_json(bypass, "GET", "/draft/#{@draft_id}/traded_picks", read_json!("d13_traded.json"))
+    respond_json(bypass, "GET", "/league/#{@league_id}/rosters", read_json!("d13_rosters.json"))
+  end
+
+  defp respond_json(bypass, method, path, body) do
+    Bypass.stub(bypass, method, path, fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(body))
+    end)
+  end
+
+  # ---------------------------------------------------------------------
+  # Corpus seeding — same shaping as
+  # `test/sleeper_player_api/intel_test.exs`'s `seed_corpus_from_json!/0`
+  # ---------------------------------------------------------------------
+
+  # `eligible_ids` (`Intel.fantasy_position_ids/1`) restricts `targets` to
+  # players with a QB/RB/WR/TE row in `players` — populated in production
+  # by the nightly `GetSleeperPlayerData` job, empty here since this test
+  # doesn't run it. Seed just the fixture's 16 target players directly
+  # (names/positions from the corpus's own pick metadata) rather than the
+  # whole ~9,400-player dump.
+  @target_players [
+    {"13353", "Chris", "Brazzell", "WR"},
+    {"13289", "Drew", "Allar", "QB"},
+    {"13347", "Demond", "Claiborne", "RB"},
+    {"13319", "Oscar", "Delp", "TE"},
+    {"13302", "Adam", "Randall", "RB"},
+    {"13303", "Cade", "Klubnik", "QB"},
+    {"13400", "Justin", "Joly", "TE"},
+    {"13434", "Will", "Kacmarek", "TE"},
+    {"13404", "Garrett", "Nussmeier", "QB"},
+    {"13306", "Taylen", "Green", "QB"},
+    {"13423", "Eli", "Heidenreich", "RB"},
+    {"13420", "Bryce", "Lance", "WR"},
+    {"13348", "J'Mari", "Taylor", "RB"},
+    {"13401", "Michael", "Trigg", "TE"},
+    {"13333", "Deion", "Burks", "WR"},
+    {"13424", "Seth", "McGowan", "RB"}
+  ]
+
+  defp seed_target_players! do
+    Enum.each(@target_players, fn {player_id, first_name, last_name, position_abbr} ->
+      position =
+        SleeperPlayerApi.Sleeper.get_position_by_abbreviation(position_abbr) ||
+          (
+            {:ok, position} =
+              SleeperPlayerApi.Sleeper.create_position(%{abbreviation: position_abbr})
+
+            position
+          )
+
+      full_name = "#{first_name} #{last_name}"
+
+      %SleeperPlayerApi.Sleeper.Player{}
+      |> SleeperPlayerApi.Sleeper.Player.changeset(%{
+        id: String.to_integer(player_id),
+        player_id: player_id,
+        player_json: "{}",
+        active: true,
+        first_name: first_name,
+        last_name: last_name,
+        full_name: full_name,
+        search_first_name: String.downcase(first_name),
+        search_last_name: String.downcase(last_name),
+        search_full_name: String.downcase(full_name),
+        position_id: position.id
+      })
+      |> SleeperPlayerApi.Repo.insert!()
+    end)
+  end
+
+  defp seed_users_only! do
+    users = read_json!("lmusers.json")
+
+    Intel.upsert_sleeper_users(
+      Enum.map(users, fn u ->
+        %{id: String.to_integer(u["user_id"]), display_name: u["display_name"]}
+      end)
+    )
+  end
+
+  defp seed_corpus_from_json! do
+    raw_drafts = read_json!("rookie_drafts.json")
+    raw_picks_by_draft = read_json!("rookie_picks.json")
+    users = read_json!("lmusers.json")
+
+    Intel.upsert_sleeper_users(
+      Enum.map(users, fn u ->
+        %{id: String.to_integer(u["user_id"]), display_name: u["display_name"]}
+      end)
+    )
+
+    Intel.upsert_observed_drafts(
+      for {draft_id, draft} <- raw_drafts do
+        %{
+          id: String.to_integer(draft_id),
+          league_id: draft["league_id"] && String.to_integer(draft["league_id"]),
+          season: draft["season"],
+          status: draft["status"],
+          draft_type: draft["type"],
+          teams: draft["settings"]["teams"],
+          rounds: draft["settings"]["rounds"]
+        }
+      end
+    )
+
+    for {draft_id, _draft} <- raw_drafts do
+      picks = Map.get(raw_picks_by_draft, draft_id, [])
+
+      entries =
+        for pick <- picks do
+          %{
+            pick_no: pick["pick_no"],
+            round: pick["round"],
+            draft_slot: pick["draft_slot"],
+            roster_id: pick["roster_id"],
+            player_id: pick["player_id"],
+            picked_by: parse_picked_by(pick["picked_by"])
+          }
+        end
+
+      Intel.upsert_observed_picks(String.to_integer(draft_id), entries)
+    end
+  end
+
+  defp parse_picked_by(nil), do: nil
+  defp parse_picked_by(""), do: nil
+  defp parse_picked_by(id), do: String.to_integer(id)
+
+  defp read_json!(filename) do
+    @corpus_dir
+    |> Path.join(filename)
+    |> File.read!()
+    |> Jason.decode!()
+  end
+end


### PR DESCRIPTION
Plan §3f step 4 — the first thing the frontend can actually consume.

`GET /api/v1/drafts/:draft_id/availability?user_id=<n>&at_pick=<n>&limit=<n>`

Response is the prototype fixture's shape (camelCase keys and all), so the
frontend step is a fetch call rather than a rewrite. Every number comes from
`Intel.Estimator` — nothing here reimplements a formula.

## Trade resolution

`PickOwnership` is pure and folds the traded-pick ledger onto the board.

§3d's formula assumes a **linear** draft, which the plan never says. On a
snake draft the slot reverses on even rounds, so applying it blindly would
attribute picks to the wrong manager — the one thing §4f says this feature
must never do. Snake is handled explicitly; any other draft type fails
loudly rather than guessing.

## Verification

| Check | Result |
| --- | --- |
| §4f acceptance | `atekipp` resolves to **both** pick 35 and 37 — impossible for the naive `draft_order` version |
| Fixture match | exact across 480 `byPick` values |
| No corpus | board still resolves, `targets: []` — never a fabricated survival read (§3e) |
| Sabotage (ignore trades) | 6 tests fail across unit, domain and controller layers |

100 tests, 0 failures.

## Three gaps in §3a/§3e, found by consuming them

- **`drafts_corpus/1` was unfiltered by status.** A live draft crawled
  alongside completed ones would count as evidence for its own board.
  Now filters to `complete`, plus an `exclude_draft_id` option for the
  moment the analyzed draft itself finishes. This is a real behaviour
  change to shipped code, not a refactor.
- **No `league_name` anywhere in the schema**, though the response needs it.
  Captured at crawl time rather than costing a live call per request. Adds
  a migration.
- **Roster ownership (`roster_id → user_id`) has no table at all**, and it's
  required to turn the roster-keyed traded-pick ledger into manager names.
  Fetched live per request rather than adding a sixth table for something
  request-scoped.

## Worth knowing before deploy

This endpoint makes **live Sleeper calls per request** (`/league/:id/rosters`,
plus a picks refresh for an in-progress draft). They go through the shared
`RateLimiter`, but it's new outbound traffic in production.

## Targets selection — a product decision, not a derived one

Nothing in the plan determines which players become `targets`. Chosen:
corpus players not yet drafted, `QB/RB/WR/TE` only, ordered by `leagueAdp`,
capped by `limit` (default 20). The position filter turned out to be
necessary — without it a 5-draft-sample linebacker out-ranked every real
target on raw ADP.

The fixture's own 16 additionally intersect FantasyCalc's tracked universe,
which needs `player_values` (step 5), so this isn't coupled to it yet.