### PR TITLE
Don't crash on picks Sleeper can't attribute to a user

### DIFF
--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
@@ -400,7 +400,21 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts do
 
   defp to_int(nil), do: nil
   defp to_int(i) when is_integer(i), do: i
-  defp to_int(s) when is_binary(s), do: String.to_integer(s)
+
+  # Real Sleeper data has `picked_by: ""` — an autopicked/unattributed pick.
+  # 3 of the 3,286 picks in the harvested corpus are like this, and a live
+  # crawl hit one immediately. `String.to_integer("")` raises, which took
+  # down a whole production crawl. Anything unparseable means "no user we
+  # can attribute this to", which is exactly `nil`: the pick still counts
+  # toward the league-wide base hazard, it just can't count toward any
+  # manager's seen/took. That matches how the JSON corpus loader and
+  # `Intel.drafts_corpus/1` already treat an unknown picker.
+  defp to_int(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {i, ""} -> i
+      _ -> nil
+    end
+  end
 
   defp utc_now, do: DateTime.utc_now() |> DateTime.truncate(:second)
 end

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
@@ -296,6 +296,44 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDraftsTest do
     end
   end
 
+  describe "picks Sleeper can't attribute to a user" do
+    # Regression: a live production crawl died on the first draft it hit.
+    # Real Sleeper data uses `picked_by: ""` (not null) for an autopicked or
+    # otherwise unattributed pick — 3 of the 3,286 picks in the harvested
+    # corpus are like this. `String.to_integer("")` raises, and it took the
+    # whole crawl down.
+    #
+    # This never surfaced because every other test either used a real id or
+    # nil, and the DB-seeding test helpers parse `picked_by` themselves
+    # rather than going through the crawler.
+    test "an empty-string picked_by is stored as nil, not a crash", %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1001", "complete")])
+
+      expect_json(bypass, "/draft/1001/picks", [
+        pick(1, "P1", "100"),
+        pick(2, "P2", ""),
+        pick(3, "P3", nil)
+      ])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert summary.errors == []
+      assert summary.picks_stored == 3
+
+      picks = Repo.all(from(p in ObservedPick, where: p.draft_id == 1001, order_by: p.pick_no))
+
+      assert [
+               %{player_id: "P1", picked_by: 100},
+               %{player_id: "P2", picked_by: nil},
+               %{player_id: "P3", picked_by: nil}
+             ] = picks
+    end
+  end
+
   describe "rookie filtering" do
     test "only rookie drafts (settings.player_type == 1) are crawled or stored", %{
       bypass: bypass


### PR DESCRIPTION
A live production crawl died on the first draft it touched.

Real Sleeper data uses `picked_by: ""` — not `null` — for an autopicked or
otherwise unattributed pick. `String.to_integer("")` raises, and it took the
whole crawl down. 3 of the 3,286 picks in the harvested corpus are like
this, so it was always going to happen on the first real run.

Anything unparseable now means "no user we can attribute this to", which is
exactly `nil`: the pick still counts toward the league-wide base hazard, it
just can't count toward any manager's seen/took. That's how the JSON corpus
loader and `Intel.drafts_corpus/1` already treat an unknown picker.

## Why no test caught it

Every crawler test used either a real id or `nil`, and — more to the point —
the DB-seeding test helpers parse `picked_by` themselves rather than going
through the crawler. `intel_test.exs` even has a `parse_picked_by("")` clause
handling this exact case. The production path was the only one that didn't,
and nothing exercised it.

Added a crawler-level regression test covering all three shapes (id, `""`,
`nil`). Sabotage-verified: restoring `String.to_integer/1` fails it.

103 tests, 0 failures.