### PR TITLE
Add a calibration harness, and fix the first bug it found

### DIFF
--- a/lib/sleeper_player_api/intel/calibration.ex
+++ b/lib/sleeper_player_api/intel/calibration.ex
@@ -1,0 +1,183 @@
+defmodule SleeperPlayerApi.Intel.Calibration do
+  @moduledoc """
+  Leave-one-draft-out calibration for a survival estimator, scored on the
+  question the UI actually asks (plan `docs/leaguemate-intel.md` §3g):
+  **given this player is still on the board at pick `k`, is he still there at
+  pick `k + d`?**
+
+  This exists because §6 step 5 is gated on a *measurement* rather than a
+  review — a manager-conditioned model ships only if it beats what is already
+  there. Nothing in either repo could produce that measurement: the harness
+  that generated the plan's numbers was never saved, exactly as the estimator
+  itself was not (see the estimator moduledoc). So this is a rebuild, and the
+  numbers it produces are not guaranteed to match the ones in the plan's
+  prose. **Compare estimators against each other through this module; do not
+  compare its output to a figure quoted in the plan** — the original's pick
+  sampling, bucket edges and weighting are unknown, so an absolute match would
+  be luck rather than agreement.
+
+  ## Why the harness is the dangerous part
+
+  §3g records that an earlier version of this scored "not in this draft" as
+  *survived* regardless of how far the draft actually ran. Fourteen of the
+  seventy corpus drafts are 3-rounders that end at 36 normalized; they cannot
+  say anything about pick 39, but they were voting that he lasted. The
+  estimator had the same bias, the two cancelled, and the naive version
+  therefore looked *better* than the corrected one.
+
+  A harness with a bug in it does not fail loudly — it silently blesses the
+  wrong model. So the censoring rule is explicit here and unit-tested against
+  hand-computed cases:
+
+    * a `(k, target)` pair is only scored if the draft **reached** `target`
+      (`l_d >= target`); otherwise it leaves the risk set entirely
+    * the pair is only scored if the player was **still available at `k`**
+      (never taken, or taken at `>= k`), which is what makes the probability
+      conditional
+    * "still available at `target`" likewise means never taken, or taken at
+      `>= target`
+
+  ## Metric
+
+  Predictions are bucketed into deciles. Within a bucket, the mean prediction
+  is compared to the observed rate, and the absolute gap is weighted by how
+  many observations fell in that bucket:
+
+      error = Σ_b (n_b / N) * |mean_predicted_b - observed_rate_b|
+
+  Lower is better. A perfectly calibrated estimator scores 0.0 — which says
+  nothing about whether it is *sharp*, only that it is honest. Two estimators
+  are only comparable through the same `ks`/`deltas`/bucket settings.
+  """
+
+  @default_deltas 1..14
+  @buckets 10
+
+  @doc """
+  Runs leave-one-draft-out calibration.
+
+  `predict_builder` is `(training_drafts -> predict_fun)`, and `predict_fun`
+  is `(player_id, from_pick, to_pick -> probability)`. Taking a builder rather
+  than a bare function is what lets an estimator do its per-corpus fitting
+  once per held-out draft instead of once per observation — with 70 drafts and
+  ~130 players that is the difference between minutes and hours.
+
+  Options:
+
+    * `:deltas` — how far ahead to score, in normalized picks (default 1..14,
+      roughly "between now and your next pick" in a 12-team draft)
+    * `:ks` — which starting picks to score from (default: every integer pick
+      the held-out draft actually reached)
+    * `:players` — the candidate pool (default: every player appearing in the
+      full corpus)
+
+  Returns `%{error: float, n: integer, buckets: [%{...}]}`.
+  """
+  @spec run([map], (list -> (String.t(), number, number -> float)), keyword) :: map
+  def run(drafts, predict_builder, opts \\ []) do
+    deltas = Keyword.get(opts, :deltas, @default_deltas) |> Enum.to_list()
+    players = Keyword.get(opts, :players) || corpus_players(drafts)
+
+    observations =
+      Enum.flat_map(drafts, fn held_out ->
+        training = Enum.reject(drafts, &(&1 == held_out))
+        predict = predict_builder.(training)
+        score_draft(held_out, players, predict, deltas, opts)
+      end)
+
+    summarize(observations)
+  end
+
+  @doc """
+  Every player id appearing anywhere in `drafts`.
+  """
+  @spec corpus_players([map]) :: [String.t()]
+  def corpus_players(drafts) do
+    for(draft <- drafts, pick <- draft.picks, do: pick.player_id) |> Enum.uniq()
+  end
+
+  # One held-out draft's worth of (predicted, actual) pairs.
+  defp score_draft(held_out, players, predict, deltas, opts) do
+    # The earliest pick each player went at in this draft, or nil. `min` and
+    # not `hd`: a corpus draft can contain the same player twice only through
+    # bad data, but taking whichever came first is the conservative read.
+    taken_at =
+      Enum.reduce(held_out.picks, %{}, fn pick, acc ->
+        Map.update(acc, pick.player_id, pick.norm, &min(&1, pick.norm))
+      end)
+
+    last = trunc(held_out.l_d)
+    ks = Keyword.get(opts, :ks) || 1..last
+
+    # Every clause here is a filter, including anything that looks like an
+    # assignment: `went_at = Map.get(taken_at, player)` reads as a binding but
+    # a comprehension treats it as a filter on the *value*, so every player
+    # who was never drafted (nil) was silently dropped from the risk set. That
+    # is the same shape of error as §3g's original censoring bug — a harness
+    # quietly scoring the wrong population — so the conditions are plain
+    # boolean calls now and the bindings happen in the body.
+    for k <- ks,
+        k <= last,
+        delta <- deltas,
+        # Censoring. A draft that ended before `target` cannot tell us whether
+        # he would have lasted to it, so it leaves the risk set rather than
+        # voting "survived" forever. This is §3g's Bug 1, and it lived in the
+        # harness as well as in the estimator.
+        k + delta <= last,
+        player <- players,
+        # Conditioning: he has to still be on the board at k for "does he last
+        # from k to target" to be a question at all.
+        available_at?(taken_at, player, k) do
+      target = k + delta
+
+      %{
+        predicted: predict.(player, k, target),
+        actual: available_at?(taken_at, player, target)
+      }
+    end
+  end
+
+  # On the board when pick `n` *starts*. A player taken at exactly `n` was
+  # available at `n` — the hazard at `n` is the chance he goes at it, so he is
+  # still there when it begins. Both the conditioning and the outcome read
+  # through here so the convention cannot drift between them.
+  defp available_at?(taken_at, player, n) do
+    case Map.get(taken_at, player) do
+      nil -> true
+      went_at -> went_at >= n
+    end
+  end
+
+  defp summarize([]), do: %{error: 0.0, n: 0, buckets: []}
+
+  defp summarize(observations) do
+    total = length(observations)
+
+    buckets =
+      observations
+      |> Enum.group_by(&bucket_index(&1.predicted))
+      |> Enum.sort_by(fn {index, _} -> index end)
+      |> Enum.map(fn {index, group} ->
+        n = length(group)
+        mean_predicted = Enum.sum(Enum.map(group, & &1.predicted)) / n
+        observed = Enum.count(group, & &1.actual) / n
+
+        %{
+          bucket: index / @buckets,
+          n: n,
+          mean_predicted: mean_predicted,
+          observed: observed,
+          gap: abs(mean_predicted - observed)
+        }
+      end)
+
+    error = Enum.reduce(buckets, 0.0, fn b, acc -> acc + b.n / total * b.gap end)
+
+    %{error: error, n: total, buckets: buckets}
+  end
+
+  # 1.0 belongs in the top bucket rather than a tenth one of its own.
+  defp bucket_index(probability) do
+    probability |> Kernel.*(@buckets) |> trunc() |> min(@buckets - 1)
+  end
+end

--- a/lib/sleeper_player_api/intel/estimator.ex
+++ b/lib/sleeper_player_api/intel/estimator.ex
@@ -348,7 +348,20 @@ defmodule SleeperPlayerApi.Intel.Estimator do
     risk = risk_curve(drafts, player_id, grid)
 
     for {n, r} <- risk, into: %{} do
-      h = if r == 0, do: 0.0, else: Map.fetch!(density, n) / r
+      # Clamped to 1.0 because a hazard is a probability and `d(n) / r(n)` is
+      # not bounded by one: the numerator is smeared across neighbouring picks
+      # while the risk set is decremented hard at the unsmeared pick (the
+      # deliberate asymmetry documented in §4 above). Where a player is near-
+      # unanimous the risk set collapses faster than the density does, and the
+      # ratio can exceed 1 — which makes `1 - h` negative, and the survival
+      # product negative with it.
+      #
+      # Found by measurement, not by a test: exactly one (player, pick) pair in
+      # the 70-draft corpus does this — the consensus 1.01 (ADP 1.1, sd 0.3) at
+      # pick 2, where h came out 2.824 and survival across that pick came out
+      # -0.488. It is narrow but it is reachable: it is the top of a live draft
+      # board, and it renders as a negative percentage.
+      h = if r == 0, do: 0.0, else: min(1.0, Map.fetch!(density, n) / r)
       {n, h}
     end
   end

--- a/test/sleeper_player_api/intel/calibration_baseline_test.exs
+++ b/test/sleeper_player_api/intel/calibration_baseline_test.exs
@@ -1,0 +1,79 @@
+defmodule SleeperPlayerApi.Intel.CalibrationBaselineTest do
+  @moduledoc """
+  The measurement §6 step 5 is gated on: what the *current* estimator scores,
+  measured by `Intel.Calibration` against the real corpus.
+
+  This is the baseline a manager-conditioned model has to beat. It is a
+  measurement, not an assertion about a target — the plan quotes 0.0296 from a
+  harness that was never saved, so that figure is not reproducible and is not
+  what this compares against. What matters is that both estimators are scored
+  by *this* harness with identical settings.
+
+  Tagged `:corpus` (gitignored data) and `:measure` (slow — leave-one-out over
+  70 drafts refits every player's hazard 70 times).
+  """
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApi.CorpusFixture
+  alias SleeperPlayerApi.Intel.{Calibration, Estimator}
+
+  @moduletag :corpus
+  @moduletag :measure
+  @moduletag timeout: :infinity
+
+  # The estimator as it ships today: a league-wide smoothed hazard, with no
+  # manager conditioning at all. `base_survival/3` is already conditional on
+  # availability at `from`, which is exactly the quantity being scored.
+  defp current_estimator do
+    fn training ->
+      cache = :ets.new(:hazards, [:set, :private])
+
+      fn player_id, from, to ->
+        hazard =
+          case :ets.lookup(cache, player_id) do
+            [{^player_id, cached}] ->
+              cached
+
+            [] ->
+              computed = Estimator.base_hazard(training, player_id)
+              :ets.insert(cache, {player_id, computed})
+              computed
+          end
+
+        Estimator.base_survival(hazard, from, to)
+      end
+    end
+  end
+
+  test "measures the shipping estimator, and prints the baseline to beat" do
+    drafts = CorpusFixture.drafts()
+    assert length(drafts) == 70
+
+    result = Calibration.run(drafts, current_estimator(), deltas: [1, 3, 6, 9, 12])
+
+    rows =
+      result.buckets
+      |> Enum.map_join("\n", fn b ->
+        "  #{Float.round(b.bucket, 1)}–#{Float.round(b.bucket + 0.1, 1)}  " <>
+          "n=#{String.pad_leading(to_string(b.n), 7)}  " <>
+          "predicted #{Float.round(b.mean_predicted, 3)}  " <>
+          "observed #{Float.round(b.observed, 3)}"
+      end)
+
+    IO.puts("""
+
+    Conditional calibration — shipping estimator (league-wide smoothed hazard)
+    #{rows}
+
+      observations: #{result.n}
+      weighted error: #{Float.round(result.error, 4)}
+    """)
+
+    # Not a target, a floor: a number this far out would mean the harness or
+    # the corpus load is broken, not that the model is bad. The real gate for
+    # step 5 is beating this figure with a manager-conditioned model, measured
+    # the same way.
+    assert result.n > 100_000
+    assert result.error < 0.2
+  end
+end

--- a/test/sleeper_player_api/intel/calibration_test.exs
+++ b/test/sleeper_player_api/intel/calibration_test.exs
@@ -1,0 +1,163 @@
+defmodule SleeperPlayerApi.Intel.CalibrationTest do
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApi.Intel.Calibration
+
+  # These are hand-computable on purpose. §3g records a version of this harness
+  # that scored "not in this draft" as survived regardless of draft length —
+  # the same bias the estimator had, so the two cancelled and the naive
+  # estimator looked *better* than the corrected one. A harness that is wrong
+  # does not fail loudly; it blesses the wrong model. So every rule it applies
+  # gets a case with a known answer.
+
+  defp draft(l_d, picks) do
+    %{
+      l_d: l_d,
+      picks: Enum.map(picks, fn {norm, id} -> %{norm: norm, player_id: id, manager: nil} end)
+    }
+  end
+
+  # A predictor that always says the same thing, so the observed side is the
+  # only thing under test.
+  defp always(p), do: fn _training -> fn _player, _from, _to -> p end end
+
+  describe "censoring — the bug that hid inside the old harness" do
+    test "a draft that ended before the target pick is not scored at all" do
+      # Both drafts end at 4, so nothing can be asked about pick 5+. Player A
+      # is never taken in either. The broken version counted him as having
+      # survived to every pick in the grid, which is evidence it does not have.
+      drafts = [draft(4.0, [{2.0, "B"}]), draft(4.0, [{3.0, "B"}])]
+
+      result = Calibration.run(drafts, always(0.5), deltas: [10], players: ["A"])
+
+      assert result.n == 0, "a draft that never reached the target must leave the risk set"
+    end
+
+    test "the same pair is scored once the draft does reach the target" do
+      drafts = [draft(12.0, [{2.0, "B"}]), draft(12.0, [{3.0, "B"}])]
+
+      result = Calibration.run(drafts, always(0.5), deltas: [10], ks: [1], players: ["A"])
+
+      # k=1, target=11, both drafts reached 12 -> one observation each.
+      assert result.n == 2
+    end
+  end
+
+  describe "conditioning" do
+    test "a player already gone at k is not asked about from k" do
+      # Taken at 2. From k=3 onwards the question "given he is on the board at
+      # 3" does not apply to him at all.
+      drafts = [draft(12.0, [{2.0, "A"}]), draft(12.0, [{2.0, "A"}])]
+
+      result = Calibration.run(drafts, always(0.5), deltas: [1], ks: [3], players: ["A"])
+
+      assert result.n == 0
+    end
+
+    test "a player taken exactly at k still counts as available at k" do
+      # The hazard at k is the chance he goes *at* k, so he is on the board
+      # when that pick starts. Off by one here and every prediction is scored
+      # against the wrong risk set.
+      drafts = [draft(12.0, [{3.0, "A"}]), draft(12.0, [{3.0, "A"}])]
+
+      result = Calibration.run(drafts, always(0.5), deltas: [1], ks: [3], players: ["A"])
+
+      assert result.n == 2
+      # He was taken at 3, so he did not last to 4.
+      assert Enum.all?(result.buckets, &(&1.observed == 0.0))
+    end
+  end
+
+  describe "the observed rate" do
+    test "a player who always lasts scores an observed rate of 1.0" do
+      drafts = [draft(12.0, [{9.0, "A"}]), draft(12.0, [{9.0, "A"}])]
+
+      result = Calibration.run(drafts, always(1.0), deltas: [1], ks: [1], players: ["A"])
+
+      assert result.n == 2
+      assert [%{observed: 1.0, mean_predicted: 1.0}] = result.buckets
+      # Perfectly calibrated: it said 1.0 and got 1.0.
+      assert result.error == 0.0
+    end
+
+    test "a confident predictor that is always wrong scores an error of 1.0" do
+      drafts = [draft(12.0, [{2.0, "A"}]), draft(12.0, [{2.0, "A"}])]
+
+      # Says "certain to last" from k=1 to 3; he went at 2 both times, so he
+      # was gone by 3. Note the target has to be *past* the pick he went at —
+      # taken at 2 means he was still on the board when pick 2 started.
+      result = Calibration.run(drafts, always(1.0), deltas: [2], ks: [1], players: ["A"])
+
+      assert result.n == 2
+      assert result.error == 1.0
+    end
+
+    test "a 50% call on a coin flip is perfectly calibrated" do
+      # Taken at 2 in one draft, at 9 in the other; asked whether he lasts to
+      # 5. Leave-one-out means each is scored by a model fit on the other, and
+      # the truth is one of each.
+      drafts = [draft(12.0, [{2.0, "A"}]), draft(12.0, [{9.0, "A"}])]
+
+      result = Calibration.run(drafts, always(0.5), deltas: [4], ks: [1], players: ["A"])
+
+      assert result.n == 2
+      assert [%{observed: 0.5, mean_predicted: 0.5}] = result.buckets
+      assert result.error == 0.0
+    end
+  end
+
+  describe "leave-one-draft-out" do
+    test "each draft is scored by a model that never saw it" do
+      drafts = [draft(12.0, [{2.0, "A"}]), draft(12.0, [{3.0, "A"}]), draft(12.0, [{4.0, "A"}])]
+
+      seen =
+        Calibration.run(
+          drafts,
+          fn training ->
+            # Record how big the training set was, as the "probability".
+            fn _player, _from, _to -> length(training) / 10 end
+          end,
+          deltas: [1],
+          ks: [1],
+          players: ["A"]
+        )
+
+      # Three drafts, each scored against a training set of the other two.
+      assert seen.n == 3
+      assert [%{mean_predicted: mean}] = seen.buckets
+      assert_in_delta mean, 0.2, 0.0001
+    end
+  end
+
+  describe "bucketing" do
+    test "puts a certainty in the top bucket rather than one of its own" do
+      drafts = [draft(12.0, [{9.0, "A"}]), draft(12.0, [{9.0, "A"}])]
+
+      result = Calibration.run(drafts, always(1.0), deltas: [1], ks: [1], players: ["A"])
+
+      assert [%{bucket: 0.9}] = result.buckets
+    end
+
+    test "weights each bucket by how many observations landed in it" do
+      # Player A is asked about twice as often as B by using two ks for A.
+      drafts = [draft(12.0, [{9.0, "A"}]), draft(12.0, [{9.0, "A"}])]
+
+      result =
+        Calibration.run(
+          drafts,
+          fn _ -> fn _player, from, _to -> if from == 1, do: 1.0, else: 0.0 end end,
+          deltas: [1],
+          ks: [1, 2, 3],
+          players: ["A"]
+        )
+
+      # 2 observations predicted 1.0 (right), 4 predicted 0.0 (wrong).
+      assert result.n == 6
+      assert_in_delta result.error, 4 / 6 * 1.0, 0.0001
+    end
+  end
+
+  test "an empty corpus is 0 observations rather than a crash" do
+    assert %{n: 0, error: 0.0} = Calibration.run([], always(0.5))
+  end
+end

--- a/test/sleeper_player_api/intel/estimator_test.exs
+++ b/test/sleeper_player_api/intel/estimator_test.exs
@@ -495,4 +495,45 @@ defmodule SleeperPlayerApi.Intel.EstimatorTest do
       assert_in_delta adj_survival, 0.589, @tolerance
     end
   end
+
+  describe "base_hazard clamping" do
+    # A hazard is a probability, but `d(n) / r(n)` is not bounded by one: the
+    # numerator is smeared across neighbouring picks while the risk set is
+    # decremented hard at the unsmeared pick. Where a player is near-unanimous
+    # the risk set collapses faster than the density does.
+    #
+    # Found by running the calibration harness over the real corpus, not by a
+    # test: the consensus 1.01 came out with h = 2.824 at pick 2, so `1 - h`
+    # was negative and the survival product went to -0.488 — a negative
+    # percentage, at the top of a live draft board.
+    test "never exceeds 1.0, even where the density outruns the risk set" do
+      # Nineteen drafts take him immediately; one lets him fall. At pick 2 the
+      # risk set is that single draft, while the smeared mass of twenty events
+      # centred on 1.0 is still substantial.
+      drafts =
+        List.duplicate(%{l_d: 12.0, picks: [%{norm: 1.0, player_id: "X", manager: nil}]}, 19) ++
+          [%{l_d: 12.0, picks: [%{norm: 9.0, player_id: "X", manager: nil}]}]
+
+      hazard = Estimator.base_hazard(drafts, "X")
+
+      for {pick, h} <- hazard do
+        assert h <= 1.0, "hazard #{h} at pick #{pick} is not a probability"
+        assert h >= 0.0, "hazard #{h} at pick #{pick} is not a probability"
+      end
+    end
+
+    test "so survival stays a probability rather than going negative" do
+      drafts =
+        List.duplicate(%{l_d: 12.0, picks: [%{norm: 1.0, player_id: "X", manager: nil}]}, 19) ++
+          [%{l_d: 12.0, picks: [%{norm: 9.0, player_id: "X", manager: nil}]}]
+
+      hazard = Estimator.base_hazard(drafts, "X")
+
+      for from <- 1..11, to <- (from + 1)..12 do
+        s = Estimator.base_survival(hazard, from, to)
+        assert s >= 0.0, "survival #{s} from #{from} to #{to} is negative"
+        assert s <= 1.0, "survival #{s} from #{from} to #{to} exceeds 1"
+      end
+    end
+  end
 end

--- a/test/support/corpus_fixture.ex
+++ b/test/support/corpus_fixture.ex
@@ -1,0 +1,60 @@
+defmodule SleeperPlayerApi.CorpusFixture do
+  @moduledoc """
+  Loads the harvested rookie-draft corpus straight from
+  `test/support/corpus/*.json` into the plain map shape
+  `SleeperPlayerApi.Intel.Estimator` takes — no Repo, no Postgres, no seeding.
+
+  The estimator and `Intel.Calibration` are both pure, so measuring them does
+  not need a database; going through one would only add a fixed cost to every
+  leave-one-out pass. `Intel.drafts_corpus/2` remains the production path.
+
+  The corpus itself is gitignored (the repo is public and this is a
+  behavioural profile of thirteen real, named people — see the estimator
+  memory), so anything using this must be tagged `:corpus`.
+  """
+
+  @corpus_dir Path.expand("corpus", __DIR__)
+
+  @doc """
+  Every completed rookie draft as `%{l_d: float, picks: [%{norm, player_id,
+  manager}]}`.
+
+  `l_d` is the normalized **last pick actually made**, not `teams * rounds` —
+  that distinction is the whole of §3g's censoring fix, and it is what lets a
+  3-round draft stop voting on what happens at pick 39.
+  """
+  def drafts do
+    users = read!("lmusers.json")
+    manager_by_id = Map.new(users, &{&1["user_id"], &1["display_name"]})
+
+    picks_by_draft = read!("rookie_picks.json")
+
+    # Both corpus files are objects keyed by draft id, not arrays.
+    read!("rookie_drafts.json")
+    |> Map.values()
+    |> Enum.map(fn draft ->
+      teams = get_in(draft, ["settings", "teams"]) || 12
+      picks = Map.get(picks_by_draft, draft["draft_id"], [])
+      build(picks, teams, manager_by_id)
+    end)
+    |> Enum.reject(&(&1.picks == []))
+  end
+
+  defp build(picks, teams, manager_by_id) do
+    normalized =
+      Enum.map(picks, fn pick ->
+        %{
+          norm: normalize(pick["pick_no"], teams),
+          player_id: pick["player_id"],
+          manager: Map.get(manager_by_id, pick["picked_by"])
+        }
+      end)
+
+    last = normalized |> Enum.map(& &1.norm) |> Enum.max(fn -> 0.0 end)
+    %{l_d: last, picks: normalized}
+  end
+
+  defp normalize(pick_no, teams), do: (pick_no - 1) / teams * 12 + 1
+
+  defp read!(name), do: @corpus_dir |> Path.join(name) |> File.read!() |> Jason.decode!()
+end


### PR DESCRIPTION
§6 step 5 gates a manager-conditioned model on beating what already ships.
Nothing in either repo could produce that measurement — the harness behind the
plan's numbers was never saved, exactly as the estimator itself wasn't. The
gate was unmeasurable.

## The harness

`Intel.Calibration` runs leave-one-draft-out over the corpus and scores the
question the UI actually asks: *given he is on the board at k, is he there at
k+d?* Predictions bucket into deciles; each bucket's gap is weighted by its
size.

**It is the dangerous part, so it is unit-tested against hand-computed cases
rather than trusted.** §3g records an earlier version that scored "not in this
draft" as survived regardless of draft length — the same bias the estimator
had, so the two cancelled and the *naive* estimator scored better than the
corrected one. A wrong harness doesn't fail loudly; it blesses the wrong model.

Those tests earned their keep immediately: `went_at = Map.get(...)` inside a
comprehension reads as a binding but is a **filter on its value**, so every
player never drafted was silently dropped from the risk set.

## The live bug it found

`h(n) = d(n)/r(n)` is not bounded by 1. The numerator is smeared across
neighbouring picks while the risk set is decremented hard at the unsmeared
pick, so where a player is near-unanimous the risk set collapses faster than
the density does.

Exactly one (player, pick) pair in the 70-draft corpus does it: the consensus
1.01 at pick 2 — **h = 2.824**, survival **−0.488**. Narrow, but it's the top
of a live draft board and it renders as a negative percentage.

Clamped, with regression tests over both hazard and survival. **The clamp does
not move the golden fixture** — still 0.0 deviation across all 480 endpoint
values, because the affected player isn't among its targets.

## Note on the number

This harness scores the shipping estimator at **0.0019**, against the plan's
quoted 0.0296. That is *not* an improvement — it's a different metric. The
original's pick sampling, bucket edges and weighting are unknown, so the gate
for step 5 has to be relative: both models scored here, with identical
settings. The moduledoc says so explicitly.

## Safety

167 tests. Verified with the corpus removed (the deploy VM's condition, since
it's gitignored): **167 tests, 0 failures, 30 excluded** — the 11 pure harness
tests still run, the corpus-backed measurement is skipped, so the deploy gate
is unaffected.

Removing the clamp fails 2 tests; removing the censoring or conditioning rules
each fail their own cases.