### PR TITLE
Return an empty board once a draft has finished

### DIFF
--- a/lib/sleeper_player_api/intel/availability.ex
+++ b/lib/sleeper_player_api/intel/availability.ex
@@ -80,7 +80,14 @@ defmodule SleeperPlayerApi.Intel.Availability do
 
     with {:ok, board_rosters} <-
            PickOwnership.resolve_board(
-             current_pick..last_pick,
+             # `//1` is load-bearing: a bare `a..b` where a > b silently
+             # becomes a DESCENDING range. Once a draft finishes,
+             # `current_pick` is `last_pick + 1`, so `49..48` yielded a board
+             # of [49, 48] — one pick that never existed and one already
+             # made — instead of the empty board that says "no picks left".
+             # Found by hitting the endpoint against the real, now-completed
+             # District 13 draft; every test used a mid-draft board.
+             current_pick..last_pick//1,
              input.teams,
              input.draft_type,
              input.slot_to_roster_id,
@@ -201,8 +208,9 @@ defmodule SleeperPlayerApi.Intel.Availability do
 
     board_mult_fun = fn pick -> mult_fun.(Map.get(board_owner, pick)) end
 
+    # `//1` for the same reason as the board range above.
     by_pick =
-      for pick <- current_pick..(last_pick + 1), into: %{} do
+      for pick <- current_pick..(last_pick + 1)//1, into: %{} do
         base_survival = Estimator.base_survival(hazard, current_pick, pick)
         adj_survival = Estimator.adjusted_survival(hazard, current_pick, pick, board_mult_fun)
 

--- a/test/sleeper_player_api/intel/availability_test.exs
+++ b/test/sleeper_player_api/intel/availability_test.exs
@@ -96,6 +96,55 @@ defmodule SleeperPlayerApi.Intel.AvailabilityTest do
     end
   end
 
+  describe "a draft that has already finished" do
+    # Regression: found by hitting the deployed endpoint against the real
+    # District 13 draft, which completed after the corpus was harvested.
+    # Every other test here uses a mid-draft board, so nothing caught it.
+    #
+    # `current_pick` becomes `last_pick + 1` once the final pick is in, and a
+    # bare `a..b` range in Elixir silently reverses when a > b. The board came
+    # back as [49, 48]: one pick that never existed, one already made.
+    setup do
+      # 4 teams x 2 rounds = 8 picks, all of them made.
+      picks_made = for n <- 1..8, do: %{pick_no: n, player_id: "P#{n}"}
+      {:ok, input: base_input(%{picks_made: picks_made})}
+    end
+
+    test "reports no remaining picks rather than phantom ones", %{input: input} do
+      assert {:ok, response} = Availability.build(input)
+
+      assert response.current_pick == 9
+      assert response.last_pick == 8
+      assert response.board == []
+      assert response.my_picks == []
+    end
+
+    test "does not invent a byPick column for a pick that cannot happen", %{input: input} do
+      # "P99" is deliberately NOT among the made picks (P1..P8), so it really
+      # is still a candidate and `targets` is non-empty — otherwise the
+      # assertion below would loop over nothing and pass vacuously.
+      corpus = [
+        %{l_d: 8.0, picks: [%{norm: 2.0, player_id: "P99", manager: "bob"}]}
+      ]
+
+      assert {:ok, response} =
+               Availability.build(
+                 Map.merge(input, %{
+                   corpus: corpus,
+                   candidate_lookup: %{"P99" => %{name: "Player Ninetynine", position: "WR"}}
+                 })
+               )
+
+      assert [target] = response.targets
+
+      assert Map.keys(target.by_pick) == [9],
+             "expected only the current pick's column, got #{inspect(Map.keys(target.by_pick))}"
+
+      assert target.by_pick[9].base_survival == 1.0
+      assert target.by_pick[9].threats == []
+    end
+  end
+
   describe "corpus-missing failure behaviour (plan §3e)" do
     test "an empty corpus returns targets: [] and corpusDrafts: 0, never fabricated survival numbers" do
       assert {:ok, response} = Availability.build(base_input())


### PR DESCRIPTION
Found by calling the **deployed** endpoint against the real District 13
draft, which finished after the corpus was harvested. Every test used a
mid-draft board, so nothing caught it.

A bare `a..b` range in Elixir silently becomes **descending** when `a > b`.
Once the final pick is in, `current_pick` is `last_pick + 1`, so `49..48`
produced a board of `[49, 48]` — one pick that never existed and one already
made — instead of the empty board that honestly says "no picks left". The
`byPick` comprehension had the same latent bug one pick further out.

The estimator already used `//1` in the equivalent spot; this module didn't.

This is the honest-answer case §3g gap 1b asks for: where there is no
following pick, say so rather than rendering something.

## Tests

102 tests, 0 failures. Two new ones for a fully-drafted board — no remaining
picks, and no `byPick` column for a pick that cannot happen.

Sabotage-verified: reverting the `//1` fails the new test.

One of the two started out passing vacuously (its only candidate player was
among the drafted picks, so `targets` was empty and the assertion looped
over nothing). Fixed to use a player that really is still available, and it
now asserts a non-empty `targets` first.