### PR TITLE
Schedule the value refresh and leaguemate crawl

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -43,11 +43,45 @@ config :phoenix, :json_library, Jason
 # SleeperPlayerApi.RateLimiter for why.
 config :sleeper_player_api, SleeperPlayerApi.RateLimiter, calls_per_minute: 300
 
-# Quantum cron jobs
+# Leagues the leaguemate-intel crawler sweeps nightly (plan §3c). Not a
+# secret — Sleeper league ids are public, and this one is already in the
+# frontend's `src/urls.js`. One league today; making this per-user is the
+# larger "configurable Sleeper user" change, not this one.
+config :sleeper_player_api, :intel_leagues, [1_313_425_233_297_813_504]
+
+# Season to crawl. Unset on purpose: the crawler falls back to the current
+# calendar year, which is how Sleeper labels a season, so this rolls over
+# without a deploy. Set it to pin a specific season.
+# config :sleeper_player_api, :intel_season, "2026"
+
+# Quantum cron jobs. Times are UTC; Central is UTC-5.
+#
+# Ordering matters: the player dump runs first because the intel crawler
+# joins to `players` for name/position, and values land before the crawl so
+# a fresh corpus is ranked against fresh market data. All three are well
+# under a minute in practice (a warm crawl is ~22 API calls), but
+# `overlap: false` means a pathological run can't stack on itself.
 config :sleeper_player_api, SleeperPlayerApi.Scheduler,
   jobs: [
-    # Runs daily at 3am Central time:
-    {"0 8 * * *", {SleeperPlayerApi.Tasks.GetSleeperPlayerData, :get_sleeper_player_data, []}}
+    # 3:00am Central — the nightly Sleeper player dump.
+    {"0 8 * * *", {SleeperPlayerApi.Tasks.GetSleeperPlayerData, :get_sleeper_player_data, []}},
+
+    # 3:30am Central — refresh market values from FantasyCalc.
+    [
+      name: :refresh_player_values,
+      schedule: "30 8 * * *",
+      task: {SleeperPlayerApi.Tasks.RefreshPlayerValues, :refresh_player_values, []},
+      overlap: false
+    ],
+
+    # 4:00am Central — sweep leaguemate drafts. Completed drafts are
+    # immutable and never refetched, so a warm run is cheap.
+    [
+      name: :crawl_leaguemate_drafts,
+      schedule: "0 9 * * *",
+      task: {SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts, :crawl_configured_leagues, []},
+      overlap: false
+    ]
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_drafts.ex
@@ -31,9 +31,10 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts do
   here becomes a throttled wait on the *next* call rather than a hot retry
   loop on this one.
 
-  No Quantum wiring, no controllers — this task is meant to be invoked
-  directly (`CrawlLeaguemateDrafts.crawl(league_id, season)`) until later
-  plan steps wire it up.
+  Scheduled nightly at 4am Central via `crawl_configured_leagues/0` (see the
+  Quantum jobs in `config/config.exs`), which sweeps every league in
+  `config :sleeper_player_api, :intel_leagues`. `crawl/2` remains the
+  direct entry point for a one-off crawl of a specific league.
   """
 
   require Logger
@@ -66,6 +67,66 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts do
               picks_stored: 0,
               traded_picks_stored: 0,
               errors: []
+  end
+
+  @doc """
+  The scheduled entry point (see the Quantum job in `config/config.exs`).
+
+  Crawls every league in `config :sleeper_player_api, :intel_leagues` for
+  `:intel_season`, defaulting to the current calendar year — Sleeper labels
+  a season by the year its regular season starts, and rookie drafts happen
+  mid-year, so the calendar year is the right label for the whole window
+  this feature is used in.
+
+  Never raises and never propagates a failure: one league erroring must not
+  stop the others, and a scheduled job that crashes takes its Quantum
+  worker down with it. Every outcome is logged. Returns the list of
+  `{league_id, result}` pairs so a manual caller can still inspect them.
+
+  With no leagues configured this logs once and does nothing, which is the
+  correct behaviour for an install that hasn't been pointed at a league yet
+  rather than an error worth waking up to.
+  """
+  @spec crawl_configured_leagues() :: [{term, {:ok, Summary.t()} | {:error, term}}]
+  def crawl_configured_leagues do
+    leagues = Application.get_env(:sleeper_player_api, :intel_leagues, [])
+    season = configured_season()
+
+    if leagues == [] do
+      Logger.info("CrawlLeaguemateDrafts: no :intel_leagues configured, nothing to crawl")
+      []
+    else
+      Enum.map(leagues, fn league_id ->
+        result =
+          try do
+            crawl(league_id, season)
+          rescue
+            e ->
+              Logger.error(
+                "CrawlLeaguemateDrafts: league #{league_id} raised: #{Exception.message(e)}"
+              )
+
+              {:error, {:raised, Exception.message(e)}}
+          end
+
+        case result do
+          {:ok, _summary} ->
+            :ok
+
+          {:error, reason} ->
+            Logger.error("CrawlLeaguemateDrafts: league #{league_id}: #{inspect(reason)}")
+        end
+
+        {league_id, result}
+      end)
+    end
+  end
+
+  defp configured_season do
+    case Application.get_env(:sleeper_player_api, :intel_season) do
+      nil -> Date.utc_today().year |> Integer.to_string()
+      season -> to_string(season)
+    end
   end
 
   @doc """

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
@@ -296,6 +296,75 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDraftsTest do
     end
   end
 
+  describe "crawl_configured_leagues/0 — the scheduled entry point" do
+    setup do
+      on_exit(fn ->
+        Application.delete_env(:sleeper_player_api, :intel_leagues)
+        Application.delete_env(:sleeper_player_api, :intel_season)
+      end)
+
+      :ok
+    end
+
+    test "does nothing, quietly, when no leagues are configured" do
+      Application.put_env(:sleeper_player_api, :intel_leagues, [])
+      assert CrawlLeaguemateDrafts.crawl_configured_leagues() == []
+    end
+
+    test "defaults the season to the current calendar year", %{bypass: bypass} do
+      year = Date.utc_today().year |> Integer.to_string()
+      Application.put_env(:sleeper_player_api, :intel_leagues, [555])
+
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      # If the season were wrong this path would never be requested and
+      # Bypass would fail the test on an unrequested expectation.
+      expect_json(bypass, "/user/100/drafts/nfl/#{year}", [])
+
+      assert [{555, {:ok, _summary}}] = CrawlLeaguemateDrafts.crawl_configured_leagues()
+    end
+
+    test "an explicit :intel_season overrides the default", %{bypass: bypass} do
+      Application.put_env(:sleeper_player_api, :intel_leagues, [555])
+      Application.put_env(:sleeper_player_api, :intel_season, "2019")
+
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2019", [])
+
+      assert [{555, {:ok, _}}] = CrawlLeaguemateDrafts.crawl_configured_leagues()
+    end
+
+    test "one league failing doesn't stop the others", %{bypass: bypass} do
+      Application.put_env(:sleeper_player_api, :intel_leagues, [555, 666])
+      Application.put_env(:sleeper_player_api, :intel_season, "2026")
+
+      # 555 can't even be enumerated.
+      Bypass.expect(bypass, "GET", "/league/555/users", fn conn ->
+        Plug.Conn.resp(conn, 500, ~s({"error":"boom"}))
+      end)
+
+      expect_json(bypass, "/league/666/users", [
+        %{"user_id" => "200", "display_name" => "bob", "avatar" => "av2"}
+      ])
+
+      expect_json(bypass, "/user/200/drafts/nfl/2026", [draft("1001", "complete")])
+      expect_json(bypass, "/draft/1001/picks", [pick(1, "P1", "200")])
+
+      results = CrawlLeaguemateDrafts.crawl_configured_leagues()
+
+      assert [{555, {:error, _}}, {666, {:ok, summary}}] = results
+      assert summary.picks_stored == 1
+
+      # The healthy league's data really landed, despite the first one dying.
+      assert %ObservedDraft{} = Repo.get(ObservedDraft, 1001)
+    end
+  end
+
   describe "picks Sleeper can't attribute to a user" do
     # Regression: a live production crawl died on the first draft it hit.
     # Real Sleeper data uses `picked_by: ""` (not null) for an autopicked or


### PR DESCRIPTION
Both tasks were invoke-only. This wires them into the existing Quantum
scheduler.

| Time (Central) | Job | Change |
| --- | --- | --- |
| 3:00 | Sleeper player dump | unchanged |
| 3:30 | FantasyCalc value refresh | new |
| 4:00 | Leaguemate draft crawl | new |

Ordered so each has what it needs: the crawl joins to `players` for
name/position, and by 4:00 it's ranked against values refreshed half an hour
earlier.

## The crawl needed an entry point

A league id and season don't belong as literals in a cron MFA, so
`crawl_configured_leagues/0` reads `:intel_leagues` and `:intel_season`.
`crawl/2` is still the direct entry point for a one-off.

**The season is deliberately unset**, falling back to the current calendar
year — Sleeper labels a season by the year it starts, so this rolls over
without a deploy. Set `:intel_season` to pin one.

**The sweep never raises and never stops early.** One league failing must
not cost the others their nightly refresh, and an exception escaping a
Quantum job takes its worker down with it. Every outcome is logged; results
are returned so a manual caller can still inspect them.

`overlap: false` on both new jobs. A warm crawl is ~22 API calls and about a
second, so stacking isn't realistic, but the guard is free.

## Verified

Quantum registers all three jobs with the expected schedules and overlap
settings; the pre-existing player job is untouched.

137 tests, 0 failures. New tests cover the empty-config case, the calendar-year
default, an explicit season override, and one league 500ing without stopping
the next — sabotage-verified by making the sweep stop after the first league.

The league id isn't a secret: Sleeper league ids are public and this one is
already in the frontend's `src/urls.js`. Making it per-user is the larger
configurable-Sleeper-user change, not this one.