### PR TITLE
FantasyCalc value layer and /intel

### DIFF
--- a/lib/clients/fantasy_calc.ex
+++ b/lib/clients/fantasy_calc.ex
@@ -1,0 +1,73 @@
+defmodule SleeperPlayerApi.Client.FantasyCalc do
+  @moduledoc """
+  Thin HTTPoison wrapper around the FantasyCalc values API, same shape as
+  `SleeperPlayerApi.Client.Sleeper` (plan `docs/leaguemate-intel.md` §2/§3f
+  step 5): `use HTTPoison.Base`, a non-raising `get/1` returning tagged
+  tuples, and the base URL read from Application env so tests can point it
+  at a local Bypass server instead of the real, public, unauthenticated API.
+
+  Unlike the Sleeper client there's no `get!/1` — nothing in this codebase
+  needs a raising variant for FantasyCalc, so it isn't built.
+
+  No throttling: FantasyCalc has no documented rate limit, and
+  `RefreshPlayerValues` makes exactly one call per run.
+  """
+
+  use HTTPoison.Base
+
+  @fantasy_calc_url "https://api.fantasycalc.com"
+
+  def process_request_url(url) do
+    base_url() <> url
+  end
+
+  # Same trick as `SleeperPlayerApi.Client.Sleeper.base_url/0` — reads from
+  # Application env rather than baking `@fantasy_calc_url` straight in, so
+  # tests can point this at Bypass. Production never sets
+  # `:fantasy_calc_base_url`, so this is a no-op outside of tests.
+  defp base_url do
+    Application.get_env(:sleeper_player_api, :fantasy_calc_base_url, @fantasy_calc_url)
+  end
+
+  # Same reasoning as `Sleeper.process_response_body/1`: left raw here so
+  # `get/1` can decode with the status code in hand.
+  def process_response_body(body), do: body
+
+  @doc """
+  `GET /values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1` — the one
+  endpoint this client calls, per plan §2. Query params are fixed (dynasty,
+  2-QB, 12-team, full PPR) rather than parameterized: nothing in this repo
+  needs a different slice of FantasyCalc's values, and pinning them here
+  means every caller gets the exact same value set the plan measured
+  against.
+
+  Returns:
+
+    * `{:ok, decoded_body}` on a 2xx response with a JSON body — a bare
+      list of value entries (not wrapped in an envelope), per the verified
+      response shape in the plan.
+    * `{:error, {:http_error, status_code}}` on any non-2xx status
+    * `{:error, {:invalid_json, status_code}}` on a 2xx response whose body
+      isn't valid JSON
+    * `{:error, {:transport_error, reason}}` on a connection failure
+  """
+  def get(
+        url \\ "/values/current?isDynasty=true&numQbs=2&numTeams=12&ppr=1",
+        headers \\ [],
+        options \\ []
+      ) do
+    case super(url, headers, options) do
+      {:ok, %HTTPoison.Response{status_code: status, body: body}} when status in 200..299 ->
+        case Jason.decode(body) do
+          {:ok, decoded} -> {:ok, decoded}
+          {:error, _reason} -> {:error, {:invalid_json, status}}
+        end
+
+      {:ok, %HTTPoison.Response{status_code: status}} ->
+        {:error, {:http_error, status}}
+
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        {:error, {:transport_error, reason}}
+    end
+  end
+end

--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -162,7 +162,15 @@ defmodule SleeperPlayerApi.Intel do
       PlayerValue,
       values,
       conflict_target: [:player_id, :source],
-      replace: [:value, :overall_rank, :position_rank, :roster_percent, :trade_frequency, :as_of]
+      replace: [
+        :value,
+        :overall_rank,
+        :position_rank,
+        :roster_percent,
+        :trade_frequency,
+        :as_of,
+        :draft_year
+      ]
     )
   end
 
@@ -706,27 +714,343 @@ defmodule SleeperPlayerApi.Intel do
         limit: limit,
         corpus: corpus,
         candidate_lookup: player_lookup(candidate_ids),
-        market_rank: Estimator.rookie_class_rank(market_rookie_class_entries()),
+        market_rank: Estimator.rookie_class_rank(market_rookie_class_entries(draft.season)),
         raw_picks: manager_pick_strings(candidate_ids, user_id_to_manager),
-        eligible_ids: fantasy_position_ids(candidate_ids)
+        eligible_ids: eligible_ids(candidate_ids)
       })
     end
   end
 
-  # `player_values` (plan §2/§3a) is refreshed from FantasyCalc by plan §3f
-  # step 5, which this endpoint step deliberately doesn't build (scope
-  # note: "NOT /intel — that's step 5"). Until that refresh job runs, this
-  # is always empty, so `marketPick`/`adpGap` come back `nil` for every
-  # target — an honest "no market read yet", not a fabricated one.
-  # `maybeDraftInfo.year` (the rookie-class filter, estimator §8) isn't a
-  # `player_values` column either; extending that schema is step 5's job.
-  defp market_rookie_class_entries do
-    from(pv in PlayerValue,
-      where: pv.source == "fantasycalc",
-      select: {pv.player_id, pv.value}
+  # `player_values` (plan §2/§3a) is populated by
+  # `SleeperPlayerApi.Tasks.RefreshPlayerValues` (plan §3f step 5) — not
+  # this module. Filters to the rookie class for `draft.season`: entries
+  # whose `draft_year` matches, per estimator §8 ("rank within the ROOKIE
+  # CLASS... not overall rank"). `draft.season` is a string ("2026", as
+  # Sleeper sends it); `draft_year` is stored as an integer (from
+  # FantasyCalc's `maybeDraftInfo.year`), so the comparison converts.
+  #
+  # Until `RefreshPlayerValues` has run — or for a season it hasn't covered
+  # — this returns `[]`, which flows through to `Estimator.rookie_class_rank/1`
+  # returning `%{}`, so `marketPick`/`adpGap` come back `nil` for every
+  # target: an honest "no market read yet", not a fabricated one.
+  #
+  # NOT the same set `eligible_ids/1` below restricts targets to — see its
+  # comment. Three of the fixture's own 16 targets (Justin Joly, Michael
+  # Trigg, J'Mari Taylor) are in FantasyCalc's payload with no
+  # `maybeDraftInfo` at all, so they're absent here (no `marketPick`) but
+  # must still be eligible targets.
+  defp market_rookie_class_entries(nil), do: []
+
+  defp market_rookie_class_entries(season) do
+    case Integer.parse(season) do
+      {year, _} ->
+        from(pv in PlayerValue,
+          where: pv.source == "fantasycalc" and pv.draft_year == ^year,
+          select: {pv.player_id, pv.value}
+        )
+        |> Repo.all()
+        |> Enum.map(fn {player_id, value} -> {to_string(player_id), value} end)
+
+      :error ->
+        []
+    end
+  end
+
+  # Every player id FantasyCalc tracks at all — source `"fantasycalc"`,
+  # regardless of `draft_year`. Deliberately broader than
+  # `market_rookie_class_entries/1`: "FantasyCalc's tracked rookie universe"
+  # (plan §3f step 5 item 5) means "FantasyCalc has *an opinion* on this
+  # player", not "FantasyCalc classifies him as this season's rookie class"
+  # — verified against the fixture, whose Joly/Trigg/Taylor entries have no
+  # `maybeDraftInfo` (so no `marketPick`) but are still present in
+  # FantasyCalc's payload and still targets.
+  defp market_universe_ids do
+    from(pv in PlayerValue, where: pv.source == "fantasycalc", select: pv.player_id)
+    |> Repo.all()
+    |> Enum.map(&to_string/1)
+    |> MapSet.new()
+  end
+
+  # Which corpus players are eligible to become `targets` (plan §3f step 5
+  # item 5 — "complete the deferred targets restriction"). Two filters,
+  # applied together once market data exists:
+  #
+  #   1. fantasy-relevant position (already built in step 4 — a rookie
+  #      draft's pool isn't exclusively QB/RB/WR/TE)
+  #   2. present in FantasyCalc's tracked universe at all (new here) — a
+  #      player with no market value shouldn't be a target. This is what
+  #      fixes the production case in the report: a one-draft, one-manager
+  #      sample ("Kyle Dixon, WR, lgADP 34.0, sd 0.0, n 1") was outranking
+  #      real targets purely on a thin ADP sample with nothing else backing
+  #      it up.
+  #
+  # Degradation is deliberate: if `market_universe_ids/0` is empty (no
+  # refresh has run yet), filter 2 is skipped entirely rather than
+  # intersecting against an empty set — which would zero out `targets`
+  # completely. That keeps `/availability` working exactly as it did before
+  # this step for anyone who hasn't run `RefreshPlayerValues` yet, which is
+  # also why the existing acceptance tests (no `player_values` seeded) pass
+  # unchanged.
+  defp eligible_ids(candidate_ids) do
+    position_ids = fantasy_position_ids(candidate_ids)
+    market_ids = market_universe_ids()
+
+    if MapSet.size(market_ids) == 0 do
+      position_ids
+    else
+      MapSet.intersection(position_ids, market_ids)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # `/intel` (plan §3e, §3f step 5)
+  # ---------------------------------------------------------------------
+
+  @doc """
+  Builds the `GET /api/v1/leagues/:league_id/intel` response (plan §3e):
+
+      %{managers: [%{user_id, display_name, leagues_count, drafts_count,
+                      drafts_complete, tendencies}],
+        corpus: %{drafts, picks, last_crawled_at}}
+
+  ## Who counts as a "manager" of this league?
+
+  Every leaguemate who has actually made a pick in one of *this* league's
+  own stored drafts — `observed_drafts.league_id == league_id`, optionally
+  narrowed further to `opts[:season]`. Derived straight from `observed_picks`
+  (a `GROUP BY`-shaped query), **not** the `draft_participants` join table
+  plan §3a describes: that table exists in the schema (`upsert_draft_participants/2`)
+  but nothing populates it yet — `CrawlLeaguemateDrafts` never calls it (see
+  the report on this step). Wiring that up is a `CrawlLeaguemateDrafts`
+  change, out of this step's scope; deriving participation from picks
+  instead is the same approach `drafts_corpus/2` already takes and needs no
+  schema change to ship.
+
+  If this league's own draft(s) haven't been crawled yet, `managers` comes
+  back `[]` — an honest "nothing crawled for this league", not an error.
+
+  ## `leagues_count` / `drafts_count` / `drafts_complete`
+
+  These are **not** scoped to `league_id` — they're the manager's totals
+  across the *entire* stored corpus (every league/draft they've ever been
+  observed in), matching plan §5's "how many leagues / rookie drafts is he
+  in? — free, it's just a count over the data already harvested." Scoping
+  them to one league would make every manager read "1 league, 1 draft",
+  which isn't the question this field answers.
+
+  ## `tendencies`
+
+  Loosely specified by plan §4c (player crushes) and §0 (positional lean,
+  reach vs ADP) — implemented here as exactly what falls out of
+  `observed_picks` as `GROUP BY` aggregates, no fitted model:
+
+    * `crushes` — this manager's top 5 most-repeated players, by raw pick
+      count, across every complete draft they're observed in (plan §4c).
+    * `position_lean` — the share of their picks at each position
+      (QB/RB/WR/TE — the same `players`-table join `fantasy_position_ids/1`
+      uses), sorted by share descending.
+    * `reach_vs_adp` — mean `(league ADP − their own ADP)` across every
+      player they've drafted at least once, restricted to players the wider
+      corpus has seen at least twice (`n >= 2`) so a single other manager's
+      one-off pick can't define "league ADP" for the comparison. Positive
+      means this manager takes players earlier than the corpus average
+      (a reacher); negative means they let players slide. `nil` if nothing
+      clears the `n >= 2` bar.
+
+  Deliberately NOT built: a fitted "how chalky" score or roster-construction
+  read (plan §0's "roster construction" bullet) — both need a model or a
+  live rosters call this step doesn't reach for; see the report on this
+  step.
+  """
+  @spec league_intel(integer | String.t(), keyword) :: map
+  def league_intel(league_id, opts \\ []) do
+    league_id = to_int(league_id)
+    season = opts[:season]
+
+    names = manager_names_by_id()
+
+    managers =
+      league_id
+      |> manager_ids_for_league(season)
+      |> Enum.map(fn user_id ->
+        stats = manager_corpus_stats(user_id)
+
+        %{
+          user_id: user_id,
+          display_name: Map.get(names, user_id),
+          leagues_count: stats.leagues_count,
+          drafts_count: stats.drafts_count,
+          drafts_complete: stats.drafts_complete,
+          tendencies: manager_tendencies(user_id)
+        }
+      end)
+      |> Enum.sort_by(&(&1.display_name || ""))
+
+    %{managers: managers, corpus: corpus_summary()}
+  end
+
+  defp manager_ids_for_league(league_id, season) do
+    base =
+      from(p in ObservedPick,
+        join: d in ObservedDraft,
+        on: d.id == p.draft_id,
+        where: d.league_id == ^league_id and not is_nil(p.picked_by)
+      )
+
+    query = if season, do: from([p, d] in base, where: d.season == ^season), else: base
+
+    query
+    |> distinct(true)
+    |> select([p, _d], p.picked_by)
+    |> Repo.all()
+  end
+
+  defp manager_corpus_stats(user_id) do
+    from(p in ObservedPick,
+      join: d in ObservedDraft,
+      on: d.id == p.draft_id,
+      where: p.picked_by == ^user_id,
+      select: %{
+        leagues_count: count(d.league_id, :distinct),
+        drafts_count: count(d.id, :distinct),
+        drafts_complete:
+          fragment("count(distinct case when ? = 'complete' then ? end)", d.status, d.id)
+      }
+    )
+    |> Repo.one()
+  end
+
+  defp corpus_summary do
+    drafts =
+      Repo.one(from(d in ObservedDraft, where: d.status == "complete", select: count(d.id))) || 0
+
+    picks =
+      Repo.one(
+        from(p in ObservedPick,
+          join: d in ObservedDraft,
+          on: d.id == p.draft_id,
+          where: d.status == "complete",
+          select: count(p.pick_no)
+        )
+      ) || 0
+
+    last_crawled_at = Repo.one(from(d in ObservedDraft, select: max(d.picks_fetched_at)))
+
+    %{drafts: drafts, picks: picks, last_crawled_at: last_crawled_at}
+  end
+
+  defp manager_tendencies(user_id) do
+    %{
+      crushes: manager_crushes(user_id),
+      position_lean: manager_position_lean(user_id),
+      reach_vs_adp: manager_reach_vs_adp(user_id)
+    }
+  end
+
+  @crush_limit 5
+
+  defp manager_crushes(user_id) do
+    rows =
+      from(p in ObservedPick,
+        join: d in ObservedDraft,
+        on: d.id == p.draft_id,
+        where: p.picked_by == ^user_id and d.status == "complete",
+        group_by: p.player_id,
+        order_by: [desc: count(p.pick_no)],
+        limit: ^@crush_limit,
+        select: %{player_id: p.player_id, times: count(p.pick_no)}
+      )
+      |> Repo.all()
+
+    seen = Map.get(manager_drafts_seen(), user_id, 0)
+    lookup = player_lookup(Enum.map(rows, & &1.player_id))
+
+    Enum.map(rows, fn row ->
+      info = Map.get(lookup, row.player_id, %{})
+
+      %{
+        player_id: row.player_id,
+        name: Map.get(info, :name),
+        position: Map.get(info, :position),
+        times: row.times,
+        of: seen
+      }
+    end)
+  end
+
+  defp manager_position_lean(user_id) do
+    rows =
+      from(p in ObservedPick,
+        join: d in ObservedDraft,
+        on: d.id == p.draft_id,
+        join: pl in SleeperPlayerApi.Sleeper.Player,
+        on: pl.player_id == p.player_id,
+        join: pos in SleeperPlayerApi.Sleeper.Position,
+        on: pos.id == pl.position_id,
+        where: p.picked_by == ^user_id and d.status == "complete",
+        group_by: pos.abbreviation,
+        select: {pos.abbreviation, count(p.pick_no)}
+      )
+      |> Repo.all()
+
+    total = rows |> Enum.map(&elem(&1, 1)) |> Enum.sum()
+
+    if total == 0 do
+      []
+    else
+      rows
+      |> Enum.map(fn {position, n} ->
+        %{position: position, picks: n, share: Float.round(n / total, 3)}
+      end)
+      |> Enum.sort_by(&(-&1.picks))
+    end
+  end
+
+  defp manager_reach_vs_adp(user_id) do
+    own_adp =
+      from(p in ObservedPick,
+        join: d in ObservedDraft,
+        on: d.id == p.draft_id,
+        where: p.picked_by == ^user_id and d.status == "complete",
+        group_by: p.player_id,
+        select: %{
+          player_id: p.player_id,
+          own_adp: avg(fragment("((? - 1)::float / ? * 12) + 1", p.pick_no, d.teams))
+        }
+      )
+      |> Repo.all()
+
+    league = league_adp_batch(Enum.map(own_adp, & &1.player_id))
+
+    deltas =
+      for %{player_id: player_id, own_adp: mine} <- own_adp,
+          %{n: n, adp: league_adp} <- [Map.get(league, player_id)],
+          not is_nil(n) and n >= 2 do
+        league_adp - mine
+      end
+
+    case deltas do
+      [] -> nil
+      _ -> Float.round(Enum.sum(deltas) / length(deltas), 2)
+    end
+  end
+
+  defp league_adp_batch([]), do: %{}
+
+  defp league_adp_batch(player_ids) do
+    from(p in ObservedPick,
+      join: d in ObservedDraft,
+      on: d.id == p.draft_id,
+      where: p.player_id in ^player_ids,
+      group_by: p.player_id,
+      select: %{
+        player_id: p.player_id,
+        n: count(p.pick_no),
+        adp: avg(fragment("((? - 1)::float / ? * 12) + 1", p.pick_no, d.teams))
+      }
     )
     |> Repo.all()
-    |> Enum.map(fn {player_id, value} -> {to_string(player_id), value} end)
+    |> Map.new(&{&1.player_id, &1})
   end
 
   defp normalize_slot_map(nil), do: %{}

--- a/lib/sleeper_player_api/intel/player_value.ex
+++ b/lib/sleeper_player_api/intel/player_value.ex
@@ -12,6 +12,12 @@ defmodule SleeperPlayerApi.Intel.PlayerValue do
     field :roster_percent, :float
     field :trade_frequency, :float
     field :as_of, :utc_datetime
+    # Season the player was drafted in (FantasyCalc's `maybeDraftInfo.year`).
+    # `nil` for a veteran or anyone the feed carries no draft info for — see
+    # the migration that added this column. Feeds the rookie-class filter
+    # (plan §3f step 5 / estimator §8), which is "rank within the ROOKIE
+    # CLASS", not the full player pool.
+    field :draft_year, :integer
 
     timestamps()
   end
@@ -27,7 +33,8 @@ defmodule SleeperPlayerApi.Intel.PlayerValue do
       :position_rank,
       :roster_percent,
       :trade_frequency,
-      :as_of
+      :as_of,
+      :draft_year
     ])
     |> validate_required([:player_id, :source])
     |> unique_constraint([:player_id, :source])

--- a/lib/sleeper_player_api/intel/player_value_source.ex
+++ b/lib/sleeper_player_api/intel/player_value_source.ex
@@ -1,0 +1,48 @@
+defmodule SleeperPlayerApi.Intel.PlayerValueSource do
+  @moduledoc """
+  The swappable player-value provider interface plan §2 calls for:
+
+  > "Build the value layer behind a `PlayerValueSource` interface so the
+  > source is one swappable module. Then this is a config change, not a
+  > rewrite, and you can decide about KTC later without it touching the
+  > model."
+
+  One behaviour, one implementation
+  (`SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalc`) — this is
+  deliberately not over-built (no registry, no multi-source merge). The
+  seam that matters is that `SleeperPlayerApi.Tasks.RefreshPlayerValues`
+  depends on this behaviour, not on `SleeperPlayerApi.Client.FantasyCalc`
+  directly, and the module it uses is one line of config
+  (`config :sleeper_player_api, :player_value_source, ...`) away from being
+  swapped for a KTC/DynastyProcess implementation later.
+  """
+
+  @typedoc """
+  One player's value, shaped exactly as `SleeperPlayerApi.Intel.upsert_player_values/1`
+  expects — `source` is this provider's own name (the `player_values.source`
+  discriminator column, plan §3a), and `draft_year` is the rookie-class
+  filter input (plan §3f step 5 / estimator §8), `nil` when the provider has
+  no draft-year data for that player at all.
+  """
+  @type value_entry :: %{
+          player_id: integer,
+          source: String.t(),
+          value: float | nil,
+          overall_rank: integer | nil,
+          position_rank: integer | nil,
+          roster_percent: float | nil,
+          trade_frequency: float | nil,
+          as_of: DateTime.t(),
+          draft_year: integer | nil
+        }
+
+  @doc "This provider's `player_values.source` value."
+  @callback name() :: String.t()
+
+  @doc """
+  Fetches every value this provider currently has. `{:error, reason}` on
+  any fetch/decode failure — callers (`RefreshPlayerValues`) do not partially
+  upsert a failed fetch.
+  """
+  @callback fetch_values() :: {:ok, [value_entry]} | {:error, term}
+end

--- a/lib/sleeper_player_api/intel/player_value_sources/fantasy_calc.ex
+++ b/lib/sleeper_player_api/intel/player_value_sources/fantasy_calc.ex
@@ -1,0 +1,80 @@
+defmodule SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalc do
+  @moduledoc """
+  The `SleeperPlayerApi.Intel.PlayerValueSource` implementation for
+  FantasyCalc (plan §2's recommended source — public, no auth,
+  `sleeperId`-keyed, carries roster % and trade frequency for free).
+
+  All the shaping lives here, not in the client: `SleeperPlayerApi.Client.FantasyCalc`
+  only knows how to make the one HTTP call and decode JSON, same split as
+  `Client.Sleeper` vs the modules that call it.
+  """
+
+  @behaviour SleeperPlayerApi.Intel.PlayerValueSource
+
+  alias SleeperPlayerApi.Client.FantasyCalc, as: Client
+
+  @source "fantasycalc"
+
+  @impl true
+  def name, do: @source
+
+  @impl true
+  def fetch_values do
+    case Client.get() do
+      {:ok, entries} when is_list(entries) ->
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+        {:ok, entries |> Enum.flat_map(&shape_entry(&1, now))}
+
+      {:ok, _not_a_list} ->
+        {:error, :unexpected_response_shape}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  # An entry with no `sleeperId` (or a non-numeric one) can't be joined to
+  # our player DB at all — plan §2's whole reason for preferring FantasyCalc
+  # over KTC is that it hands us `sleeperId` for free, so an entry without
+  # one is simply not usable here. `flat_map` with `[]`/`[entry]` drops it
+  # without failing the whole fetch over one bad row.
+  defp shape_entry(entry, now) do
+    player = entry["player"] || %{}
+
+    case parse_int(player["sleeperId"]) do
+      nil ->
+        []
+
+      player_id ->
+        [
+          %{
+            player_id: player_id,
+            source: @source,
+            value: to_float(entry["value"]),
+            overall_rank: entry["overallRank"],
+            position_rank: entry["positionRank"],
+            roster_percent: to_float(entry["maybeRosterPercent"]),
+            trade_frequency: to_float(entry["maybeTradeFrequency"]),
+            draft_year: get_in(player, ["maybeDraftInfo", "year"]),
+            as_of: now
+          }
+        ]
+    end
+  end
+
+  defp parse_int(nil), do: nil
+  defp parse_int(i) when is_integer(i), do: i
+
+  defp parse_int(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {i, ""} -> i
+      _ -> nil
+    end
+  end
+
+  defp parse_int(_), do: nil
+
+  defp to_float(nil), do: nil
+  defp to_float(n) when is_float(n), do: n
+  defp to_float(n) when is_integer(n), do: n * 1.0
+end

--- a/lib/sleeper_player_api/tasks/refresh_player_values.ex
+++ b/lib/sleeper_player_api/tasks/refresh_player_values.ex
@@ -1,0 +1,61 @@
+defmodule SleeperPlayerApi.Tasks.RefreshPlayerValues do
+  @moduledoc """
+  Fetches player values from a `SleeperPlayerApi.Intel.PlayerValueSource`
+  and upserts them into `player_values`, per plan §3f step 5.
+
+  Deliberately NOT wired into the Quantum schedule
+  (`config/config.exs`) — scheduling this is a production behaviour change
+  that needs separate sign-off. Invoke directly, same as
+  `SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts`:
+
+      SleeperPlayerApi.Tasks.RefreshPlayerValues.refresh_player_values()
+
+  Batched `Repo.insert_all`/`on_conflict` throughout (via
+  `SleeperPlayerApi.Intel.upsert_player_values/1`) — the one-shot fetch
+  makes this a single batch in practice (FantasyCalc's current payload is
+  under 500 entries), but it goes through the same batching path as every
+  other upsert in this codebase rather than a bespoke per-row loop, which is
+  the exact anti-pattern `GetSleeperPlayerData` has and the plan calls out
+  not to copy.
+  """
+
+  require Logger
+
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalc
+
+  @doc """
+  Fetches every value `source` currently has and upserts them.
+
+  `source` defaults to the configured `SleeperPlayerApi.Intel.PlayerValueSource`
+  implementation (`config :sleeper_player_api, :player_value_source`,
+  falling back to `PlayerValueSources.FantasyCalc`) — this default, not a
+  hardcoded module reference, is the swappable seam plan §2 asks for: making
+  KTC (or any other source) the default later is a one-line config change,
+  not a call-site change here.
+
+  Returns `{:ok, count}` (rows upserted) or `{:error, reason}` if the
+  source's fetch fails — nothing is upserted on a failed fetch, so a bad
+  fetch can't partially clobber a good prior refresh.
+  """
+  @spec refresh_player_values(module) :: {:ok, non_neg_integer} | {:error, term}
+  def refresh_player_values(source \\ source_module()) do
+    case source.fetch_values() do
+      {:ok, entries} ->
+        {count, _} = Intel.upsert_player_values(entries)
+        Logger.info("RefreshPlayerValues: stored #{count} values from #{source.name()}")
+        {:ok, count}
+
+      {:error, reason} = error ->
+        Logger.error(
+          "RefreshPlayerValues: fetch from #{inspect(source)} failed: #{inspect(reason)}"
+        )
+
+        error
+    end
+  end
+
+  defp source_module do
+    Application.get_env(:sleeper_player_api, :player_value_source, FantasyCalc)
+  end
+end

--- a/lib/sleeper_player_api_web/controllers/intel_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/intel_controller.ex
@@ -1,0 +1,19 @@
+defmodule SleeperPlayerApiWeb.IntelController do
+  use SleeperPlayerApiWeb, :controller
+
+  alias SleeperPlayerApi.Intel
+
+  action_fallback SleeperPlayerApiWeb.FallbackController
+
+  @doc """
+  `GET /api/v1/leagues/:league_id/intel?season=<n>`
+
+  See `SleeperPlayerApi.Intel.league_intel/2` for the full contract.
+  `season` is optional — omitting it reports on every stored draft for this
+  league regardless of season.
+  """
+  def show(conn, %{"league_id" => league_id} = params) do
+    intel = Intel.league_intel(league_id, season: params["season"])
+    render(conn, :show, intel: intel)
+  end
+end

--- a/lib/sleeper_player_api_web/controllers/intel_json.ex
+++ b/lib/sleeper_player_api_web/controllers/intel_json.ex
@@ -1,0 +1,45 @@
+defmodule SleeperPlayerApiWeb.IntelJSON do
+  @moduledoc """
+  Renders `SleeperPlayerApi.Intel.league_intel/2` into `/intel`'s response
+  shape (plan §3e) — camelCase keys, same split (snake_case context,
+  camelCase view) as `AvailabilityJSON`.
+  """
+
+  def show(%{intel: i}) do
+    %{
+      managers: Enum.map(i.managers, &manager/1),
+      corpus: %{
+        drafts: i.corpus.drafts,
+        picks: i.corpus.picks,
+        lastCrawledAt: i.corpus.last_crawled_at
+      }
+    }
+  end
+
+  defp manager(m) do
+    %{
+      userId: m.user_id,
+      displayName: m.display_name,
+      leaguesCount: m.leagues_count,
+      draftsCount: m.drafts_count,
+      draftsComplete: m.drafts_complete,
+      tendencies: tendencies(m.tendencies)
+    }
+  end
+
+  defp tendencies(t) do
+    %{
+      crushes: Enum.map(t.crushes, &crush/1),
+      positionLean: Enum.map(t.position_lean, &position_lean/1),
+      reachVsAdp: t.reach_vs_adp
+    }
+  end
+
+  defp crush(c) do
+    %{playerId: c.player_id, name: c.name, position: c.position, times: c.times, of: c.of}
+  end
+
+  defp position_lean(p) do
+    %{position: p.position, picks: p.picks, share: p.share}
+  end
+end

--- a/lib/sleeper_player_api_web/router.ex
+++ b/lib/sleeper_player_api_web/router.ex
@@ -21,6 +21,7 @@ defmodule SleeperPlayerApiWeb.Router do
     get "/players/active", PlayerController, :active
     get "/players/:id", PlayerController, :show
     get "/drafts/:draft_id/availability", AvailabilityController, :show
+    get "/leagues/:league_id/intel", IntelController, :show
   end
 
   scope "/api/legacy", SleeperPlayerApiWeb do

--- a/priv/repo/migrations/20260806130000_add_draft_year_to_player_values.exs
+++ b/priv/repo/migrations/20260806130000_add_draft_year_to_player_values.exs
@@ -1,0 +1,22 @@
+defmodule SleeperPlayerApi.Repo.Migrations.AddDraftYearToPlayerValues do
+  use Ecto.Migration
+
+  # Adds `draft_year` to `player_values` — plan §3f step 5's rookie-class
+  # filter (estimator §8: "rank within the ROOKIE CLASS by FantasyCalc
+  # `value`") needs to know which season a player was drafted in, and the
+  # originally migrated `player_values` columns (§3a) don't carry it.
+  #
+  # Sourced from FantasyCalc's `player.maybeDraftInfo.year`, which is `nil`
+  # for players the feed doesn't have draft info for at all (three of the
+  # fixture's targets — Justin Joly, Michael Trigg, J'Mari Taylor — verified
+  # in docs/leaguemate-intel-estimator.md §10 note 4). Nullable, no default:
+  # a row with no draft year simply never matches a rookie-class filter,
+  # which is correct for a veteran or an unclassified player.
+  def change do
+    alter table(:player_values) do
+      add :draft_year, :integer
+    end
+
+    create index(:player_values, [:source, :draft_year])
+  end
+end

--- a/test/clients/fantasy_calc_test.exs
+++ b/test/clients/fantasy_calc_test.exs
@@ -1,0 +1,68 @@
+defmodule SleeperPlayerApi.Client.FantasyCalcTest do
+  # Bypass owns a real port per test and this module points the client at it
+  # via a shared Application env key, same trick as `test/clients/sleeper_test.exs`
+  # — this suite can't run concurrently with itself or anything else that
+  # touches :fantasy_calc_base_url.
+  use ExUnit.Case, async: false
+
+  alias SleeperPlayerApi.Client.FantasyCalc
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :sleeper_player_api,
+      :fantasy_calc_base_url,
+      "http://localhost:#{bypass.port}"
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:sleeper_player_api, :fantasy_calc_base_url)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  describe "get/0 (non-raising, default URL)" do
+    test "hits /values/current with the plan's fixed query params and decodes the body", %{
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        assert conn.query_string == "isDynasty=true&numQbs=2&numTeams=12&ppr=1"
+        Plug.Conn.resp(conn, 200, ~s([{"value": 100}]))
+      end)
+
+      assert FantasyCalc.get() == {:ok, [%{"value" => 100}]}
+    end
+
+    test "returns a tagged error on 429, instead of raising", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        Plug.Conn.resp(conn, 429, "rate limited")
+      end)
+
+      assert FantasyCalc.get() == {:error, {:http_error, 429}}
+    end
+
+    test "returns a tagged error on a 5xx, instead of raising", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        Plug.Conn.resp(conn, 503, "service unavailable")
+      end)
+
+      assert FantasyCalc.get() == {:error, {:http_error, 503}}
+    end
+
+    test "returns a tagged error on a connection failure, instead of raising", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert {:error, {:transport_error, _reason}} = FantasyCalc.get()
+    end
+
+    test "returns a tagged error instead of raising on a non-JSON body", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        Plug.Conn.resp(conn, 200, "<html>not json</html>")
+      end)
+
+      assert FantasyCalc.get() == {:error, {:invalid_json, 200}}
+    end
+  end
+end

--- a/test/sleeper_player_api/intel/player_value_sources/fantasy_calc_test.exs
+++ b/test/sleeper_player_api/intel/player_value_sources/fantasy_calc_test.exs
@@ -1,0 +1,105 @@
+defmodule SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalcTest do
+  # Same Bypass-owns-a-port trick as `Client.FantasyCalcTest` — can't run
+  # concurrently with anything else touching :fantasy_calc_base_url.
+  use ExUnit.Case, async: false
+
+  alias SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalc
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :sleeper_player_api,
+      :fantasy_calc_base_url,
+      "http://localhost:#{bypass.port}"
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:sleeper_player_api, :fantasy_calc_base_url)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  defp entry(player_overrides, value \\ 5000) do
+    player =
+      Map.merge(
+        %{"name" => "Test Player", "sleeperId" => "9001", "position" => "WR"},
+        player_overrides
+      )
+
+    %{
+      "player" => player,
+      "value" => value,
+      "overallRank" => 10,
+      "positionRank" => 3,
+      "maybeRosterPercent" => 0.85,
+      "maybeTradeFrequency" => 0.01
+    }
+  end
+
+  test "name/0 is the player_values.source discriminator" do
+    assert FantasyCalc.name() == "fantasycalc"
+  end
+
+  describe "fetch_values/0" do
+    test "shapes a rookie entry (with maybeDraftInfo) into the value_entry contract", %{
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        payload = [
+          entry(
+            %{
+              "sleeperId" => "13353",
+              "maybeDraftInfo" => %{"year" => 2026, "round" => 3, "pick" => 7}
+            },
+            4200
+          )
+        ]
+
+        Plug.Conn.resp(conn, 200, Jason.encode!(payload))
+      end)
+
+      assert {:ok, [value]} = FantasyCalc.fetch_values()
+
+      assert value.player_id == 13353
+      assert value.source == "fantasycalc"
+      assert value.value == 4200.0
+      assert value.overall_rank == 10
+      assert value.position_rank == 3
+      assert value.roster_percent == 0.85
+      assert value.trade_frequency == 0.01
+      assert value.draft_year == 2026
+      assert %DateTime{} = value.as_of
+    end
+
+    test "an entry with no maybeDraftInfo gets draft_year: nil, not dropped", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        payload = [entry(%{"sleeperId" => "13400"})]
+        Plug.Conn.resp(conn, 200, Jason.encode!(payload))
+      end)
+
+      assert {:ok, [value]} = FantasyCalc.fetch_values()
+      assert value.player_id == 13400
+      assert value.draft_year == nil
+    end
+
+    test "an entry with no sleeperId at all is dropped, not crashed on", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        payload = [entry(%{"sleeperId" => nil}), entry(%{"sleeperId" => "13424"})]
+        Plug.Conn.resp(conn, 200, Jason.encode!(payload))
+      end)
+
+      assert {:ok, [value]} = FantasyCalc.fetch_values()
+      assert value.player_id == 13424
+    end
+
+    test "propagates a client-level error rather than swallowing it", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        Plug.Conn.resp(conn, 503, "boom")
+      end)
+
+      assert FantasyCalc.fetch_values() == {:error, {:http_error, 503}}
+    end
+  end
+end

--- a/test/sleeper_player_api/intel_test.exs
+++ b/test/sleeper_player_api/intel_test.exs
@@ -111,6 +111,134 @@ defmodule SleeperPlayerApi.IntelTest do
   end
 
   # ---------------------------------------------------------------------
+  # league_intel/2 (plan §3e / §3f step 5) — hand-built fixture, no corpus
+  # ---------------------------------------------------------------------
+
+  describe "league_intel/2" do
+    setup do
+      Intel.upsert_sleeper_users([
+        %{id: 100, display_name: "alice"},
+        %{id: 200, display_name: "bob"}
+      ])
+
+      seed_player!("P1", "WR")
+      seed_player!("P2", "RB")
+
+      # The home league (555), season 2026 — this is what `league_id`
+      # scopes "who's a manager" to.
+      Intel.upsert_observed_drafts([
+        %{id: 501, league_id: 555, season: "2026", status: "complete", teams: 12, rounds: 1}
+      ])
+
+      Intel.upsert_observed_picks(501, [
+        %{pick_no: 1, player_id: "P1", picked_by: 100},
+        %{pick_no: 2, player_id: "P2", picked_by: 200}
+      ])
+
+      # Alice's other leagues (777, 999-via-bob) — these must count toward
+      # her `leagues_count`/`drafts_count`/`reach_vs_adp` totals (not
+      # scoped to league 555) but must NOT make anyone a "manager of 555".
+      Intel.upsert_observed_drafts([
+        %{id: 502, league_id: 777, season: "2026", status: "complete", teams: 12, rounds: 1},
+        %{id: 503, league_id: 555, season: "2025", status: "complete", teams: 12, rounds: 1},
+        %{id: 504, league_id: 999, season: "2026", status: "complete", teams: 12, rounds: 1}
+      ])
+
+      Intel.upsert_observed_picks(502, [%{pick_no: 3, player_id: "P1", picked_by: 100}])
+      Intel.upsert_observed_picks(503, [%{pick_no: 5, player_id: "P1", picked_by: 100}])
+      Intel.upsert_observed_picks(504, [%{pick_no: 1, player_id: "P1", picked_by: 200}])
+
+      :ok
+    end
+
+    test "managers are scoped to league_id + season; per-manager counts are corpus-wide" do
+      %{managers: managers, corpus: corpus} = Intel.league_intel(555, season: "2026")
+
+      assert Enum.map(managers, & &1.user_id) == [100, 200]
+
+      alice = Enum.find(managers, &(&1.user_id == 100))
+      assert alice.display_name == "alice"
+      # drafts 501 (league 555), 502 (777), 503 (555, season 2025) — 2 distinct leagues.
+      assert alice.leagues_count == 2
+      assert alice.drafts_count == 3
+      assert alice.drafts_complete == 3
+
+      bob = Enum.find(managers, &(&1.user_id == 200))
+      # bob only appears in 501 (555) and 504 (999) — 2 leagues, 2 drafts.
+      assert bob.leagues_count == 2
+      assert bob.drafts_count == 2
+
+      assert corpus.drafts == 4
+      assert corpus.picks == 5
+    end
+
+    test "season filter changes who counts as a manager, without changing their stats" do
+      %{managers: managers_2025} = Intel.league_intel(555, season: "2025")
+      # Only draft 503 (season 2025) belongs to league 555 in that season,
+      # and only alice picked in it.
+      assert Enum.map(managers_2025, & &1.user_id) == [100]
+
+      alice_2025 = hd(managers_2025)
+      # Same corpus-wide totals regardless of which season made her a manager.
+      assert alice_2025.leagues_count == 2
+      assert alice_2025.drafts_count == 3
+    end
+
+    test "omitting season includes every stored season for this league_id" do
+      %{managers: managers} = Intel.league_intel(555, [])
+      assert Enum.map(managers, & &1.user_id) == [100, 200]
+    end
+
+    test "a league_id with nothing crawled yet returns an empty managers list, not an error" do
+      assert %{managers: [], corpus: %{drafts: 4}} = Intel.league_intel(424_242, season: "2026")
+    end
+
+    test "tendencies.crushes: alice's repeated P1 picks across every league she's in" do
+      %{managers: managers} = Intel.league_intel(555, season: "2026")
+      alice = Enum.find(managers, &(&1.user_id == 100))
+
+      assert [%{player_id: "P1", times: 3, of: 3}] = alice.tendencies.crushes
+    end
+
+    test "tendencies.position_lean: 100% of alice's picks are WR" do
+      %{managers: managers} = Intel.league_intel(555, season: "2026")
+      alice = Enum.find(managers, &(&1.user_id == 100))
+
+      assert alice.tendencies.position_lean == [%{position: "WR", picks: 3, share: 1.0}]
+    end
+
+    test "tendencies.reach_vs_adp: league ADP minus the manager's own ADP, n >= 2 only" do
+      %{managers: managers} = Intel.league_intel(555, season: "2026")
+      alice = Enum.find(managers, &(&1.user_id == 100))
+
+      # P1 corpus events: alice at norm 1.0 (501), 3.0 (502), 5.0 (503);
+      # bob at norm 1.0 (504). League ADP = (1+3+5+1)/4 = 2.5.
+      # Alice's own ADP for P1 = (1+3+5)/3 = 3.0.
+      # reach_vs_adp = 2.5 - 3.0 = -0.5 (she drafts P1 later than the
+      # corpus average — the sign convention this step chose: positive
+      # means "reaches earlier than average", negative means "lets him
+      # slide").
+      assert_in_delta alice.tendencies.reach_vs_adp, -0.5, 0.001
+    end
+
+    test "tendencies.reach_vs_adp is nil when no picked player clears the n >= 2 corpus threshold" do
+      Intel.upsert_sleeper_users([%{id: 300, display_name: "carol"}])
+      seed_player!("P3", "TE")
+
+      Intel.upsert_observed_drafts([
+        %{id: 505, league_id: 555, season: "2026", status: "complete", teams: 12, rounds: 1}
+      ])
+
+      Intel.upsert_observed_picks(505, [%{pick_no: 1, player_id: "P3", picked_by: 300}])
+
+      %{managers: managers} = Intel.league_intel(555, season: "2026")
+      carol = Enum.find(managers, &(&1.user_id == 300))
+
+      assert carol.tendencies.reach_vs_adp == nil
+    end
+  end
+
+  # ---------------------------------------------------------------------
   # Corpus round-trip — the point of this step
   # ---------------------------------------------------------------------
 
@@ -222,6 +350,33 @@ defmodule SleeperPlayerApi.IntelTest do
   defp sample_player_ids do
     # Names for these ids are in docs/leaguemate-intel.md §4a/§4e-bis.
     ["13306", "13319", "13353", "13347", "13434", "13287"]
+  end
+
+  defp seed_player!(player_id, position_abbr) do
+    position =
+      SleeperPlayerApi.Sleeper.get_position_by_abbreviation(position_abbr) ||
+        (
+          {:ok, position} =
+            SleeperPlayerApi.Sleeper.create_position(%{abbreviation: position_abbr})
+
+          position
+        )
+
+    %SleeperPlayerApi.Sleeper.Player{}
+    |> SleeperPlayerApi.Sleeper.Player.changeset(%{
+      id: String.to_integer(player_id |> String.replace_prefix("P", "9")),
+      player_id: player_id,
+      player_json: "{}",
+      active: true,
+      first_name: player_id,
+      last_name: position_abbr,
+      full_name: "#{player_id} #{position_abbr}",
+      search_first_name: String.downcase(player_id),
+      search_last_name: String.downcase(position_abbr),
+      search_full_name: String.downcase("#{player_id} #{position_abbr}"),
+      position_id: position.id
+    })
+    |> Repo.insert!()
   end
 
   defp seed_corpus_from_json! do

--- a/test/sleeper_player_api/tasks/refresh_player_values_test.exs
+++ b/test/sleeper_player_api/tasks/refresh_player_values_test.exs
@@ -1,0 +1,81 @@
+defmodule SleeperPlayerApi.Tasks.RefreshPlayerValuesTest do
+  # Bypass owns a real port and this module points the FantasyCalc client at
+  # it via :fantasy_calc_base_url, same trick as every other Bypass-backed
+  # suite in this repo — can't run concurrently with itself.
+  use SleeperPlayerApi.DataCase, async: false
+
+  alias SleeperPlayerApi.Tasks.RefreshPlayerValues
+  alias SleeperPlayerApi.Intel.PlayerValue
+
+  setup do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :sleeper_player_api,
+      :fantasy_calc_base_url,
+      "http://localhost:#{bypass.port}"
+    )
+
+    on_exit(fn ->
+      Application.delete_env(:sleeper_player_api, :fantasy_calc_base_url)
+    end)
+
+    {:ok, bypass: bypass}
+  end
+
+  defp entry(sleeper_id, value, draft_info \\ nil) do
+    player =
+      %{"name" => "Player #{sleeper_id}", "sleeperId" => sleeper_id, "position" => "WR"}
+      |> then(fn p -> if draft_info, do: Map.put(p, "maybeDraftInfo", draft_info), else: p end)
+
+    %{
+      "player" => player,
+      "value" => value,
+      "overallRank" => 1,
+      "positionRank" => 1,
+      "maybeRosterPercent" => 0.5,
+      "maybeTradeFrequency" => 0.02
+    }
+  end
+
+  test "fetches from FantasyCalc via Bypass and upserts into player_values (default source, not seeded)",
+       %{bypass: bypass} do
+    payload = [
+      entry("13353", 4200, %{"year" => 2026, "round" => 3, "pick" => 7}),
+      entry("4984", 10_000)
+    ]
+
+    Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(payload))
+    end)
+
+    assert {:ok, 2} = RefreshPlayerValues.refresh_player_values()
+
+    rows = Repo.all(PlayerValue) |> Enum.sort_by(& &1.player_id)
+    assert [%{player_id: 4984, draft_year: nil}, %{player_id: 13353, draft_year: 2026}] = rows
+    assert Enum.find(rows, &(&1.player_id == 13353)).value == 4200.0
+    assert Enum.find(rows, &(&1.player_id == 13353)).source == "fantasycalc"
+  end
+
+  test "a second run overwrites the same (player_id, source) row instead of duplicating", %{
+    bypass: bypass
+  } do
+    Bypass.expect(bypass, "GET", "/values/current", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!([entry("13353", 4200)]))
+    end)
+
+    assert {:ok, 1} = RefreshPlayerValues.refresh_player_values()
+    assert {:ok, 1} = RefreshPlayerValues.refresh_player_values()
+
+    assert [%{value: 4200.0}] = Repo.all(PlayerValue)
+  end
+
+  test "a fetch failure returns {:error, reason} and upserts nothing", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+      Plug.Conn.resp(conn, 503, "boom")
+    end)
+
+    assert {:error, {:http_error, 503}} = RefreshPlayerValues.refresh_player_values()
+    assert Repo.all(PlayerValue) == []
+  end
+end

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -146,6 +146,125 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
     end
   end
 
+  describe "GET /api/v1/drafts/:draft_id/availability — market values from FantasyCalc (§3f step 5)" do
+    @describetag :corpus
+
+    # This block is the "tests that bypass the crawler" regression guard for
+    # the value layer: `player_values` rows come from actually running
+    # `RefreshPlayerValues` against Bypass (the real fetch/shape/upsert
+    # path), not from a seeding helper poking rows straight into Postgres.
+    # A second, independent Bypass instance stands in for FantasyCalc —
+    # separate Application env key (`:fantasy_calc_base_url`) from the
+    # Sleeper one, so both can be stubbed in the same test.
+    setup %{bypass: bypass} do
+      seed_corpus_from_json!()
+      seed_target_players!()
+      stub_district_13(bypass)
+
+      fc_bypass = Bypass.open()
+
+      Application.put_env(
+        :sleeper_player_api,
+        :fantasy_calc_base_url,
+        "http://localhost:#{fc_bypass.port}"
+      )
+
+      on_exit(fn ->
+        Application.delete_env(:sleeper_player_api, :fantasy_calc_base_url)
+      end)
+
+      Bypass.expect_once(fc_bypass, "GET", "/values/current", fn conn ->
+        Plug.Conn.resp(conn, 200, File.read!(Path.join(@corpus_dir, "fc2.json")))
+      end)
+
+      assert {:ok, _count} = SleeperPlayerApi.Tasks.RefreshPlayerValues.refresh_player_values()
+
+      :ok
+    end
+
+    test "marketPick/adpGap reproduce all 16 fixture values exactly", %{conn: conn} do
+      fixture = read_json!("fixture.json")
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&limit=60"
+        )
+
+      body = json_response(conn, 200)
+      targets_by_id = Map.new(body["targets"], &{&1["id"], &1})
+
+      for expected <- fixture["targets"] do
+        actual = Map.fetch!(targets_by_id, expected["id"])
+
+        assert actual["marketPick"] == expected["marketPick"],
+               "marketPick mismatch for #{expected["name"]}"
+
+        assert actual["adpGap"] == expected["adpGap"],
+               "adpGap mismatch for #{expected["name"]}"
+      end
+    end
+
+    test "Joly/Trigg/Taylor (no maybeDraftInfo) still target with marketPick nil", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&limit=60"
+        )
+
+      body = json_response(conn, 200)
+      target_ids = MapSet.new(body["targets"], & &1["id"])
+
+      for id <- ["13400", "13401", "13348"] do
+        assert MapSet.member?(target_ids, id), "expected #{id} to still be a target"
+      end
+
+      by_id = Map.new(body["targets"], &{&1["id"], &1})
+      assert by_id["13400"]["marketPick"] == nil
+      assert by_id["13400"]["name"] == "Justin Joly"
+    end
+
+    test "a candidate absent from FantasyCalc entirely is excluded from targets", %{conn: conn} do
+      # Seed one more fantasy-position corpus player who has no FantasyCalc
+      # entry at all (not in fc2.json) — before this step it would have
+      # ranked into targets on raw ADP alone, same shape as the production
+      # "Kyle Dixon" case in the report for this step.
+      Intel.upsert_observed_drafts([%{id: 99_999, teams: 12, status: "complete"}])
+
+      Intel.upsert_observed_picks(99_999, [
+        %{pick_no: 1, player_id: "90001", picked_by: nil}
+      ])
+
+      %SleeperPlayerApi.Sleeper.Player{}
+      |> SleeperPlayerApi.Sleeper.Player.changeset(%{
+        id: 90_001,
+        player_id: "90001",
+        player_json: "{}",
+        active: true,
+        first_name: "No",
+        last_name: "Value",
+        full_name: "No Value",
+        search_first_name: "no",
+        search_last_name: "value",
+        search_full_name: "no value",
+        position_id:
+          (SleeperPlayerApi.Sleeper.get_position_by_abbreviation("WR") ||
+             elem(SleeperPlayerApi.Sleeper.create_position(%{abbreviation: "WR"}), 1)).id
+      })
+      |> Repo.insert!()
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&limit=60"
+        )
+
+      body = json_response(conn, 200)
+      target_ids = MapSet.new(body["targets"], & &1["id"])
+      refute MapSet.member?(target_ids, "90001")
+    end
+  end
+
   describe "GET /api/v1/drafts/:draft_id/availability — no crawled corpus at all" do
     # Reads `lmusers.json` (below) to seed leaguemate names, so it needs the
     # same `:corpus` gate as the acceptance-case block above.

--- a/test/sleeper_player_api_web/controllers/intel_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/intel_controller_test.exs
@@ -1,0 +1,62 @@
+defmodule SleeperPlayerApiWeb.IntelControllerTest do
+  use SleeperPlayerApiWeb.ConnCase, async: true
+
+  alias SleeperPlayerApi.Intel
+
+  setup %{conn: conn} do
+    Intel.upsert_sleeper_users([
+      %{id: 100, display_name: "alice"},
+      %{id: 200, display_name: "bob"}
+    ])
+
+    Intel.upsert_observed_drafts([
+      %{id: 601, league_id: 555, season: "2026", status: "complete", teams: 12, rounds: 1}
+    ])
+
+    Intel.upsert_observed_picks(601, [
+      %{pick_no: 1, player_id: "P1", picked_by: 100},
+      %{pick_no: 2, player_id: "P2", picked_by: 200}
+    ])
+
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "GET /api/v1/leagues/:league_id/intel" do
+    test "renders managers + corpus in the plan §3e camelCase shape", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/leagues/555/intel?season=2026")
+      body = json_response(conn, 200)
+
+      assert %{"managers" => managers, "corpus" => corpus} = body
+      assert Enum.map(managers, & &1["userId"]) == [100, 200]
+
+      alice = Enum.find(managers, &(&1["userId"] == 100))
+      assert alice["displayName"] == "alice"
+      assert is_integer(alice["leaguesCount"])
+      assert is_integer(alice["draftsCount"])
+      assert is_integer(alice["draftsComplete"])
+
+      assert %{"crushes" => crushes, "positionLean" => lean, "reachVsAdp" => _} =
+               alice["tendencies"]
+
+      assert is_list(crushes)
+      assert is_list(lean)
+
+      assert corpus["drafts"] == 1
+      assert corpus["picks"] == 2
+      assert Map.has_key?(corpus, "lastCrawledAt")
+    end
+
+    test "an uncrawled league returns an empty managers list, not a 500 or 404", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/leagues/999999999/intel?season=2026")
+      body = json_response(conn, 200)
+
+      assert body["managers"] == []
+      assert body["corpus"]["drafts"] == 1
+    end
+
+    test "season is optional — omitting it still returns 200", %{conn: conn} do
+      conn = get(conn, ~p"/api/v1/leagues/555/intel")
+      assert json_response(conn, 200)["managers"] |> length() == 2
+    end
+  end
+end


### PR DESCRIPTION
Plan §3f step 5. **Nothing is added to the Quantum schedule** — this task and
the crawler both stay invoke-directly until scheduling is agreed separately.

## What's here

| | |
| --- | --- |
| `Client.FantasyCalc` | HTTPoison.Base, tagged tuples, configurable base URL |
| `PlayerValueSource` | the §2 seam — swapping provider is a config change |
| `RefreshPlayerValues` | batched upsert into `player_values` |
| `marketPick` / `adpGap` | now populated on `/availability` |
| `GET /api/v1/leagues/:id/intel` | manager profiles + corpus summary |

133 tests, 0 failures.

## Two filters that look like one, and aren't

This is the part worth reviewing, because the wrong version is the intuitive
one and it fails silently:

- **`marketPick` ranks the rookie class** (`draft_year == season`), not the
  whole pool. Brazzell is rookie #31 but FantasyCalc overall #229 — ranking
  everything gives numbers that are internally consistent and completely
  wrong.
- **Target eligibility is the *whole* tracked universe**, regardless of
  `draft_year`. Joly, Trigg and Taylor are in FantasyCalc's payload with no
  `maybeDraftInfo`, so they carry `marketPick: null` but are still real
  targets. Filtering eligibility by `draft_year` drops all three silently.

Both are sabotage-verified: conflating them fails 2 tests.

## Fixes a real production problem

The eligibility filter resolves the thin-sample case from the last verify
run — "Kyle Dixon, WR, lgADP 34.0, sd 0.0, **n 1**" was outranking Kacmarek
and Nussmeier on ADP alone and reading 100% survival everywhere. He isn't in
FantasyCalc's universe, so he no longer qualifies. Confirmed against the
harvested payload.

With `player_values` empty the filter is **skipped** rather than intersected
against nothing, so an unrun refresh degrades to previous behaviour instead
of blanking the board. That's also why the 480-value acceptance test needed
zero edits.

## Verified through the real ingest path

Per the lesson from the last two production bugs, the 16/16 `marketPick`
check doesn't insert rows by hand — it stubs FantasyCalc on Bypass, runs
`RefreshPlayerValues.refresh_player_values()`, then asserts `/availability`
against that state.

## Notes

- Adds `draft_year` to `player_values`; §3a's column list didn't have it and
  the rookie-class filter needs it.
- `tendencies` includes crushes, positional lean, and reach-vs-ADP (over
  players seen ≥2 times, so one stray pick can't define "league ADP").
  Chalkiness and roster construction are left out — they need a model or a
  live rosters call.
- **Found, not fixed:** `draft_participants` (§3a) is schema-complete with a
  passing test but nothing populates it — `CrawlLeaguemateDrafts` never calls
  `upsert_draft_participants/2`. Worked around by deriving league managers
  from `observed_picks`, same as `drafts_corpus/2` already does.