### PR TITLE
Fetch slot_to_roster_id for the draft being analyzed

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -19,7 +19,10 @@ defmodule SleeperPlayerApi.Intel do
 
   `availability/2` (plan §3f step 4) is the one exception to "no HTTP" —
   resolving trade-aware pick ownership needs a live `/league/:id/rosters`
-  call (see its doc) and, for an in-progress draft, a refresh through
+  call (see its doc) and a live `/draft/:id` call for `slot_to_roster_id`
+  (see `fetch_slot_to_roster_id/1` — the crawler's own listing call never
+  gets that field, so it can't come from the DB alone) and, for an
+  in-progress draft, a refresh through
   `SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts.refresh_draft/1`.
   """
 
@@ -477,6 +480,53 @@ defmodule SleeperPlayerApi.Intel do
   end
 
   @doc """
+  Live `slot -> roster_id` for one draft, via `GET /draft/:id` — deliberately
+  not read from the stored `observed_drafts.slot_to_roster_id` column.
+
+  `GET /user/:id/drafts/nfl/:season` (what `CrawlLeaguemateDrafts` reads to
+  discover and store a leaguemate's drafts) doesn't include
+  `slot_to_roster_id` at all — confirmed against the harvested corpus
+  (`test/support/corpus/rookie_drafts.json` has no such key on any entry,
+  while `GET /draft/:id`'s own payload, `test/support/corpus/d13.json`,
+  does). So a draft the crawler has only ever seen via that listing call —
+  which is every `"complete"` draft once it stops being refreshed — has
+  `slot_to_roster_id: nil` in the DB forever, and
+  `PickOwnership.resolve_roster/5` needs an authoritative mapping to
+  resolve pick ownership. This fetches it fresh for the one draft being
+  analyzed, same request-scoped live-fetch pattern as
+  `fetch_roster_owners/1` above (one extra call, no new table), rather than
+  trusting whatever's stored.
+
+  Also persists the fetched map onto the `observed_drafts` row (keyed on
+  `id`, replacing only `slot_to_roster_id`) — the column already exists and
+  is otherwise dead for any draft the crawler found via the listing call, so
+  this is a cheap opportunistic backfill: once a draft has been analyzed
+  once, later reads of the stored row (if anything ever needs one) see the
+  real mapping too.
+  """
+  @spec fetch_slot_to_roster_id(integer) :: {:ok, %{integer => integer}} | {:error, term}
+  def fetch_slot_to_roster_id(draft_id) do
+    case Sleeper.get("/draft/#{draft_id}") do
+      {:ok, response} ->
+        raw = Map.get(response, "slot_to_roster_id") || %{}
+        persist_slot_to_roster_id(draft_id, raw)
+        {:ok, normalize_slot_map(raw)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  defp persist_slot_to_roster_id(draft_id, slot_to_roster_id) do
+    insert_all_batched(
+      ObservedDraft,
+      [%{id: draft_id, slot_to_roster_id: slot_to_roster_id}],
+      conflict_target: [:id],
+      replace: [:slot_to_roster_id]
+    )
+  end
+
+  @doc """
   `%{player_id => %{name, position}}` for a set of Sleeper player ids,
   joined from the `players` table (populated by the nightly
   `GetSleeperPlayerData` job, per plan §3f step 4 "should come from the
@@ -625,9 +675,9 @@ defmodule SleeperPlayerApi.Intel do
   defp build_availability(draft, my_user_id, at_pick, limit) do
     picks_made = draft_picks(draft.id)
     traded_picks = draft_traded_picks(draft.id)
-    slot_to_roster_id = normalize_slot_map(draft.slot_to_roster_id)
 
-    with {:ok, roster_to_user} <- fetch_roster_owners(draft.league_id) do
+    with {:ok, slot_to_roster_id} <- fetch_slot_to_roster_id(draft.id),
+         {:ok, roster_to_user} <- fetch_roster_owners(draft.league_id) do
       user_id_to_manager = manager_names_by_id()
       corpus = drafts_corpus(user_id_to_manager, exclude_draft_id: draft.id)
 

--- a/lib/sleeper_player_api/intel/pick_ownership.ex
+++ b/lib/sleeper_player_api/intel/pick_ownership.ex
@@ -64,16 +64,32 @@ defmodule SleeperPlayerApi.Intel.PickOwnership do
   Sleeper's own JSON has string keys; callers normalize before calling
   this). `traded_picks` is `%{{round, original_roster_id} => new_roster_id}`
   — a pick not present in that map is still owned by its original roster.
+
+  A slot missing from `slot_to_roster_id` (empty map, or a hole in it) is a
+  data problem — the crawler couldn't populate the mapping, or Sleeper
+  hasn't assigned that slot yet — not a crash: `{:error, {:unmapped_slot,
+  slot}}`, same shape as the unsupported-draft-type error, rather than
+  `Map.fetch!/2` raising `KeyError` and turning one bad row into a 500 (hit
+  in production against a real draft whose `slot_to_roster_id` was `%{}`).
   """
   @spec resolve_roster(pos_integer, pos_integer, String.t(), %{integer => integer}, %{
           {integer, integer} => integer
-        }) :: {:ok, integer} | {:error, {:unsupported_draft_type, String.t()}}
+        }) ::
+          {:ok, integer}
+          | {:error, {:unsupported_draft_type, String.t()} | {:unmapped_slot, pos_integer}}
   def resolve_roster(pick_no, teams, draft_type, slot_to_roster_id, traded_picks) do
-    with {:ok, slot} <- slot_of(pick_no, teams, draft_type) do
+    with {:ok, slot} <- slot_of(pick_no, teams, draft_type),
+         {:ok, original_roster} <- fetch_roster(slot_to_roster_id, slot) do
       round = round_of(pick_no, teams)
-      original_roster = Map.fetch!(slot_to_roster_id, slot)
       true_roster = Map.get(traded_picks, {round, original_roster}, original_roster)
       {:ok, true_roster}
+    end
+  end
+
+  defp fetch_roster(slot_to_roster_id, slot) do
+    case Map.fetch(slot_to_roster_id, slot) do
+      {:ok, roster_id} -> {:ok, roster_id}
+      :error -> {:error, {:unmapped_slot, slot}}
     end
   end
 

--- a/lib/sleeper_player_api_web/controllers/fallback_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/fallback_controller.ex
@@ -44,6 +44,17 @@ defmodule SleeperPlayerApiWeb.FallbackController do
     |> Phoenix.Controller.json(%{errors: %{detail: "unsupported draft type: #{type}"}})
   end
 
+  # `PickOwnership.resolve_roster/5` couldn't find a roster for a draft
+  # slot — Sleeper's `slot_to_roster_id` was missing or incomplete for this
+  # draft. Same "hard failure, never a fabricated board" reasoning as
+  # `:unsupported_draft_type` above.
+  def call(conn, {:error, {:unmapped_slot, slot}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: SleeperPlayerApiWeb.ErrorJSON)
+    |> Phoenix.Controller.json(%{errors: %{detail: "no roster mapped for draft slot #{slot}"}})
+  end
+
   # Anything else an action returns as `{:error, reason}` — e.g. the
   # `/league/:id/rosters` fetch in `Intel.availability/2` failing.
   def call(conn, {:error, reason}) do

--- a/test/sleeper_player_api/intel/pick_ownership_test.exs
+++ b/test/sleeper_player_api/intel/pick_ownership_test.exs
@@ -68,6 +68,26 @@ defmodule SleeperPlayerApi.Intel.PickOwnershipTest do
       assert PickOwnership.resolve_roster(1, 12, "snek", slot_to_roster_id, %{}) ==
                {:error, {:unsupported_draft_type, "snek"}}
     end
+
+    test "an empty slot_to_roster_id is an error, not a KeyError crash" do
+      # Regression: a real production draft had `slot_to_roster_id: %{}`
+      # (the crawler's own `/user/:id/drafts/nfl/:season` listing call
+      # never returns that field — see `SleeperPlayerApi.Intel.
+      # fetch_slot_to_roster_id/1`). `Map.fetch!/2` turned that into an
+      # uncaught `KeyError` and a 500; this must come back as a tagged
+      # error instead.
+      assert PickOwnership.resolve_roster(1, 12, "linear", %{}, %{}) ==
+               {:error, {:unmapped_slot, 1}}
+    end
+
+    test "a partial slot_to_roster_id errors only for the slot that's actually missing" do
+      partial = %{1 => 1, 2 => 2}
+
+      assert PickOwnership.resolve_roster(1, 12, "linear", partial, %{}) == {:ok, 1}
+
+      assert PickOwnership.resolve_roster(3, 12, "linear", partial, %{}) ==
+               {:error, {:unmapped_slot, 3}}
+    end
   end
 
   describe "resolve_board/5 — the §4f acceptance case" do

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -7,6 +7,9 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
   use SleeperPlayerApiWeb.ConnCase, async: false
 
   alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.ObservedDraft
+  alias SleeperPlayerApi.Repo
+  alias SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts
 
   @corpus_dir Path.expand("../../support/corpus", __DIR__)
   @draft_id "1313425233306198016"
@@ -166,6 +169,113 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
       assert body["corpusDrafts"] == 0
       assert body["targets"] == []
       assert Enum.find(body["board"], &(&1["pick"] == 35))["manager"] == "atekipp"
+    end
+  end
+
+  describe "GET /api/v1/drafts/:draft_id/availability — draft state produced by the crawler, not seeded" do
+    # Regression for a production 500. Every other describe block above
+    # seeds `observed_drafts` directly (`seed_corpus_from_json!`,
+    # `upsert_observed_drafts` in this file's own helpers), which writes
+    # whatever `slot_to_roster_id` the test fixture happens to include.
+    # That's not what the crawler can ever actually produce: `GET
+    # /user/:id/drafts/nfl/:season` — the only call `CrawlLeaguemateDrafts`
+    # makes to discover a draft — doesn't return `slot_to_roster_id` at
+    # all. So a draft that's `"complete"` (never refreshed again by
+    # `ensure_fresh/1`) has `slot_to_roster_id: nil` in the DB forever once
+    # it's gone through a *real* `CrawlLeaguemateDrafts.crawl/2`, not a
+    # seeding helper — and `/availability` 500'd on exactly that column
+    # against real production data.
+    #
+    # This block runs the actual crawler against Bypass stubs shaped like
+    # real Sleeper responses (no `slot_to_roster_id` on the listing call,
+    # same as `CrawlLeaguemateDraftsTest`'s fixtures), then hits
+    # `/availability` against the state it left behind.
+    @small_league_id "999"
+    @small_user_id "100"
+    @small_draft_id "5000"
+
+    defp small_draft(status) do
+      %{
+        "draft_id" => @small_draft_id,
+        "league_id" => @small_league_id,
+        "season" => "2026",
+        "status" => status,
+        "type" => "linear",
+        "start_time" => 1_700_000_000_000,
+        "settings" => %{"player_type" => 1, "teams" => 2, "rounds" => 3}
+        # Deliberately no "slot_to_roster_id" key — real
+        # `/user/:id/drafts/nfl/:season` responses don't have one either.
+      }
+    end
+
+    defp small_pick(pick_no, player_id, picked_by) do
+      %{
+        "pick_no" => pick_no,
+        "round" => 1,
+        "draft_slot" => pick_no,
+        "roster_id" => pick_no,
+        "player_id" => player_id,
+        "picked_by" => picked_by
+      }
+    end
+
+    setup %{bypass: bypass} do
+      respond_json(bypass, "GET", "/league/#{@small_league_id}/users", [
+        %{"user_id" => @small_user_id, "username" => "alice_u", "display_name" => "alice"}
+      ])
+
+      respond_json(bypass, "GET", "/user/#{@small_user_id}/drafts/nfl/2026", [
+        small_draft("complete")
+      ])
+
+      # Only 2 of the draft's 6 picks are "made" — leaves picks 3-6 for
+      # `/availability` to resolve against `slot_to_roster_id`, which is
+      # exactly the path that raised.
+      respond_json(bypass, "GET", "/draft/#{@small_draft_id}/picks", [
+        small_pick(1, "P1", @small_user_id),
+        small_pick(2, "P2", nil)
+      ])
+
+      # `/availability`'s live fetch for the analyzed draft — the fix under
+      # test. Has to be the full draft object (status "complete" here,
+      # matching what's stored) with a real `slot_to_roster_id`, unlike the
+      # listing call above.
+      respond_json(bypass, "GET", "/draft/#{@small_draft_id}", %{
+        "draft_id" => @small_draft_id,
+        "league_id" => @small_league_id,
+        "status" => "complete",
+        "type" => "linear",
+        "slot_to_roster_id" => %{"1" => 1, "2" => 2}
+      })
+
+      respond_json(bypass, "GET", "/league/#{@small_league_id}/rosters", [
+        %{"roster_id" => 1, "owner_id" => @small_user_id},
+        %{"roster_id" => 2, "owner_id" => "200"}
+      ])
+
+      assert {:ok, %{drafts_fetched: 1}} = CrawlLeaguemateDrafts.crawl(@small_league_id, "2026")
+
+      assert %ObservedDraft{status: "complete", slot_to_roster_id: nil} =
+               Repo.get!(ObservedDraft, String.to_integer(@small_draft_id))
+
+      :ok
+    end
+
+    test "resolves the board instead of 500ing on the crawler's own slot_to_roster_id gap", %{
+      conn: conn
+    } do
+      conn =
+        get(conn, ~p"/api/v1/drafts/#{@small_draft_id}/availability?user_id=#{@small_user_id}")
+
+      body = json_response(conn, 200)
+
+      assert body["currentPick"] == 3
+      assert body["lastPick"] == 6
+
+      board = Enum.map(body["board"], &{&1["pick"], &1["mine"]})
+      # slot 1 -> roster 1 -> alice (owner_id 100, this request's user);
+      # slot 2 -> roster 2 -> owner_id 200, not this request's user.
+      assert board == [{3, true}, {4, false}, {5, true}, {6, false}]
     end
   end
 


### PR DESCRIPTION
`/availability` returned **500 against real production data**. `slot_to_roster_id`
was `%{}` for every stored draft, so pick ownership raised on the first slot
lookup.

## Root cause

The crawler discovers drafts through `GET /user/:id/drafts/nfl/:season`, and
that response has **no `slot_to_roster_id`** — only `GET /draft/:id` does,
which the crawler never calls. The column could never be populated, and it's
the one thing pick resolution cannot work without.

Verified against the harvested corpus: `rookie_drafts.json` entries (the
listing shape) lack the key; `d13.json` (the single-draft shape) has it.

## Fix

Fetched live for the single draft being analyzed — the same request-scoped
pattern already used for `/league/:id/rosters` — and opportunistically
persisted, since the column exists and was otherwise dead.

`PickOwnership.resolve_roster/5` no longer uses `Map.fetch!`. An unmapped
slot is a data problem, not a crash: it returns an error the controller
renders as 422, matching how an unsupported draft type is already handled.

## The test gap, which matters more than the fix

**Both production bugs so far came from the same blind spot.** The tests seed
the database directly, so they exercise state the crawler never actually
produces:

| Bug | Why tests missed it |
| --- | --- |
| `picked_by: ""` crashed the crawl | helpers parsed `picked_by` themselves |
| `slot_to_roster_id` always empty | helpers seeded it from `d13.json` |

Both suites were green throughout.

Added a test that drives `CrawlLeaguemateDrafts.crawl/2` against Bypass to
build the draft row, then calls `/availability` against that state — no
seeding helper involved. It reproduces the exact production crash
(`KeyError` at `pick_ownership.ex:74`) without the fix, and it is not
corpus-tagged, so it runs on the deploy gate too.

106 tests, 0 failures. The §4f trade-resolved board and the 480-value fixture
comparison both pass unchanged.