### PR TITLE
Let /availability callers choose their own targets

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -700,7 +700,37 @@ defmodule SleeperPlayerApi.Intel do
     * `:at_pick` — analyze as if the draft were currently at this pick
       instead of its actual next open one (plan §3g hypotheticals).
       Defaults to the draft's actual next pick.
-    * `:limit` — how many corpus players become `targets` (default 20)
+    * `:limit` — how many corpus players become `targets` (default 20, or
+      the length of `:player_ids` when that is given)
+    * `:player_ids` — restrict `targets` to these players (plan §6 step 3).
+      See "Caller-chosen targets" below.
+
+  ## Caller-chosen targets
+
+  Without `:player_ids` this picks the targets itself: every corpus player
+  still on the board, ordered by league ADP, capped at `:limit`. That is a
+  reasonable default for a caller with no opinion, but the frontend has
+  one — "Best Available" means *the user's own rank list* everywhere else
+  in that app, so it asks about exactly those players and joins the answer
+  onto rows it is already rendering.
+
+  Two consequences worth being explicit about, because both are deliberate:
+
+    * **Explicit ids replace the internal eligibility filters** rather than
+      intersecting with them. `eligible_ids/1`'s position and market
+      filters exist to stop a thin-sample junk player out-ranking real
+      targets when 20 are being *selected* from a pool of hundreds. When
+      the caller names the players, nothing is being selected and that
+      pressure is gone — so filtering further could only drop a player the
+      caller explicitly asked about, and the caller cannot tell that
+      "absent" from "the corpus has never seen him".
+    * **Corpus membership still applies.** A player nobody in the circle
+      has ever drafted has no survival curve to compute and is silently
+      absent from `targets` at any limit. That is the honest "no read"
+      case, and the caller renders it as such.
+
+  The default of `:limit` follows `:player_ids` so that asking about a
+  40-player rank list doesn't silently answer for 20 of them.
 
   Refreshes the draft's own picks/traded_picks first when it isn't stored
   yet or its stored status is `"drafting"`, via
@@ -721,15 +751,21 @@ defmodule SleeperPlayerApi.Intel do
     draft_id = to_int(draft_id)
     my_user_id = opts |> Keyword.fetch!(:user_id) |> to_int()
     at_pick = opts[:at_pick]
-    limit = Keyword.get(opts, :limit, 20)
+    player_ids = opts[:player_ids]
+    limit = Keyword.get(opts, :limit) || default_limit(player_ids)
 
     with :ok <- ensure_fresh(draft_id) do
       case get_observed_draft(draft_id) do
         nil -> {:error, :draft_not_found}
-        draft -> build_availability(draft, my_user_id, at_pick, limit)
+        draft -> build_availability(draft, my_user_id, at_pick, limit, player_ids)
       end
     end
   end
+
+  # A caller naming its players wants an answer about all of them, not the
+  # 20 of them with the earliest league ADP — see "Caller-chosen targets".
+  defp default_limit(nil), do: 20
+  defp default_limit(player_ids), do: length(player_ids)
 
   defp ensure_fresh(draft_id) do
     case get_observed_draft(draft_id) do
@@ -746,7 +782,7 @@ defmodule SleeperPlayerApi.Intel do
     end
   end
 
-  defp build_availability(draft, my_user_id, at_pick, limit) do
+  defp build_availability(draft, my_user_id, at_pick, limit, player_ids) do
     picks_made = draft_picks(draft.id)
     traded_picks = draft_traded_picks(draft.id)
 
@@ -782,7 +818,7 @@ defmodule SleeperPlayerApi.Intel do
         candidate_lookup: player_lookup(candidate_ids),
         market_rank: Estimator.rookie_class_rank(market_rookie_class_entries(draft.season)),
         raw_picks: manager_pick_strings(candidate_ids, user_id_to_manager),
-        eligible_ids: eligible_ids(candidate_ids)
+        eligible_ids: eligible_ids(candidate_ids, player_ids)
       })
     end
   end
@@ -857,6 +893,14 @@ defmodule SleeperPlayerApi.Intel do
   # this step for anyone who hasn't run `RefreshPlayerValues` yet, which is
   # also why the existing acceptance tests (no `player_values` seeded) pass
   # unchanged.
+  # When the caller named its own players, that set *is* the eligibility —
+  # both filters below are selection aids, and nothing is being selected.
+  # See `availability/2`'s "Caller-chosen targets".
+  defp eligible_ids(_candidate_ids, player_ids) when is_list(player_ids),
+    do: MapSet.new(player_ids)
+
+  defp eligible_ids(candidate_ids, nil), do: eligible_ids(candidate_ids)
+
   defp eligible_ids(candidate_ids) do
     position_ids = fantasy_position_ids(candidate_ids)
     market_ids = market_universe_ids()

--- a/lib/sleeper_player_api_web/controllers/availability_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/availability_controller.ex
@@ -6,18 +6,28 @@ defmodule SleeperPlayerApiWeb.AvailabilityController do
   action_fallback SleeperPlayerApiWeb.FallbackController
 
   @doc """
-  `GET /api/v1/drafts/:draft_id/availability?user_id=<n>&at_pick=<n>&limit=<n>`
+  `GET /api/v1/drafts/:draft_id/availability?user_id=<n>&at_pick=<n>&limit=<n>&player_ids=<a,b,c>`
 
   See `SleeperPlayerApi.Intel.availability/2` for the full contract —
-  `user_id` is required (whose remaining picks are "mine"), `at_pick` and
-  `limit` are optional.
+  `user_id` is required (whose remaining picks are "mine"), `at_pick`,
+  `limit` and `player_ids` are optional.
+
+  `player_ids` is a comma-separated list of Sleeper player ids and
+  restricts `targets` to those players (plan §6 step 3 — the frontend
+  sends its rank list). A blank value is treated as absent rather than as
+  "no players": `?player_ids=` is what an empty rank list serialises to,
+  and answering it with zero targets would be indistinguishable from a
+  corpus with no reads.
   """
   def show(conn, %{"draft_id" => draft_id} = params) do
     with {:ok, user_id} <- require_param(params, "user_id"),
+         {:ok, at_pick} <- optional_int(params, "at_pick"),
+         {:ok, limit} <- optional_int(params, "limit"),
          opts <- [
            user_id: user_id,
-           at_pick: to_int(params["at_pick"]),
-           limit: to_int(params["limit"])
+           at_pick: at_pick,
+           limit: limit,
+           player_ids: to_id_list(params["player_ids"])
          ],
          opts <- Enum.reject(opts, fn {_k, v} -> is_nil(v) end),
          {:ok, availability} <- Intel.availability(draft_id, opts) do
@@ -32,6 +42,29 @@ defmodule SleeperPlayerApiWeb.AvailabilityController do
     end
   end
 
-  defp to_int(nil), do: nil
-  defp to_int(value) when is_binary(value), do: String.to_integer(value)
+  # `String.to_integer/1` raises on anything non-numeric, and
+  # `action_fallback` only catches `{:error, _}` *returns* — so parsing
+  # these with it turned `?limit=abc` into a 500. A malformed query param
+  # is the caller's mistake, not the server's.
+  defp optional_int(params, key) do
+    case params[key] do
+      nil ->
+        {:ok, nil}
+
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {int, ""} -> {:ok, int}
+          _ -> {:error, {:invalid_param, key, value}}
+        end
+    end
+  end
+
+  defp to_id_list(nil), do: nil
+
+  defp to_id_list(value) when is_binary(value) do
+    case value |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == "")) do
+      [] -> nil
+      ids -> Enum.uniq(ids)
+    end
+  end
 end

--- a/lib/sleeper_player_api_web/controllers/fallback_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/fallback_controller.ex
@@ -32,6 +32,19 @@ defmodule SleeperPlayerApiWeb.FallbackController do
     |> Phoenix.Controller.json(%{errors: %{detail: "missing required param: #{key}"}})
   end
 
+  # A query param that must be numeric wasn't (`AvailabilityController`'s
+  # `at_pick`/`limit`). Previously these were parsed with
+  # `String.to_integer/1`, which raises rather than returning an error, so
+  # `?limit=abc` came back as a 500.
+  def call(conn, {:error, {:invalid_param, key, value}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: SleeperPlayerApiWeb.ErrorJSON)
+    |> Phoenix.Controller.json(%{
+      errors: %{detail: "#{key} must be an integer, got: #{inspect(value)}"}
+    })
+  end
+
   # `SleeperPlayerApi.Intel.PickOwnership` couldn't resolve the draft's own
   # order (not `"linear"`/`"snake"`) — per `Availability`'s moduledoc, this
   # is a hard failure rather than a degraded response, because serving

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -225,33 +225,7 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
     end
 
     test "a candidate absent from FantasyCalc entirely is excluded from targets", %{conn: conn} do
-      # Seed one more fantasy-position corpus player who has no FantasyCalc
-      # entry at all (not in fc2.json) — before this step it would have
-      # ranked into targets on raw ADP alone, same shape as the production
-      # "Kyle Dixon" case in the report for this step.
-      Intel.upsert_observed_drafts([%{id: 99_999, teams: 12, status: "complete"}])
-
-      Intel.upsert_observed_picks(99_999, [
-        %{pick_no: 1, player_id: "90001", picked_by: nil}
-      ])
-
-      %SleeperPlayerApi.Sleeper.Player{}
-      |> SleeperPlayerApi.Sleeper.Player.changeset(%{
-        id: 90_001,
-        player_id: "90001",
-        player_json: "{}",
-        active: true,
-        first_name: "No",
-        last_name: "Value",
-        full_name: "No Value",
-        search_first_name: "no",
-        search_last_name: "value",
-        search_full_name: "no value",
-        position_id:
-          (SleeperPlayerApi.Sleeper.get_position_by_abbreviation("WR") ||
-             elem(SleeperPlayerApi.Sleeper.create_position(%{abbreviation: "WR"}), 1)).id
-      })
-      |> Repo.insert!()
+      seed_valueless_corpus_player!()
 
       conn =
         get(
@@ -262,6 +236,118 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
       body = json_response(conn, 200)
       target_ids = MapSet.new(body["targets"], & &1["id"])
       refute MapSet.member?(target_ids, "90001")
+    end
+
+    test "but naming that same player in player_ids returns him — explicit ids replace the filters",
+         %{conn: conn} do
+      # The market filter is a *selection* aid: it stops a thin-sample junk
+      # player out-ranking real targets when 20 are being chosen from
+      # hundreds. A caller naming its players has chosen already, so
+      # filtering further could only drop someone it explicitly asked
+      # about — and it could not tell that from "the corpus never saw him".
+      seed_valueless_corpus_player!()
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=90001"
+        )
+
+      body = json_response(conn, 200)
+      assert Enum.map(body["targets"], & &1["id"]) == ["90001"]
+      assert hd(body["targets"])["marketPick"] == nil
+    end
+  end
+
+  describe "GET /api/v1/drafts/:draft_id/availability — caller-chosen targets (plan §6 step 3)" do
+    @describetag :corpus
+
+    setup %{bypass: bypass} do
+      seed_corpus_from_json!()
+      seed_target_players!()
+      stub_district_13(bypass)
+      :ok
+    end
+
+    test "restricts targets to exactly the named players, still ordered by league ADP", %{
+      conn: conn
+    } do
+      # Deliberately out of ADP order in the query string: the caller sends
+      # its rank list in *its* order, and the response's ordering must stay
+      # the endpoint's own (league ADP ascending), not echo the input.
+      asked = ["13434", "13353", "13319"]
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=#{Enum.join(asked, ",")}"
+        )
+
+      body = json_response(conn, 200)
+
+      assert Enum.map(body["targets"], & &1["id"]) == ["13353", "13319", "13434"]
+
+      assert Enum.map(body["targets"], & &1["leagueAdp"]) ==
+               Enum.sort(Enum.map(body["targets"], & &1["leagueAdp"]))
+    end
+
+    test "an asked-for player the corpus has never seen is simply absent — the honest 'no read'",
+         %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=13353,999999"
+        )
+
+      body = json_response(conn, 200)
+
+      # Not an error and not a fabricated row: the caller renders the
+      # missing id as "no read" against the rank-list row it already has.
+      assert Enum.map(body["targets"], & &1["id"]) == ["13353"]
+    end
+
+    test "limit defaults to the number of ids asked about, not 20", %{conn: conn} do
+      # 25 corpus players still on the board at pick 35, derived from
+      # `rookie_picks.json` minus `d13_now.json`'s 34 made picks. The point
+      # is that it exceeds the default limit of 20 — without the default
+      # following the id list, five of these would silently vanish.
+      asked = twenty_five_available_ids()
+      assert length(asked) == 25
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=#{Enum.join(asked, ",")}"
+        )
+
+      body = json_response(conn, 200)
+
+      assert length(body["targets"]) == 25
+      assert MapSet.new(body["targets"], & &1["id"]) == MapSet.new(asked)
+    end
+
+    test "an explicit limit still wins over the id count", %{conn: conn} do
+      asked = twenty_five_available_ids()
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&limit=3&player_ids=#{Enum.join(asked, ",")}"
+        )
+
+      assert length(json_response(conn, 200)["targets"]) == 3
+    end
+
+    test "a blank player_ids is treated as absent, not as 'no players'", %{conn: conn} do
+      # What an empty rank list serialises to. Answering it with zero
+      # targets would be indistinguishable from a corpus with no reads.
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=&limit=60"
+        )
+
+      assert length(json_response(conn, 200)["targets"]) == 16
     end
   end
 
@@ -403,6 +489,29 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
       conn = get(conn, ~p"/api/v1/drafts/#{@draft_id}/availability")
       assert json_response(conn, 422)
     end
+
+    # These two were 500s: the params were parsed with
+    # `String.to_integer/1`, which *raises*, and `action_fallback` only
+    # catches `{:error, _}` returns.
+    test "a non-numeric limit is a 422, not a 500", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&limit=abc"
+        )
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ "limit must be an integer"
+    end
+
+    test "a non-numeric at_pick is a 422, not a 500", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&at_pick=39x"
+        )
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ "at_pick must be an integer"
+    end
   end
 
   # ---------------------------------------------------------------------
@@ -481,6 +590,55 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
       })
       |> SleeperPlayerApi.Repo.insert!()
     end)
+  end
+
+  # One more fantasy-position corpus player with no FantasyCalc entry at
+  # all (not in fc2.json) — the shape of the production "Kyle Dixon" case
+  # in the report for §3f step 5: before that step he ranked into targets
+  # on a thin ADP sample alone.
+  defp seed_valueless_corpus_player! do
+    Intel.upsert_observed_drafts([%{id: 99_999, teams: 12, status: "complete"}])
+    Intel.upsert_observed_picks(99_999, [%{pick_no: 1, player_id: "90001", picked_by: nil}])
+
+    %SleeperPlayerApi.Sleeper.Player{}
+    |> SleeperPlayerApi.Sleeper.Player.changeset(%{
+      id: 90_001,
+      player_id: "90001",
+      player_json: "{}",
+      active: true,
+      first_name: "No",
+      last_name: "Value",
+      full_name: "No Value",
+      search_first_name: "no",
+      search_last_name: "value",
+      search_full_name: "no value",
+      position_id:
+        (SleeperPlayerApi.Sleeper.get_position_by_abbreviation("WR") ||
+           elem(SleeperPlayerApi.Sleeper.create_position(%{abbreviation: "WR"}), 1)).id
+    })
+    |> Repo.insert!()
+  end
+
+  # Corpus players still on the board at pick 35 — every player id in
+  # `rookie_picks.json` that isn't among `d13_now.json`'s 34 made picks,
+  # most-drafted first, trimmed to 25. Derived rather than hardcoded so it
+  # can't drift from the corpus files; the count matters because it has to
+  # exceed the default limit of 20.
+  defp twenty_five_available_ids do
+    made =
+      read_json!("d13_now.json")
+      |> Enum.map(& &1["player_id"])
+      |> MapSet.new()
+
+    read_json!("rookie_picks.json")
+    |> Map.values()
+    |> List.flatten()
+    |> Enum.map(& &1["player_id"])
+    |> Enum.reject(&MapSet.member?(made, &1))
+    |> Enum.frequencies()
+    |> Enum.sort_by(fn {_id, count} -> -count end)
+    |> Enum.map(fn {id, _count} -> id end)
+    |> Enum.take(25)
   end
 
   defp seed_users_only! do


### PR DESCRIPTION
Prep for the frontend swap (plan §6 step 3). The rank list is what "Best
Available" means everywhere else in the app, so the UI needs to ask about
exactly those players instead of joining against a corpus-chosen top 20 and
hoping they overlap.

`?player_ids=a,b,c` restricts `targets` to a caller-supplied set, routed into
the `eligible_ids` seam `Availability.build/1` already had.

Two deliberate choices, both documented on `Intel.availability/2`:

- **Explicit ids replace the position/market filters** rather than intersecting.
  Those filters stop a thin-sample junk player out-ranking real targets when 20
  are *selected* from hundreds; when the caller names the players nothing is
  being selected, so filtering further could only drop someone it explicitly
  asked about — which it cannot distinguish from "the corpus has never seen him".
- **`limit` defaults to the number of ids**, so a 40-player rank list isn't
  silently answered for 20 of them. An explicit `limit` still wins.

Corpus membership still applies: a player nobody in the circle has drafted has
no curve to compute and is absent at any limit. That is the honest "no read".

Also fixes a 500 — `at_pick`/`limit` were parsed with `String.to_integer/1`,
which raises, and `action_fallback` only catches `{:error, _}` returns, so
`?limit=abc` crashed instead of returning 422.

Backward-compatible: no `player_ids` is today's behaviour exactly, and the
existing fixture-parity tests pass at 0.0 max deviation.

152 tests, 0 failures (was 144). Each new behaviour was sabotaged and confirmed
to fail before being restored.