### PR TITLE
Populate draft_participants and complete /intel's manager list

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -1,9 +1,9 @@
 defmodule SleeperPlayerApi.Intel do
   @moduledoc """
   Context for the leaguemate-intel corpus: storing the Sleeper drafts/picks
-  harvested by the (not-yet-built, see `docs/leaguemate-intel.md` §3f steps
-  2-3) crawler, and shaping what's stored back out into the plain-map input
-  `SleeperPlayerApi.Intel.Estimator` expects.
+  harvested by `SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts` (see
+  `docs/leaguemate-intel.md` §3f steps 2-3), and shaping what's stored back
+  out into the plain-map input `SleeperPlayerApi.Intel.Estimator` expects.
 
   Two halves, per the plan's §3e "where the math runs":
 
@@ -27,6 +27,8 @@ defmodule SleeperPlayerApi.Intel do
   """
 
   import Ecto.Query, warn: false
+
+  require Logger
 
   alias SleeperPlayerApi.Repo
   alias SleeperPlayerApi.Client.Sleeper
@@ -95,19 +97,43 @@ defmodule SleeperPlayerApi.Intel do
 
   Keyed on `(draft_id, pick_no)`, so re-crawling an in-progress draft (the
   `status == "drafting"` refresh case from plan §3c) safely overwrites.
+
+  Also upserts `draft_participants` for this draft — every distinct non-nil
+  `picked_by` among the picks just stored (plan §3a's rationale for the
+  table: "avoids re-deriving participation from `observed_picks` every
+  query"). This is deliberately done *here*, as a side effect of storing
+  picks, rather than as a separate call `CrawlLeaguemateDrafts` has to
+  remember to make: every caller that stores picks (the crawl itself,
+  `refresh_draft/1`, and any test that seeds through this function rather
+  than a DB-seeding shortcut) gets participants for free and can never drift
+  from what `observed_picks` says, which is exactly the bug class flagged in
+  the report on this step. `upsert_draft_participants/2` is itself
+  conflict-safe, so re-storing the same picks (a `"drafting"` refresh) is a
+  no-op here too.
   """
   @spec upsert_observed_picks(integer, [map]) :: {non_neg_integer, nil}
   def upsert_observed_picks(draft_id, picks) do
-    picks
-    |> Enum.map(&Map.put(&1, :draft_id, draft_id))
-    |> then(
-      &insert_all_batched(
+    stamped = Enum.map(picks, &Map.put(&1, :draft_id, draft_id))
+
+    result =
+      insert_all_batched(
         ObservedPick,
-        &1,
+        stamped,
         conflict_target: [:draft_id, :pick_no],
         replace: [:round, :draft_slot, :roster_id, :player_id, :picked_by]
       )
-    )
+
+    participant_ids =
+      stamped
+      |> Enum.map(& &1[:picked_by])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+
+    unless participant_ids == [] do
+      upsert_draft_participants(draft_id, participant_ids)
+    end
+
+    result
   end
 
   @doc """
@@ -149,6 +175,38 @@ defmodule SleeperPlayerApi.Intel do
         on_conflict: :nothing
       )
     )
+  end
+
+  @doc """
+  Backfills `draft_participants` from every `draft_id`/non-nil-`picked_by`
+  pair already sitting in `observed_picks` — the one-time catch-up for
+  production, where `observed_picks` has ~3,400 rows and
+  `draft_participants` has zero, because nothing called
+  `upsert_draft_participants/2` before `upsert_observed_picks/2` started
+  doing it as a side effect (see that function's doc, and the report on this
+  step). Called from the `20260806140100_backfill_draft_participants.exs`
+  migration's `up/0`.
+
+  Idempotent — safe to run twice. Every row it writes goes through
+  `upsert_draft_participants/2`, which is itself `on_conflict: :nothing` on
+  `(draft_id, user_id)`, so a second run touches nothing and inserts no
+  duplicates.
+  """
+  @spec backfill_draft_participants() :: {non_neg_integer, nil}
+  def backfill_draft_participants do
+    from(p in ObservedPick,
+      where: not is_nil(p.picked_by),
+      distinct: true,
+      select: {p.draft_id, p.picked_by}
+    )
+    |> Repo.all()
+    |> Enum.group_by(fn {draft_id, _user_id} -> draft_id end, fn {_draft_id, user_id} ->
+      user_id
+    end)
+    |> Enum.reduce({0, nil}, fn {draft_id, user_ids}, {count, _} ->
+      {n, _} = upsert_draft_participants(draft_id, user_ids)
+      {count + n, nil}
+    end)
   end
 
   @doc """
@@ -397,17 +455,25 @@ defmodule SleeperPlayerApi.Intel do
   end
 
   @doc """
-  `%{picked_by => count of distinct drafts}` across every stored pick —
-  "how many drafts have we observed this manager in at all", the `seen_m`
-  input to the estimator's manager multiplier (§6). Managers with `nil`
-  `picked_by` (not a tracked leaguemate) are excluded.
+  `%{user_id => count of distinct drafts}` — "how many drafts have we
+  observed this manager in at all", the `seen_m` input to the estimator's
+  manager multiplier (§6).
+
+  Reads `draft_participants` rather than `GROUP BY`-ing `observed_picks`
+  directly — the exact point of that table per plan §3a ("avoids re-deriving
+  participation from `observed_picks` every query"). `Intel.upsert_observed_picks/2`
+  keeps it populated as a side effect of storing picks, so this is
+  equivalent to the old direct-from-`observed_picks` query, just without
+  re-scanning every pick row on every call. `user_id` here is *any* Sleeper
+  user id observed picking, tracked leaguemate or not — same scope the old
+  query had (`not is_nil(picked_by)`, no filter on `sleeper_users`
+  membership).
   """
   @spec manager_drafts_seen() :: %{integer => non_neg_integer}
   def manager_drafts_seen do
-    from(p in ObservedPick,
-      where: not is_nil(p.picked_by),
-      group_by: p.picked_by,
-      select: {p.picked_by, count(p.draft_id, :distinct)}
+    from(dp in DraftParticipant,
+      group_by: dp.user_id,
+      select: {dp.user_id, count(dp.draft_id, :distinct)}
     )
     |> Repo.all()
     |> Map.new()
@@ -811,23 +877,48 @@ defmodule SleeperPlayerApi.Intel do
 
       %{managers: [%{user_id, display_name, leagues_count, drafts_count,
                       drafts_complete, tendencies}],
-        corpus: %{drafts, picks, last_crawled_at}}
+        corpus: %{drafts, picks, last_crawled_at, membership_source}}
 
   ## Who counts as a "manager" of this league?
 
-  Every leaguemate who has actually made a pick in one of *this* league's
-  own stored drafts — `observed_drafts.league_id == league_id`, optionally
-  narrowed further to `opts[:season]`. Derived straight from `observed_picks`
-  (a `GROUP BY`-shaped query), **not** the `draft_participants` join table
-  plan §3a describes: that table exists in the schema (`upsert_draft_participants/2`)
-  but nothing populates it yet — `CrawlLeaguemateDrafts` never calls it (see
-  the report on this step). Wiring that up is a `CrawlLeaguemateDrafts`
-  change, out of this step's scope; deriving participation from picks
-  instead is the same approach `drafts_corpus/2` already takes and needs no
-  schema change to ship.
+  Every member of the *live* Sleeper league, via `GET /league/:id/users` —
+  the same call `CrawlLeaguemateDrafts` already makes, and the same
+  request-scoped live-fetch pattern `fetch_roster_owners/1` uses for
+  `/availability`. This is deliberately **not** derived from
+  `observed_picks` or `draft_participants`: both only know about managers
+  who have actually picked in an *observed* draft, so a leaguemate sitting
+  out this year's rookie draft (0 drafts seen) would silently vanish from
+  the list entirely — exactly backwards from what the frontend needs. Plan
+  §3 Frontend is explicit that a 0-draft manager must still render, as
+  "league average · none of their drafts seen", not disappear. See the
+  report on this step for the two production leaguemates this fixes.
 
-  If this league's own draft(s) haven't been crawled yet, `managers` comes
-  back `[]` — an honest "nothing crawled for this league", not an error.
+  `draft_participants` (now populated, see `Intel.upsert_observed_picks/2`)
+  does NOT fix this on its own — it records draft *participation*, and a
+  leaguemate who has never drafted appears in no participation table
+  either. League *membership* is a different fact than participation, and
+  `GET /league/:id/users` is its only authoritative source.
+
+  A member's `display_name` comes from the live response itself (falling
+  back to the stored `sleeper_users` row if Sleeper ever returns one with a
+  blank name); nothing here writes back to `sleeper_users` — that table's
+  writer stays `CrawlLeaguemateDrafts.store_users/1`, keeping "who crawls
+  writes it" a single rule.
+
+  **Failure behaviour.** If the live call fails (Sleeper down, bad
+  `league_id`, rate limited), this falls back to the old derived set —
+  every user_id with at least one observed pick in one of this league's own
+  stored drafts, via `manager_ids_for_league/2` — rather than failing the
+  whole request: `/intel` is a browse view, not a survival number, so a
+  degraded-but-present response is more useful than a 5xx. That degradation
+  is never silent, though: it's logged, and `corpus.membership_source` in
+  the response is `"live"` or `"derived"` so a caller (or a future UI badge)
+  can tell a complete membership list from a possibly-incomplete one rather
+  than the response looking equally authoritative either way.
+
+  If neither the live call nor any stored draft exists for this league,
+  `managers` comes back `[]` — an honest "nothing known about this league",
+  not an error.
 
   ## `leagues_count` / `drafts_count` / `drafts_complete`
 
@@ -866,18 +957,18 @@ defmodule SleeperPlayerApi.Intel do
   def league_intel(league_id, opts \\ []) do
     league_id = to_int(league_id)
     season = opts[:season]
-
     names = manager_names_by_id()
 
+    {member_pairs, membership_source} = league_membership(league_id, season, names)
+
     managers =
-      league_id
-      |> manager_ids_for_league(season)
-      |> Enum.map(fn user_id ->
+      member_pairs
+      |> Enum.map(fn {user_id, display_name} ->
         stats = manager_corpus_stats(user_id)
 
         %{
           user_id: user_id,
-          display_name: Map.get(names, user_id),
+          display_name: display_name,
           leagues_count: stats.leagues_count,
           drafts_count: stats.drafts_count,
           drafts_complete: stats.drafts_complete,
@@ -886,30 +977,96 @@ defmodule SleeperPlayerApi.Intel do
       end)
       |> Enum.sort_by(&(&1.display_name || ""))
 
-    %{managers: managers, corpus: corpus_summary()}
+    %{
+      managers: managers,
+      corpus: Map.put(corpus_summary(), :membership_source, membership_source)
+    }
   end
 
+  # `{[{user_id, display_name}], :live | :derived}` — see `league_intel/2`'s
+  # "Failure behaviour" doc for why the fallback exists and why it's not
+  # silent.
+  defp league_membership(league_id, season, names) do
+    case fetch_league_members(league_id) do
+      {:ok, members} ->
+        pairs =
+          Enum.map(members, fn m -> {m.user_id, m.display_name || Map.get(names, m.user_id)} end)
+
+        {pairs, :live}
+
+      {:error, reason} ->
+        Logger.warning(
+          "Intel.league_intel: live GET /league/#{league_id}/users failed (#{inspect(reason)}); " <>
+            "falling back to observed_picks-derived membership"
+        )
+
+        pairs =
+          league_id
+          |> manager_ids_for_league(season)
+          |> Enum.map(fn user_id -> {user_id, Map.get(names, user_id)} end)
+
+        {pairs, :derived}
+    end
+  end
+
+  @doc """
+  Live league membership via `GET /league/:id/users` — the authoritative
+  source for "who is in this league" (see `league_intel/2`'s moduledoc
+  section on why `observed_picks`/`draft_participants` can't answer this).
+  Deliberately not persisted anywhere here; see that same doc.
+  """
+  @spec fetch_league_members(integer | String.t()) ::
+          {:ok, [%{user_id: integer, display_name: String.t() | nil}]} | {:error, term}
+  def fetch_league_members(league_id) do
+    case Sleeper.get("/league/#{league_id}/users") do
+      {:ok, users} ->
+        members =
+          Enum.map(users, fn u ->
+            %{user_id: to_int(u["user_id"]), display_name: u["display_name"]}
+          end)
+
+        {:ok, members}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # The pre-Gap-2 derivation, kept only as the fallback `league_membership/3`
+  # reaches for when the live call fails: every user_id with at least one
+  # observed pick in one of this league's own stored drafts, optionally
+  # narrowed to `season`. This is participation, not membership — it will
+  # never surface a 0-draft manager, which is the exact gap the live call
+  # exists to close. Reads `draft_participants` rather than `GROUP BY`-ing
+  # `observed_picks` directly, same reasoning as `manager_drafts_seen/0`.
   defp manager_ids_for_league(league_id, season) do
     base =
-      from(p in ObservedPick,
+      from(dp in DraftParticipant,
         join: d in ObservedDraft,
-        on: d.id == p.draft_id,
-        where: d.league_id == ^league_id and not is_nil(p.picked_by)
+        on: d.id == dp.draft_id,
+        where: d.league_id == ^league_id
       )
 
-    query = if season, do: from([p, d] in base, where: d.season == ^season), else: base
+    query = if season, do: from([dp, d] in base, where: d.season == ^season), else: base
 
     query
     |> distinct(true)
-    |> select([p, _d], p.picked_by)
+    |> select([dp, _d], dp.user_id)
     |> Repo.all()
   end
 
+  # Corpus-wide totals for one manager — NOT scoped to any one league (see
+  # `league_intel/2`'s doc on `leagues_count`/`drafts_count`/`drafts_complete`).
+  # Reads `draft_participants` rather than `GROUP BY`-ing `observed_picks`
+  # directly, per plan §3a's rationale for the table; a user_id with no
+  # participation rows at all (a live-membership manager with 0 observed
+  # drafts, Gap 2's whole point) correctly comes back all zeros rather than
+  # `nil`, since `count(...)` over an empty match set is `0` in Postgres.
   defp manager_corpus_stats(user_id) do
-    from(p in ObservedPick,
+    from(dp in DraftParticipant,
       join: d in ObservedDraft,
-      on: d.id == p.draft_id,
-      where: p.picked_by == ^user_id,
+      on: d.id == dp.draft_id,
+      where: dp.user_id == ^user_id,
       select: %{
         leagues_count: count(d.league_id, :distinct),
         drafts_count: count(d.id, :distinct),

--- a/lib/sleeper_player_api/intel/draft_participant.ex
+++ b/lib/sleeper_player_api/intel/draft_participant.ex
@@ -1,13 +1,25 @@
 defmodule SleeperPlayerApi.Intel.DraftParticipant do
+  @moduledoc """
+  `(draft_id, user_id)` participation join row — every distinct non-nil
+  `picked_by` observed on a draft's picks (see `Intel.upsert_observed_picks/2`,
+  which populates this table as a side effect of storing picks).
+
+  `user_id` deliberately has no DB-level foreign key to `sleeper_users`
+  (see `20260806140000_drop_draft_participants_user_fk.exs`): a draft pulled
+  in via a leaguemate's *other* league is full of co-managers `sleeper_users`
+  has never heard of (it's only ever populated from `GET /league/:id/users`
+  for the league being crawled), and participation must count all of them —
+  same scope `observed_picks.picked_by` already has, no FK either.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias SleeperPlayerApi.Intel.{ObservedDraft, SleeperUser}
+  alias SleeperPlayerApi.Intel.ObservedDraft
 
   @primary_key false
   schema "draft_participants" do
     belongs_to :draft, ObservedDraft, references: :id
-    belongs_to :user, SleeperUser, references: :id
+    field :user_id, :integer
 
     timestamps()
   end

--- a/lib/sleeper_player_api_web/controllers/intel_json.ex
+++ b/lib/sleeper_player_api_web/controllers/intel_json.ex
@@ -3,6 +3,12 @@ defmodule SleeperPlayerApiWeb.IntelJSON do
   Renders `SleeperPlayerApi.Intel.league_intel/2` into `/intel`'s response
   shape (plan §3e) — camelCase keys, same split (snake_case context,
   camelCase view) as `AvailabilityJSON`.
+
+  `corpus.membershipSource` is `"live"` when `managers` came from a live
+  `GET /league/:id/users` call (the normal case) or `"derived"` when that
+  call failed and the list fell back to observed-participation only — see
+  `Intel.league_intel/2`'s "Failure behaviour" doc. A `"derived"` list may
+  be missing 0-draft members.
   """
 
   def show(%{intel: i}) do
@@ -11,7 +17,8 @@ defmodule SleeperPlayerApiWeb.IntelJSON do
       corpus: %{
         drafts: i.corpus.drafts,
         picks: i.corpus.picks,
-        lastCrawledAt: i.corpus.last_crawled_at
+        lastCrawledAt: i.corpus.last_crawled_at,
+        membershipSource: i.corpus.membership_source
       }
     }
   end

--- a/priv/repo/migrations/20260806140000_drop_draft_participants_user_fk.exs
+++ b/priv/repo/migrations/20260806140000_drop_draft_participants_user_fk.exs
@@ -1,0 +1,31 @@
+defmodule SleeperPlayerApi.Repo.Migrations.DropDraftParticipantsUserFk do
+  @moduledoc """
+  `draft_participants.user_id` was created with a foreign key to
+  `sleeper_users(id)` (see `20260805215408_create_draft_participants.exs`),
+  which was fine as long as nothing populated the table. Now that
+  `CrawlLeaguemateDrafts` derives participants from every stored pick's
+  `picked_by` (see `Intel.upsert_observed_picks/2`), that assumption breaks:
+  `sleeper_users` only holds the ~13 leaguemates of *this* league (from
+  `GET /league/:id/users`), but a leaguemate's *other* leagues' drafts are
+  full of co-managers Sleeper never told us about via that call.
+  `observed_picks.picked_by` already has no such constraint for exactly this
+  reason — see its migration — and `draft_participants` needs to mirror that
+  same "any observed Sleeper user id, tracked or not" scope, since
+  `manager_drafts_seen/0` (and everything the plan's §4d shrinkage math
+  reads from it) has always counted every observed `picked_by`, not just
+  known leaguemates.
+  """
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER TABLE draft_participants DROP CONSTRAINT draft_participants_user_id_fkey"
+  end
+
+  def down do
+    execute """
+    ALTER TABLE draft_participants
+    ADD CONSTRAINT draft_participants_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES sleeper_users(id) ON DELETE CASCADE
+    """
+  end
+end

--- a/priv/repo/migrations/20260806140100_backfill_draft_participants.exs
+++ b/priv/repo/migrations/20260806140100_backfill_draft_participants.exs
@@ -1,0 +1,28 @@
+defmodule SleeperPlayerApi.Repo.Migrations.BackfillDraftParticipants do
+  @moduledoc """
+  Production has ~3,400 `observed_picks` rows and an empty
+  `draft_participants` table — nothing called `upsert_draft_participants/2`
+  before this branch (see the report on this step). Once the participation
+  queries (`Intel.manager_drafts_seen/0`, `Intel.manager_ids_for_league/2`,
+  `Intel.manager_corpus_stats/1`) switch onto `draft_participants` instead of
+  re-deriving from `observed_picks`, an unbackfilled table means every
+  manager reads 0 drafts seen — silently zeroing the shrinkage weights and
+  corrupting every survival number. This is mandatory, not optional.
+
+  Delegates to `SleeperPlayerApi.Intel.backfill_draft_participants/0` rather
+  than duplicating the derivation as raw SQL here, so there is exactly one
+  place that knows how to turn `observed_picks` into participation rows.
+  That function is itself idempotent (`upsert_draft_participants/2` is
+  `on_conflict: :nothing` on `(draft_id, user_id)`), so this migration is
+  safe to re-run if it's ever replayed.
+  """
+  use Ecto.Migration
+
+  def up do
+    SleeperPlayerApi.Intel.backfill_draft_participants()
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/test/sleeper_player_api/intel_test.exs
+++ b/test/sleeper_player_api/intel_test.exs
@@ -1,5 +1,11 @@
 defmodule SleeperPlayerApi.IntelTest do
-  use SleeperPlayerApi.DataCase, async: true
+  # `league_intel/2` now makes a live `GET /league/:id/users` call (Gap 2 —
+  # see its moduledoc), so the `describe "league_intel/2"` block below points
+  # the Sleeper client at a Bypass server via the shared `:sleeper_base_url`
+  # Application env key (same trick as `CrawlLeaguemateDraftsTest`), which
+  # means this whole module can't run concurrently with itself or with
+  # anything else that touches that key.
+  use SleeperPlayerApi.DataCase, async: false
 
   alias SleeperPlayerApi.Intel
   alias SleeperPlayerApi.IntelCorpus
@@ -111,11 +117,71 @@ defmodule SleeperPlayerApi.IntelTest do
   end
 
   # ---------------------------------------------------------------------
+  # backfill_draft_participants/0 — the mandatory production catch-up
+  # ---------------------------------------------------------------------
+
+  describe "backfill_draft_participants/0" do
+    test "derives participant rows from observed_picks and is safe to run twice" do
+      Intel.upsert_observed_drafts([
+        %{id: 701, teams: 12, status: "complete"},
+        %{id: 702, teams: 12, status: "complete"}
+      ])
+
+      Intel.upsert_observed_picks(701, [
+        %{pick_no: 1, player_id: "P1", picked_by: 10},
+        %{pick_no: 2, player_id: "P2", picked_by: 11},
+        %{pick_no: 3, player_id: "P3", picked_by: 10}
+      ])
+
+      Intel.upsert_observed_picks(702, [
+        %{pick_no: 1, player_id: "P1", picked_by: 11},
+        %{pick_no: 2, player_id: "P2", picked_by: nil}
+      ])
+
+      # Simulate the exact production gap this backfills: observed_picks
+      # populated, draft_participants empty. `upsert_observed_picks/2`
+      # normally keeps the two in sync as it writes (see its doc) — but
+      # production accumulated its ~3,400 picks before that existed, so
+      # this wipes the table back to that pre-fix state before backfilling.
+      Repo.delete_all(SleeperPlayerApi.Intel.DraftParticipant)
+
+      assert Intel.backfill_draft_participants() == {3, nil}
+
+      rows_query =
+        from(dp in SleeperPlayerApi.Intel.DraftParticipant,
+          order_by: [dp.draft_id, dp.user_id],
+          select: {dp.draft_id, dp.user_id}
+        )
+
+      assert Repo.all(rows_query) == [{701, 10}, {701, 11}, {702, 11}]
+
+      # Idempotent: running again inserts nothing new and changes nothing.
+      assert Intel.backfill_draft_participants() == {0, nil}
+      assert Repo.all(rows_query) == [{701, 10}, {701, 11}, {702, 11}]
+    end
+  end
+
+  # ---------------------------------------------------------------------
   # league_intel/2 (plan §3e / §3f step 5) — hand-built fixture, no corpus
   # ---------------------------------------------------------------------
 
   describe "league_intel/2" do
+    # Gap 2: `league_intel/2` now derives "who's a manager" from a live
+    # `GET /league/:id/users` call, not from `observed_picks`/
+    # `draft_participants` — see the moduledoc on `Intel.league_intel/2` for
+    # why. So this block needs a Bypass server the way
+    # `CrawlLeaguemateDraftsTest` does.
     setup do
+      bypass = Bypass.open()
+
+      Application.put_env(
+        :sleeper_player_api,
+        :sleeper_base_url,
+        "http://localhost:#{bypass.port}"
+      )
+
+      on_exit(fn -> Application.delete_env(:sleeper_player_api, :sleeper_base_url) end)
+
       Intel.upsert_sleeper_users([
         %{id: 100, display_name: "alice"},
         %{id: 200, display_name: "bob"}
@@ -124,8 +190,8 @@ defmodule SleeperPlayerApi.IntelTest do
       seed_player!("P1", "WR")
       seed_player!("P2", "RB")
 
-      # The home league (555), season 2026 — this is what `league_id`
-      # scopes "who's a manager" to.
+      # The home league (555), season 2026 — the league every test below
+      # analyzes.
       Intel.upsert_observed_drafts([
         %{id: 501, league_id: 555, season: "2026", status: "complete", teams: 12, rounds: 1}
       ])
@@ -137,7 +203,7 @@ defmodule SleeperPlayerApi.IntelTest do
 
       # Alice's other leagues (777, 999-via-bob) — these must count toward
       # her `leagues_count`/`drafts_count`/`reach_vs_adp` totals (not
-      # scoped to league 555) but must NOT make anyone a "manager of 555".
+      # scoped to league 555).
       Intel.upsert_observed_drafts([
         %{id: 502, league_id: 777, season: "2026", status: "complete", teams: 12, rounds: 1},
         %{id: 503, league_id: 555, season: "2025", status: "complete", teams: 12, rounds: 1},
@@ -148,13 +214,32 @@ defmodule SleeperPlayerApi.IntelTest do
       Intel.upsert_observed_picks(503, [%{pick_no: 5, player_id: "P1", picked_by: 100}])
       Intel.upsert_observed_picks(504, [%{pick_no: 1, player_id: "P1", picked_by: 200}])
 
-      :ok
+      {:ok, bypass: bypass}
     end
 
-    test "managers are scoped to league_id + season; per-manager counts are corpus-wide" do
+    defp stub_league_users(bypass, league_id, users) do
+      Bypass.stub(bypass, "GET", "/league/#{league_id}/users", fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!(users))
+      end)
+    end
+
+    defp fail_league_users(bypass, league_id) do
+      Bypass.stub(bypass, "GET", "/league/#{league_id}/users", fn conn ->
+        Plug.Conn.resp(conn, 500, "boom")
+      end)
+    end
+
+    test "managers come from the live /league/:id/users call; per-manager counts are corpus-wide",
+         %{bypass: bypass} do
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"}
+      ])
+
       %{managers: managers, corpus: corpus} = Intel.league_intel(555, season: "2026")
 
       assert Enum.map(managers, & &1.user_id) == [100, 200]
+      assert corpus.membership_source == :live
 
       alice = Enum.find(managers, &(&1.user_id == 100))
       assert alice.display_name == "alice"
@@ -172,10 +257,43 @@ defmodule SleeperPlayerApi.IntelTest do
       assert corpus.picks == 5
     end
 
-    test "season filter changes who counts as a manager, without changing their stats" do
-      %{managers: managers_2025} = Intel.league_intel(555, season: "2025")
+    test "a live league member with zero observed drafts appears with honest zeros, not absent",
+         %{bypass: bypass} do
+      # carol is a real league member Sleeper reports, but has never
+      # appeared in any stored draft — the exact case §3 Frontend needs
+      # ("league average · none of their drafts seen") and that deriving
+      # membership from observed_picks/draft_participants could never show.
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"},
+        %{"user_id" => "300", "display_name" => "carol"}
+      ])
+
+      %{managers: managers, corpus: corpus} = Intel.league_intel(555, season: "2026")
+
+      assert Enum.map(managers, & &1.user_id) == [100, 200, 300]
+      assert corpus.membership_source == :live
+
+      carol = Enum.find(managers, &(&1.user_id == 300))
+      assert carol.display_name == "carol"
+      assert carol.leagues_count == 0
+      assert carol.drafts_count == 0
+      assert carol.drafts_complete == 0
+      assert carol.tendencies.crushes == []
+      assert carol.tendencies.position_lean == []
+      assert carol.tendencies.reach_vs_adp == nil
+    end
+
+    test "when the live call fails, falls back to observed-participation-derived membership, honestly flagged",
+         %{bypass: bypass} do
+      fail_league_users(bypass, 555)
+
+      %{managers: managers_2025, corpus: corpus} = Intel.league_intel(555, season: "2025")
+
+      assert corpus.membership_source == :derived
       # Only draft 503 (season 2025) belongs to league 555 in that season,
-      # and only alice picked in it.
+      # and only alice picked in it — the derived fallback's season filter
+      # (the live path ignores `season` entirely, see the moduledoc).
       assert Enum.map(managers_2025, & &1.user_id) == [100]
 
       alice_2025 = hd(managers_2025)
@@ -184,30 +302,54 @@ defmodule SleeperPlayerApi.IntelTest do
       assert alice_2025.drafts_count == 3
     end
 
-    test "omitting season includes every stored season for this league_id" do
+    test "derived fallback: omitting season includes every stored season for this league_id",
+         %{bypass: bypass} do
+      fail_league_users(bypass, 555)
+
       %{managers: managers} = Intel.league_intel(555, [])
       assert Enum.map(managers, & &1.user_id) == [100, 200]
     end
 
-    test "a league_id with nothing crawled yet returns an empty managers list, not an error" do
-      assert %{managers: [], corpus: %{drafts: 4}} = Intel.league_intel(424_242, season: "2026")
+    test "an unknown league_id whose live call also fails returns an empty managers list, not an error",
+         %{bypass: bypass} do
+      fail_league_users(bypass, 424_242)
+
+      assert %{managers: [], corpus: %{drafts: 4, membership_source: :derived}} =
+               Intel.league_intel(424_242, season: "2026")
     end
 
-    test "tendencies.crushes: alice's repeated P1 picks across every league she's in" do
+    test "tendencies.crushes: alice's repeated P1 picks across every league she's in",
+         %{bypass: bypass} do
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"}
+      ])
+
       %{managers: managers} = Intel.league_intel(555, season: "2026")
       alice = Enum.find(managers, &(&1.user_id == 100))
 
       assert [%{player_id: "P1", times: 3, of: 3}] = alice.tendencies.crushes
     end
 
-    test "tendencies.position_lean: 100% of alice's picks are WR" do
+    test "tendencies.position_lean: 100% of alice's picks are WR", %{bypass: bypass} do
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"}
+      ])
+
       %{managers: managers} = Intel.league_intel(555, season: "2026")
       alice = Enum.find(managers, &(&1.user_id == 100))
 
       assert alice.tendencies.position_lean == [%{position: "WR", picks: 3, share: 1.0}]
     end
 
-    test "tendencies.reach_vs_adp: league ADP minus the manager's own ADP, n >= 2 only" do
+    test "tendencies.reach_vs_adp: league ADP minus the manager's own ADP, n >= 2 only",
+         %{bypass: bypass} do
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"}
+      ])
+
       %{managers: managers} = Intel.league_intel(555, season: "2026")
       alice = Enum.find(managers, &(&1.user_id == 100))
 
@@ -221,7 +363,8 @@ defmodule SleeperPlayerApi.IntelTest do
       assert_in_delta alice.tendencies.reach_vs_adp, -0.5, 0.001
     end
 
-    test "tendencies.reach_vs_adp is nil when no picked player clears the n >= 2 corpus threshold" do
+    test "tendencies.reach_vs_adp is nil when no picked player clears the n >= 2 corpus threshold",
+         %{bypass: bypass} do
       Intel.upsert_sleeper_users([%{id: 300, display_name: "carol"}])
       seed_player!("P3", "TE")
 
@@ -230,6 +373,12 @@ defmodule SleeperPlayerApi.IntelTest do
       ])
 
       Intel.upsert_observed_picks(505, [%{pick_no: 1, player_id: "P3", picked_by: 300}])
+
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"},
+        %{"user_id" => "300", "display_name" => "carol"}
+      ])
 
       %{managers: managers} = Intel.league_intel(555, season: "2026")
       carol = Enum.find(managers, &(&1.user_id == 300))

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_drafts_test.exs
@@ -5,8 +5,16 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDraftsTest do
   # with itself or with anything else that touches that key.
   use SleeperPlayerApi.DataCase, async: false
 
+  alias SleeperPlayerApi.Intel
   alias SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts
-  alias SleeperPlayerApi.Intel.{ObservedDraft, ObservedPick, ObservedTradedPick, SleeperUser}
+
+  alias SleeperPlayerApi.Intel.{
+    DraftParticipant,
+    ObservedDraft,
+    ObservedPick,
+    ObservedTradedPick,
+    SleeperUser
+  }
 
   setup do
     bypass = Bypass.open()
@@ -470,6 +478,105 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateDraftsTest do
       # one per unique draft) — no traded_picks calls at all.
       assert summary.api_calls == 6
       assert Enum.map([t1, t2, t3], &hits/1) == [0, 0, 0]
+    end
+  end
+
+  describe "draft_participants (Gap 1: populated by a real crawl, not seeded)" do
+    # Regression per the report on this step: `draft_participants` existed
+    # with a passing unit test on `Intel.upsert_draft_participants/2`
+    # directly, but nothing in the crawl path called it, so production had
+    # 0 rows. These tests drive the real `crawl/2` against Bypass — no
+    # DB-seeding helper in the path — and assert on the table and the
+    # participation query it feeds, per
+    # `tests-that-bypass-the-crawler` lessons.
+    test "a crawled draft's distinct pickers land in draft_participants, and manager_drafts_seen counts them",
+         %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"},
+        %{"user_id" => "200", "display_name" => "bob", "avatar" => "av2"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1001", "complete")])
+      expect_json(bypass, "/user/200/drafts/nfl/2026", [draft("1001", "complete")])
+
+      # alice picks twice, bob once, one pick unattributed (nil) — draft
+      # participation must be distinct pickers, not distinct picks.
+      expect_json(bypass, "/draft/1001/picks", [
+        pick(1, "P1", "100"),
+        pick(2, "P2", "200"),
+        pick(3, "P3", "100"),
+        pick(4, "P4", nil)
+      ])
+
+      stub_json(bypass, "/draft/1001/traded_picks", [])
+
+      assert {:ok, _summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      rows =
+        Repo.all(from(dp in DraftParticipant, where: dp.draft_id == 1001, order_by: dp.user_id))
+
+      assert Enum.map(rows, & &1.user_id) == [100, 200]
+
+      seen = Intel.manager_drafts_seen()
+      assert Map.get(seen, 100) == 1
+      assert Map.get(seen, 200) == 1
+    end
+
+    test "a picker who isn't one of this league's own leaguemates still gets a participant row (no FK crash)",
+         %{bypass: bypass} do
+      # alice's OTHER league draft is full of co-managers `sleeper_users`
+      # never heard of via `/league/555/users` — draft_participants must not
+      # have a hard FK to sleeper_users (see
+      # `20260806140000_drop_draft_participants_user_fk.exs`) or this raises.
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1001", "complete")])
+
+      expect_json(bypass, "/draft/1001/picks", [
+        pick(1, "P1", "100"),
+        pick(2, "P2", "999")
+      ])
+
+      stub_json(bypass, "/draft/1001/traded_picks", [])
+
+      assert {:ok, summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+      assert summary.errors == []
+
+      rows =
+        Repo.all(from(dp in DraftParticipant, where: dp.draft_id == 1001, order_by: dp.user_id))
+
+      assert Enum.map(rows, & &1.user_id) == [100, 999]
+      refute Repo.get(SleeperUser, 999)
+    end
+
+    test "a pre_draft draft (no picks fetched) gets no participant rows", %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1003", "pre_draft")])
+
+      assert {:ok, _summary} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      assert Repo.all(from(dp in DraftParticipant, where: dp.draft_id == 1003)) == []
+    end
+
+    test "re-crawling an in-progress draft doesn't duplicate participant rows", %{bypass: bypass} do
+      expect_json(bypass, "/league/555/users", [
+        %{"user_id" => "100", "display_name" => "alice", "avatar" => "av1"}
+      ])
+
+      expect_json(bypass, "/user/100/drafts/nfl/2026", [draft("1002", "drafting")])
+      expect_json(bypass, "/draft/1002/picks", [pick(1, "P1", "100")])
+      expect_json(bypass, "/draft/1002/traded_picks", [])
+
+      assert {:ok, _} = CrawlLeaguemateDrafts.crawl(555, "2026")
+      assert {:ok, _} = CrawlLeaguemateDrafts.crawl(555, "2026")
+
+      rows = Repo.all(from(dp in DraftParticipant, where: dp.draft_id == 1002))
+      assert length(rows) == 1
     end
   end
 end

--- a/test/sleeper_player_api_web/controllers/intel_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/intel_controller_test.exs
@@ -1,9 +1,18 @@
 defmodule SleeperPlayerApiWeb.IntelControllerTest do
-  use SleeperPlayerApiWeb.ConnCase, async: true
+  # `/intel` now makes a live `GET /league/:id/users` call (Gap 2 — see
+  # `Intel.league_intel/2`'s moduledoc), so this suite points the Sleeper
+  # client at a Bypass server via the shared `:sleeper_base_url` Application
+  # env key (same trick as `AvailabilityControllerTest`), which means it
+  # can't run concurrently with itself or anything else touching that key.
+  use SleeperPlayerApiWeb.ConnCase, async: false
 
   alias SleeperPlayerApi.Intel
 
   setup %{conn: conn} do
+    bypass = Bypass.open()
+    Application.put_env(:sleeper_player_api, :sleeper_base_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.delete_env(:sleeper_player_api, :sleeper_base_url) end)
+
     Intel.upsert_sleeper_users([
       %{id: 100, display_name: "alice"},
       %{id: 200, display_name: "bob"}
@@ -18,11 +27,31 @@ defmodule SleeperPlayerApiWeb.IntelControllerTest do
       %{pick_no: 2, player_id: "P2", picked_by: 200}
     ])
 
-    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+    {:ok, conn: put_req_header(conn, "accept", "application/json"), bypass: bypass}
+  end
+
+  defp stub_league_users(bypass, league_id, users) do
+    Bypass.stub(bypass, "GET", "/league/#{league_id}/users", fn conn ->
+      Plug.Conn.resp(conn, 200, Jason.encode!(users))
+    end)
+  end
+
+  defp fail_league_users(bypass, league_id) do
+    Bypass.stub(bypass, "GET", "/league/#{league_id}/users", fn conn ->
+      Plug.Conn.resp(conn, 500, "boom")
+    end)
   end
 
   describe "GET /api/v1/leagues/:league_id/intel" do
-    test "renders managers + corpus in the plan §3e camelCase shape", %{conn: conn} do
+    test "renders managers + corpus in the plan §3e camelCase shape", %{
+      conn: conn,
+      bypass: bypass
+    } do
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"}
+      ])
+
       conn = get(conn, ~p"/api/v1/leagues/555/intel?season=2026")
       body = json_response(conn, 200)
 
@@ -44,17 +73,48 @@ defmodule SleeperPlayerApiWeb.IntelControllerTest do
       assert corpus["drafts"] == 1
       assert corpus["picks"] == 2
       assert Map.has_key?(corpus, "lastCrawledAt")
+      assert corpus["membershipSource"] == "live"
     end
 
-    test "an uncrawled league returns an empty managers list, not a 500 or 404", %{conn: conn} do
+    test "a league member with zero observed drafts still renders, with honest zeros", %{
+      conn: conn,
+      bypass: bypass
+    } do
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"},
+        %{"user_id" => "300", "display_name" => "carol"}
+      ])
+
+      conn = get(conn, ~p"/api/v1/leagues/555/intel?season=2026")
+      body = json_response(conn, 200)
+
+      carol = Enum.find(body["managers"], &(&1["userId"] == 300))
+      assert carol["displayName"] == "carol"
+      assert carol["draftsCount"] == 0
+      assert carol["leaguesCount"] == 0
+      assert carol["tendencies"]["crushes"] == []
+      assert carol["tendencies"]["reachVsAdp"] == nil
+    end
+
+    test "an uncrawled league whose live members call also fails returns an empty managers list, not a 500 or 404",
+         %{conn: conn, bypass: bypass} do
+      fail_league_users(bypass, 999_999_999)
+
       conn = get(conn, ~p"/api/v1/leagues/999999999/intel?season=2026")
       body = json_response(conn, 200)
 
       assert body["managers"] == []
       assert body["corpus"]["drafts"] == 1
+      assert body["corpus"]["membershipSource"] == "derived"
     end
 
-    test "season is optional — omitting it still returns 200", %{conn: conn} do
+    test "season is optional — omitting it still returns 200", %{conn: conn, bypass: bypass} do
+      stub_league_users(bypass, 555, [
+        %{"user_id" => "100", "display_name" => "alice"},
+        %{"user_id" => "200", "display_name" => "bob"}
+      ])
+
       conn = get(conn, ~p"/api/v1/leagues/555/intel")
       assert json_response(conn, 200)["managers"] |> length() == 2
     end


### PR DESCRIPTION
Two gaps found by running the deployed system.

## `draft_participants` had 0 rows

The table and `upsert_draft_participants/2` existed but nothing called them,
so participation was re-derived from `observed_picks` on every query — the
exact thing §3a created the table to avoid.

Population now happens inside `Intel.upsert_observed_picks/2` rather than in
the crawler, so every caller that stores picks records participants too and
the two can't drift. `manager_drafts_seen/0`, `manager_corpus_stats/1` and
`manager_ids_for_league/2` read the table now. Pick-*content* aggregates
(crushes, positional lean, reach) stay on `observed_picks` — they aren't
participation derivations.

**The backfill migration is not optional.** Production has ~3,400 picks and
an empty table; the switched queries would otherwise report zero drafts seen
for everyone.

**Dropping the FK on `draft_participants.user_id` is a prerequisite, not
tidying.** It referenced `sleeper_users`, which only holds the leaguemates
of the league being crawled — but a leaguemate's *other* leagues are full of
co-managers we never enumerate. Storing participants would have raised a FK
violation on the first foreign draft. `observed_picks.picked_by` already has
no such constraint, for exactly this reason. §3a doesn't mention this;
worth a note if the doc is revised.

## `/intel` returned 11 of 13 managers

It derived managers from observed picks, so leaguemates with no rookie
drafts disappeared entirely — precisely the "0 drafts seen" case §3 Frontend
needs *rendered* ("league average · none of their drafts seen") rather than
hidden.

Membership now comes from a live `GET /league/:id/users` — the same
request-scoped pattern `/availability` uses for rosters — falling back to
the derived set if that call fails. The response carries
`corpus.membershipSource: "live" | "derived"` so a caller can tell a
complete list from a possibly-incomplete one.

Zero-draft members render honest zeros with `reachVsAdp: nil`, not `0`,
which would read as "perfectly average" rather than "unknown".

## Scope note

Survival numbers were never at risk here. `/availability` takes its counts
and shrinkage weights from `Estimator.manager_seen/2` over the in-memory
corpus; the SQL participation queries only feed `/intel`. A test asserts the
two agree.

## Verification

144 tests, 0 failures, with and without the corpus. Migrations apply cleanly
from scratch. The four protected acceptance tests (§4f board, 480-value
fixture, 16/16 `marketPick`, byte-identical `drafts_corpus`) are untouched in
the diff and still pass.

Sabotage-verified both ways: a no-op backfill fails its test; removing the
participant population fails 8 tests, including the crawler-produced-state
ones and the cross-check against `Estimator.manager_seen/2`.