### PR TITLE
Send one hazard per pick, not a threat list per pick

### DIFF
--- a/lib/sleeper_player_api/intel/availability.ex
+++ b/lib/sleeper_player_api/intel/availability.ex
@@ -208,31 +208,33 @@ defmodule SleeperPlayerApi.Intel.Availability do
 
     board_mult_fun = fn pick -> mult_fun.(Map.get(board_owner, pick)) end
 
+    # Survival stays server-side for both figures. It is tempting to send
+    # only `hazards` and let the client derive survival from it, which is
+    # smaller again - but §3g's whole point is that one estimator serves the
+    # headline and the stations so the gauntlet telescopes exactly to the
+    # chip. Deriving it a second time on the client is precisely the second,
+    # inconsistent computation that fixed.
+    #
     # `//1` for the same reason as the board range above.
     by_pick =
       for pick <- current_pick..(last_pick + 1)//1, into: %{} do
-        base_survival = Estimator.base_survival(hazard, current_pick, pick)
-        adj_survival = Estimator.adjusted_survival(hazard, current_pick, pick, board_mult_fun)
-
-        threats =
-          Estimator.threats(
-            hazard,
-            current_pick,
-            pick,
-            board_owner,
-            known_managers,
-            mult_fun,
-            fn manager -> Estimator.manager_seen(input.corpus, manager) end,
-            fn manager -> Estimator.manager_took(input.corpus, manager, player_id) end
-          )
-
         {pick,
          %{
-           adj_survival: round3(adj_survival),
-           base_survival: round3(base_survival),
-           threats: Enum.map(threats, &round_threat/1)
+           adj_survival:
+             round3(Estimator.adjusted_survival(hazard, current_pick, pick, board_mult_fun)),
+           base_survival: round3(Estimator.base_survival(hazard, current_pick, pick))
          }}
       end
+
+    # One entry per pick rather than a threat list per target pick - see
+    # `Estimator.hazards/6` on why the latter was 22x larger than its own
+    # content. The top of the range is `last_pick`, not `last_pick + 1`:
+    # by_pick runs one past the end so the gauntlet can read "survival after
+    # this pick", but no threat ever sits at that extra pick.
+    hazards =
+      hazard
+      |> Estimator.hazards(current_pick, last_pick, board_owner, known_managers, mult_fun)
+      |> Enum.map(fn h -> %{h | prob: round3(h.prob)} end)
 
     market_pick = Map.get(input.market_rank, player_id)
     adp_gap = Estimator.adp_gap(summary.adp, market_pick)
@@ -249,14 +251,13 @@ defmodule SleeperPlayerApi.Intel.Availability do
       min: round1(summary.min),
       max: round1(summary.max),
       by_pick: by_pick,
+      hazards: hazards,
       per_manager: per_manager(input, player_id),
       market_pick: market_pick,
       adp_gap: adp_gap,
       notable: notable(input, player_id, board_owner, summary.adp)
     }
   end
-
-  defp round_threat(threat), do: %{threat | prob: round3(threat.prob)}
 
   defp round3(nil), do: nil
   defp round3(x), do: Float.round(x * 1.0, 3)

--- a/lib/sleeper_player_api/intel/estimator.ex
+++ b/lib/sleeper_player_api/intel/estimator.ex
@@ -480,9 +480,48 @@ defmodule SleeperPlayerApi.Intel.Estimator do
   # ---------------------------------------------------------------------
 
   @doc """
+  One entry per pick in `[first_pick, last_pick]` whose owner (per `board`,
+  a `%{pick_number => manager}` map) is a known leaguemate: the probability
+  that owner takes this player there, given he is still available.
+
+  This is what `threats/8` builds its lists *out of*, and it is the thing
+  worth sending over the wire. A threat list for target pick `n` is every
+  entry here with `pick < n`, so serving one list per target pick means
+  re-sending the same prefix `n` times — measured against production, that
+  was 11,760 threat objects and 837KB for ten players at pick 1, where the
+  irreducible content is 38KB. The other two fields `threats/8` carries
+  (`drafts` and `tookCount`) do not vary by pick either: the first belongs
+  to the board entry and the second to `per_manager`, so a caller can
+  rebuild the full list by joining on the pick number.
+
+  Picks owned by someone outside `known_managers` are excluded, exactly as
+  in `threats/8` — they still affect survival through `mult_fun`, they just
+  produce no itemized receipt.
+  """
+  @spec hazards(
+          %{integer => float},
+          integer,
+          integer,
+          %{integer => String.t()},
+          MapSet.t(String.t()),
+          (String.t() -> float)
+        ) :: [map]
+  def hazards(hazard, first_pick, last_pick, board, known_managers, mult_fun) do
+    for k <- first_pick..last_pick//1,
+        manager = Map.get(board, k),
+        manager != nil,
+        MapSet.member?(known_managers, manager) do
+      %{pick: k, prob: Map.get(hazard, k, 0.0) * mult_fun.(manager)}
+    end
+  end
+
+  @doc """
   The threat list for target pick `target_pick`: every pick `k` in
   `[current_pick, target_pick)` whose owner (per `board`, a `%{pick_number
   => manager}` map) is a known leaguemate, in pick order.
+
+  Retained for tests and for `hazards/6`'s own equivalence check; the API
+  serves `hazards/6` instead. See its docstring for why.
 
   `hazard` is the base hazard curve (see `base_hazard/3`). `known_managers`
   is used to decide whether a board owner is a tracked leaguemate at all —

--- a/lib/sleeper_player_api_web/controllers/availability_json.ex
+++ b/lib/sleeper_player_api_web/controllers/availability_json.ex
@@ -49,6 +49,7 @@ defmodule SleeperPlayerApiWeb.AvailabilityJSON do
       min: t.min,
       max: t.max,
       byPick: by_pick(t.by_pick),
+      hazards: Enum.map(t.hazards, &hazard/1),
       perManager: Enum.map(t.per_manager, &per_manager/1),
       marketPick: t.market_pick,
       adpGap: t.adp_gap,
@@ -59,17 +60,15 @@ defmodule SleeperPlayerApiWeb.AvailabilityJSON do
   defp by_pick(by_pick) do
     Map.new(by_pick, fn {pick, entry} ->
       {Integer.to_string(pick),
-       %{
-         adjSurvival: entry.adj_survival,
-         baseSurvival: entry.base_survival,
-         threats: Enum.map(entry.threats, &threat/1)
-       }}
+       %{adjSurvival: entry.adj_survival, baseSurvival: entry.base_survival}}
     end)
   end
 
-  defp threat(t) do
-    %{manager: t.manager, pick: t.pick, prob: t.prob, drafts: t.drafts, tookCount: t.tookCount}
-  end
+  # One entry per pick, not a threat list per target pick. The threat list
+  # for pick `n` is every entry with `pick < n`, joined to `board` for the
+  # manager and their drafts-seen and to `perManager` for the take count -
+  # none of which vary by target pick. See `Estimator.hazards/6`.
+  defp hazard(h), do: %{pick: h.pick, prob: h.prob}
 
   defp per_manager(m) do
     %{manager: m.manager, times: m.times, of: m.of, adp: m.adp, picks: m.picks}

--- a/test/sleeper_player_api/intel/availability_test.exs
+++ b/test/sleeper_player_api/intel/availability_test.exs
@@ -141,7 +141,8 @@ defmodule SleeperPlayerApi.Intel.AvailabilityTest do
              "expected only the current pick's column, got #{inspect(Map.keys(target.by_pick))}"
 
       assert target.by_pick[9].base_survival == 1.0
-      assert target.by_pick[9].threats == []
+      # No picks left, so nothing can take him: no hazard entries either.
+      assert target.hazards == []
     end
   end
 
@@ -198,7 +199,25 @@ defmodule SleeperPlayerApi.Intel.AvailabilityTest do
       keys = target.by_pick |> Map.keys() |> Enum.sort()
       # current_pick 1 .. last_pick 8, +1 for the extra survival-after column
       assert keys == Enum.to_list(1..9)
-      assert target.by_pick[1] == %{adj_survival: 1.0, base_survival: 1.0, threats: []}
+      assert target.by_pick[1] == %{adj_survival: 1.0, base_survival: 1.0}
+    end
+
+    # The shape change that made the response 22x smaller: one hazard entry
+    # per pick, instead of a threat list per target pick that re-sent the
+    # same prefix every time. See `Estimator.hazards/6`.
+    test "hazards carry one entry per pick, stopping at last_pick", %{corpus: corpus} do
+      input = base_input(%{corpus: corpus, limit: 1})
+
+      assert {:ok, response} = Availability.build(input)
+      target = hd(response.targets)
+
+      # by_pick runs to 9 so the gauntlet can read "survival after pick 8",
+      # but no threat can sit at a pick that does not exist.
+      assert Enum.map(target.hazards, & &1.pick) == Enum.to_list(1..8)
+      assert Enum.all?(target.hazards, &is_float(&1.prob))
+
+      refute Enum.any?(target.hazards, &Map.has_key?(&1, :manager)),
+             "manager belongs to the board entry, not to every hazard on every pick"
     end
   end
 end

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -82,6 +82,14 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
       assert pick39["mine"] == true
     end
 
+    # The fixture is the frozen ground truth from the live District 13 draft
+    # and it still carries the *old* per-pick threat lists. That is
+    # deliberate: the response shape got 22x smaller by not sending those,
+    # but the numbers behind them did not change, so this test rebuilds the
+    # threat list the way the frontend now does - hazards joined to `board`
+    # and `perManager` on the pick number - and asserts the reconstruction
+    # against the untouched fixture. If the join is wrong, or a hazard goes
+    # missing, this fails; and the ground truth stays ground truth.
     test "byPick numbers match the fixture within 0.0005 — proves the whole stack", %{conn: conn} do
       fixture = read_json!("fixture.json")
 
@@ -94,13 +102,34 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
       body = json_response(conn, 200)
 
       targets_by_id = Map.new(body["targets"], &{&1["id"], &1})
+      board_by_pick = Map.new(body["board"], &{&1["pick"], &1})
 
       deviations =
         Enum.flat_map(fixture["targets"], fn expected_target ->
           actual_target = Map.fetch!(targets_by_id, expected_target["id"])
+          took_by_manager = Map.new(actual_target["perManager"], &{&1["manager"], &1["times"]})
 
           Enum.map(expected_target["byPick"], fn {pick_str, expected} ->
             actual = Map.fetch!(actual_target["byPick"], pick_str)
+
+            # The reconstruction the frontend performs, done here against the
+            # fixture's own expectations.
+            rebuilt_threats =
+              actual_target["hazards"]
+              |> Enum.filter(&(&1["pick"] < String.to_integer(pick_str)))
+              |> Enum.map(fn h ->
+                board = Map.fetch!(board_by_pick, h["pick"])
+
+                %{
+                  "manager" => board["manager"],
+                  "pick" => h["pick"],
+                  "prob" => h["prob"],
+                  "drafts" => board["drafts"],
+                  "tookCount" => Map.get(took_by_manager, board["manager"], 0)
+                }
+              end)
+
+            actual = Map.put(actual, "threats", rebuilt_threats)
 
             assert_in_delta actual["baseSurvival"],
                             expected["baseSurvival"],


### PR DESCRIPTION
`byPick[n].threats` was a prefix accumulation — the list for pick `n` was the
list for `n-1` plus one entry — so a 48-pick board re-sent the same prefix 48
times. Each entry also repeated two fields that don't vary by pick: `drafts`
belongs to the board entry, `tookCount` to `perManager`.

Measured against production, ten players at `at_pick=1`:

| | raw | gzipped |
| --- | --- | --- |
| before | 837 KB | 14 KB |
| after | **38 KB** | 4 KB |

22× on its own. Compression alone would have hidden the waste on the wire while
still making a phone parse 837 KB and allocate ~11,760 objects mid-draft.

## The shape

`targets[].hazards` is one `{pick, prob}` per pick. The threat list for pick `n`
is every entry with `pick < n`, joined to `board` on the pick number for the
manager and their drafts-seen, and to `perManager` for the take count. `byPick`
keeps its keys and both survival figures.

Survival deliberately **stays server-side**. Sending only hazards and deriving
survival on the client is smaller again, but §3g's whole point is that one
estimator serves the headline and the stations so the gauntlet telescopes
exactly to the chip. Deriving it a second time on the client is the
inconsistency §3g removed.

## Breaking, and now is when it's free

The only consumer is my-sleeper-app#149, which isn't merged. If it were, I'd
have added `hazards` alongside and deprecated `threats` instead.

## The golden test still proves the stack

`fixture.json` is untouched and still carries the old threat lists — it stays
the frozen ground truth. The parity test now rebuilds threats exactly the way
the frontend does and asserts the reconstruction against it: all 16 targets,
480 survival values and 1,680 threat probabilities, at **0.0 deviation**. So it
proves the join as well as the numbers.

Sabotage check: dropping the manager multiplier from a hazard fails it.

153 tests, 0 failures.