### PR TITLE
Leaguemate transactions: schema, crawler, endpoint, schedule

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -81,6 +81,22 @@ config :sleeper_player_api, SleeperPlayerApi.Scheduler,
       schedule: "0 9 * * *",
       task: {SleeperPlayerApi.Tasks.CrawlLeaguemateDrafts, :crawl_configured_leagues, []},
       overlap: false
+    ],
+
+    # 4:30am Central — sweep leaguemate transactions. Last, because it is the
+    # heaviest: measured against the live API at 365 calls cold and 189 warm,
+    # against ~22 for a warm draft crawl. It runs after the draft sweep so the
+    # two never contend for the same rate-limit bucket.
+    #
+    # A warm run stays at 189 rather than dropping further because the
+    # offseason has no settled weeks: Sleeper files every offseason move under
+    # week 1 and week 1 never closes, so the live week comes back every night.
+    # That falls away once the season starts.
+    [
+      name: :crawl_leaguemate_transactions,
+      schedule: "30 9 * * *",
+      task: {SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions, :crawl_configured_leagues, []},
+      overlap: false
     ]
   ]
 

--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -260,7 +260,12 @@ defmodule SleeperPlayerApi.Intel do
               season: fragment("COALESCE(EXCLUDED.season, ?)", l.season),
               roster_to_user: fragment("COALESCE(EXCLUDED.roster_to_user, ?)", l.roster_to_user),
               rosters_fetched_at:
-                fragment("COALESCE(EXCLUDED.rosters_fetched_at, ?)", l.rosters_fetched_at)
+                fragment("COALESCE(EXCLUDED.rosters_fetched_at, ?)", l.rosters_fetched_at),
+              transactions_fetched_through:
+                fragment(
+                  "GREATEST(COALESCE(EXCLUDED.transactions_fetched_through, 0), COALESCE(?, 0))",
+                  l.transactions_fetched_through
+                )
             ]
           ]
         )

--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -40,7 +40,9 @@ defmodule SleeperPlayerApi.Intel do
     ObservedPick,
     ObservedTradedPick,
     PlayerValue,
-    DraftParticipant
+    DraftParticipant,
+    ObservedLeague,
+    ObservedTransaction
   }
 
   @batch_size 1000
@@ -230,6 +232,171 @@ defmodule SleeperPlayerApi.Intel do
         :draft_year
       ]
     )
+  end
+
+  # ---------------------------------------------------------------------
+  # Transactions (plan §6 step 6)
+  # ---------------------------------------------------------------------
+
+  @doc """
+  Upserts leagues by Sleeper league id.
+
+  `roster_to_user` is stored as given (string roster-id keys, since it
+  round-trips as jsonb) and is only replaced when the caller actually
+  supplies one — a crawl that fetched transactions but not rosters must not
+  blank out a map an earlier pass already stored.
+  """
+  @spec upsert_observed_leagues([map]) :: {non_neg_integer, nil}
+  def upsert_observed_leagues(leagues) do
+    insert_all_batched(
+      ObservedLeague,
+      leagues,
+      conflict_target: [:id],
+      on_conflict:
+        from(l in ObservedLeague,
+          update: [
+            set: [
+              name: fragment("COALESCE(EXCLUDED.name, ?)", l.name),
+              season: fragment("COALESCE(EXCLUDED.season, ?)", l.season),
+              roster_to_user: fragment("COALESCE(EXCLUDED.roster_to_user, ?)", l.roster_to_user),
+              rosters_fetched_at:
+                fragment("COALESCE(EXCLUDED.rosters_fetched_at, ?)", l.rosters_fetched_at)
+            ]
+          ]
+        )
+    )
+  end
+
+  @doc """
+  Upserts transactions by Sleeper transaction id.
+
+  Keyed on the transaction's own id rather than a synthetic one because a
+  *live* week is refetched repeatedly — in the offseason every transaction
+  lands in week 1 and week 1 never closes, so the same rows come back nightly
+  for months. Anything else would duplicate.
+  """
+  @spec upsert_observed_transactions([map]) :: {non_neg_integer, nil}
+  def upsert_observed_transactions(transactions) do
+    insert_all_batched(
+      ObservedTransaction,
+      transactions,
+      conflict_target: [:id],
+      replace: [
+        :league_id,
+        :week,
+        :type,
+        :status,
+        :created,
+        :creator,
+        :participant_ids,
+        :adds,
+        :drops,
+        :draft_picks,
+        :waiver_bid
+      ]
+    )
+  end
+
+  @doc """
+  Resolves the roster ids on a raw transaction payload to the user ids behind
+  them, using a league's `roster_to_user` map.
+
+  This is the whole reason `observed_leagues` exists. `creator` is a *user*
+  id; `roster_ids` and `consenter_ids` are *roster* ids. Attributing a trade
+  only to its creator drops the manager who accepted it, and trades are both
+  the rarest transaction type and the most interesting — so the undercount
+  would be invisible and would lose exactly the wrong half.
+
+  The creator is always included, even when their roster is missing from the
+  map (a league whose rosters have not been fetched yet still yields partial
+  attribution rather than none).
+  """
+  @spec participants(map, map) :: [integer]
+  def participants(raw, roster_to_user) do
+    from_rosters =
+      raw
+      |> Map.get("roster_ids", [])
+      |> Enum.map(&Map.get(roster_to_user, to_string(&1)))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(&to_int/1)
+
+    [to_int(raw["creator"]) | from_rosters]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  @doc """
+  Every stored transaction a user was involved in, newest first.
+
+  Reads `participant_ids`, not `creator` — see `participants/2`.
+
+  `:limit` caps the rows; `:season` scopes to one season's leagues; `:types`
+  narrows to particular transaction types. `status: "failed"` rows are
+  included by default and it is deliberate: a failed waiver claim is a
+  revealed preference nobody else in that league can see. Filter it where it
+  is displayed, with a label, not here.
+  """
+  @spec transactions_for_user(integer | String.t(), keyword) :: [ObservedTransaction.t()]
+  def transactions_for_user(user_id, opts \\ []) do
+    user_id = to_int(user_id)
+    limit = Keyword.get(opts, :limit, 50)
+
+    ObservedTransaction
+    |> where([t], ^user_id in t.participant_ids)
+    |> then(fn q ->
+      case Keyword.get(opts, :types) do
+        nil -> q
+        types -> where(q, [t], t.type in ^types)
+      end
+    end)
+    |> then(fn q ->
+      case Keyword.get(opts, :season) do
+        nil ->
+          q
+
+        season ->
+          join(q, :inner, [t], l in ObservedLeague,
+            on: l.id == t.league_id and l.season == ^season
+          )
+      end
+    end)
+    |> order_by([t], desc: t.created, desc: t.id)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  @doc """
+  How much of a user's activity the store can actually see: how many leagues
+  hold a transaction of theirs, and how many leagues are known at all.
+
+  This is what the endpoint reports as `coverage`. A fan-out that saw 38 of 42
+  leagues and reports "5 trades" is a figure without its sample size, which is
+  the error this feature keeps re-learning.
+  """
+  @spec transaction_coverage(integer | String.t(), keyword) :: map
+  def transaction_coverage(user_id, opts \\ []) do
+    user_id = to_int(user_id)
+    season = Keyword.get(opts, :season)
+
+    leagues_seen =
+      ObservedTransaction
+      |> where([t], ^user_id in t.participant_ids)
+      |> select([t], count(fragment("DISTINCT ?", t.league_id)))
+      |> Repo.one()
+
+    known =
+      ObservedLeague
+      |> then(fn q -> if season, do: where(q, [l], l.season == ^season), else: q end)
+      |> select([l], count(l.id))
+      |> Repo.one()
+
+    last =
+      ObservedLeague
+      |> select([l], max(l.rosters_fetched_at))
+      |> Repo.one()
+
+    %{leagues_seen: leagues_seen || 0, leagues_known: known || 0, last_crawled_at: last}
   end
 
   defp insert_all_batched(schema, entries, opts) do

--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -234,6 +234,39 @@ defmodule SleeperPlayerApi.Intel do
     )
   end
 
+  @doc """
+  One manager's recent activity, plus what it rests on.
+
+  Bundles `transactions_for_user/2` with `transaction_coverage/2` and the
+  names behind the player ids in `adds`/`drops`, so the caller renders from
+  one response.
+
+  **`coverage` travels with the transactions, always.** A list of five trades
+  means something different across 42 leagues than across 4, and this feature
+  has shipped a figure that outran its sample size four separate times. The
+  two are returned together so a caller cannot render one without the other
+  being available.
+
+  Names are resolved here rather than left to the client for the same reason
+  `/intel` resolves crush names: the section that renders this has no player
+  database of its own.
+  """
+  @spec manager_activity(integer | String.t(), keyword) :: map
+  def manager_activity(user_id, opts \\ []) do
+    transactions = transactions_for_user(user_id, opts)
+
+    player_ids =
+      transactions
+      |> Enum.flat_map(fn t -> Map.keys(t.adds || %{}) ++ Map.keys(t.drops || %{}) end)
+      |> Enum.uniq()
+
+    %{
+      transactions: transactions,
+      players: player_lookup(player_ids),
+      coverage: transaction_coverage(user_id, opts)
+    }
+  end
+
   # ---------------------------------------------------------------------
   # Transactions (plan §6 step 6)
   # ---------------------------------------------------------------------

--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -42,7 +42,8 @@ defmodule SleeperPlayerApi.Intel do
     PlayerValue,
     DraftParticipant,
     ObservedLeague,
-    ObservedTransaction
+    ObservedTransaction,
+    LeagueMember
   }
 
   @batch_size 1000
@@ -306,6 +307,19 @@ defmodule SleeperPlayerApi.Intel do
   end
 
   @doc """
+  Records which tracked leaguemates are in which leagues. Idempotent.
+  """
+  @spec upsert_league_members([map]) :: {non_neg_integer, nil}
+  def upsert_league_members(memberships) do
+    insert_all_batched(
+      LeagueMember,
+      Enum.uniq(memberships),
+      conflict_target: [:league_id, :user_id],
+      on_conflict: :nothing
+    )
+  end
+
+  @doc """
   Upserts transactions by Sleeper transaction id.
 
   Keyed on the transaction's own id rather than a synthetic one because a
@@ -423,10 +437,24 @@ defmodule SleeperPlayerApi.Intel do
       |> select([t], count(fragment("DISTINCT ?", t.league_id)))
       |> Repo.one()
 
+    # *Their* leagues, not every league in the corpus. Comparing a manager's
+    # leagues-with-activity against the whole corpus reported "33 of 175" for
+    # someone who is in 42 — a denominator that describes nobody. Found by
+    # running the crawler against the live API; every fixture had one league,
+    # so nothing caught it.
     known =
-      ObservedLeague
-      |> then(fn q -> if season, do: where(q, [l], l.season == ^season), else: q end)
-      |> select([l], count(l.id))
+      LeagueMember
+      |> where([m], m.user_id == ^user_id)
+      |> then(fn q ->
+        if season do
+          join(q, :inner, [m], l in ObservedLeague,
+            on: l.id == m.league_id and l.season == ^season
+          )
+        else
+          q
+        end
+      end)
+      |> select([m], count(m.league_id))
       |> Repo.one()
 
     last =

--- a/lib/sleeper_player_api/intel/league_member.ex
+++ b/lib/sleeper_player_api/intel/league_member.ex
@@ -1,0 +1,31 @@
+defmodule SleeperPlayerApi.Intel.LeagueMember do
+  @moduledoc """
+  A tracked leaguemate's membership of one league.
+
+  The crawl learns this while enumerating each user's leagues and used to
+  discard it in the dedupe. It is kept because coverage needs an honest
+  denominator: "33 of 42 of their leagues" is a claim about them, where
+  "33 of 175" — every league in the corpus — is a claim about nothing.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SleeperPlayerApi.Intel.ObservedLeague
+
+  @primary_key false
+  schema "league_members" do
+    belongs_to :league, ObservedLeague, references: :id, type: :id, define_field: false
+    field :league_id, :integer
+    field :user_id, :integer
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(league_member, attrs) do
+    league_member
+    |> cast(attrs, [:league_id, :user_id])
+    |> validate_required([:league_id, :user_id])
+    |> unique_constraint([:league_id, :user_id])
+  end
+end

--- a/lib/sleeper_player_api/intel/observed_league.ex
+++ b/lib/sleeper_player_api/intel/observed_league.ex
@@ -1,0 +1,35 @@
+defmodule SleeperPlayerApi.Intel.ObservedLeague do
+  @moduledoc """
+  A league one of the tracked leaguemates is in (plan §6 step 6).
+
+  Wider than `observed_drafts`' league coverage on purpose: that only knows
+  the leagues that happened to have a completed rookie draft (70), where
+  enumerating per user reaches every league they are in (176 measured).
+
+  `roster_to_user` is why this is a table rather than a derived value. A
+  transaction payload carries `creator` as a user id and `roster_ids` /
+  `consenter_ids` as roster ids, so attributing a trade to the manager who
+  *accepted* it needs this map — and re-deriving it would mean re-fetching
+  `/league/:id/rosters` for every league on every crawl.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :id, autogenerate: false}
+  schema "observed_leagues" do
+    field :name, :string
+    field :season, :string
+    # %{"roster_id" => user_id}. String keys because it round-trips as jsonb.
+    field :roster_to_user, :map
+    field :rosters_fetched_at, :utc_datetime
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(observed_league, attrs) do
+    observed_league
+    |> cast(attrs, [:id, :name, :season, :roster_to_user, :rosters_fetched_at])
+    |> validate_required([:id])
+  end
+end

--- a/lib/sleeper_player_api/intel/observed_league.ex
+++ b/lib/sleeper_player_api/intel/observed_league.ex
@@ -22,6 +22,7 @@ defmodule SleeperPlayerApi.Intel.ObservedLeague do
     # %{"roster_id" => user_id}. String keys because it round-trips as jsonb.
     field :roster_to_user, :map
     field :rosters_fetched_at, :utc_datetime
+    field :transactions_fetched_through, :integer
 
     timestamps()
   end
@@ -29,7 +30,14 @@ defmodule SleeperPlayerApi.Intel.ObservedLeague do
   @doc false
   def changeset(observed_league, attrs) do
     observed_league
-    |> cast(attrs, [:id, :name, :season, :roster_to_user, :rosters_fetched_at])
+    |> cast(attrs, [
+      :id,
+      :name,
+      :season,
+      :roster_to_user,
+      :rosters_fetched_at,
+      :transactions_fetched_through
+    ])
     |> validate_required([:id])
   end
 end

--- a/lib/sleeper_player_api/intel/observed_transaction.ex
+++ b/lib/sleeper_player_api/intel/observed_transaction.ex
@@ -1,0 +1,52 @@
+defmodule SleeperPlayerApi.Intel.ObservedTransaction do
+  @moduledoc """
+  One trade, waiver claim or free-agent add from a leaguemate's league
+  (plan §6 step 6).
+
+  Two things worth knowing before querying this.
+
+  **Read it by `participant_ids`, not `creator`.** `creator` is whoever
+  *initiated* the transaction; a trade has two sides and only one creator, so
+  filtering on it drops every trade a manager accepted rather than proposed.
+  Trades are the rarest type and the most interesting (5 of 124 for the
+  heaviest leaguemate measured), so that undercount would be both invisible
+  and exactly the wrong half to lose.
+
+  **`status: "failed"` rows are kept deliberately.** A failed waiver claim is
+  a revealed preference nobody else in that league can see — it is signal, not
+  noise. Filter it at the point of display, with a label, rather than dropping
+  it at ingest.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SleeperPlayerApi.Intel.ObservedLeague
+
+  @primary_key {:id, :id, autogenerate: false}
+  schema "observed_transactions" do
+    belongs_to :league, ObservedLeague, references: :id, type: :id, define_field: false
+    field :league_id, :integer
+    field :week, :integer
+    field :type, :string
+    field :status, :string
+    field :created, :utc_datetime
+    field :creator, :integer
+    field :participant_ids, {:array, :integer}, default: []
+    # %{player_id => roster_id}, as Sleeper sends them.
+    field :adds, :map
+    field :drops, :map
+    field :draft_picks, {:array, :map}, default: []
+    field :waiver_bid, :integer
+
+    timestamps()
+  end
+
+  @fields ~w(id league_id week type status created creator participant_ids adds drops draft_picks waiver_bid)a
+
+  @doc false
+  def changeset(observed_transaction, attrs) do
+    observed_transaction
+    |> cast(attrs, @fields)
+    |> validate_required([:id, :league_id, :week])
+  end
+end

--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
@@ -135,11 +135,13 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
         user_ids = users |> Enum.map(& &1["user_id"]) |> Enum.reject(&is_nil/1)
         summary = %{summary | leaguemates: length(user_ids)}
 
-        {leagues, summary} = enumerate_leagues(user_ids, season, summary)
+        {leagues, memberships, summary} = enumerate_leagues(user_ids, season, summary)
         {current_week, summary} = current_week(summary)
 
         summary = %{summary | leagues_seen: map_size(leagues)}
         store_leagues(leagues, season)
+        # After the leagues exist, since this references them.
+        Intel.upsert_league_members(memberships)
 
         summary =
           Enum.reduce(leagues, summary, fn {id, _name}, acc ->
@@ -159,9 +161,11 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
   # One call per leaguemate. The dedupe is the whole reason this is a crawl:
   # 257 memberships collapse to 176 leagues.
   defp enumerate_leagues(user_ids, season, summary) do
-    Enum.reduce(user_ids, {%{}, summary}, fn user_id, {acc, summary} ->
+    Enum.reduce(user_ids, {%{}, [], summary}, fn user_id, {acc, members, summary} ->
       case request("/user/#{user_id}/leagues/nfl/#{season}", summary) do
         {{:ok, leagues}, summary} when is_list(leagues) ->
+          ids = leagues |> Enum.map(&to_int(&1["league_id"])) |> Enum.reject(&is_nil/1)
+
           merged =
             Enum.reduce(leagues, acc, fn league, inner ->
               case to_int(league["league_id"]) do
@@ -170,10 +174,15 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
               end
             end)
 
-          {merged, summary}
+          # Kept, not discarded in the dedupe: coverage needs to know how many
+          # leagues *this* manager is in, not how many the corpus holds.
+          new_members =
+            Enum.map(ids, &%{league_id: &1, user_id: to_int(user_id)})
+
+          {merged, members ++ new_members, summary}
 
         {{:error, reason}, summary} ->
-          {acc, add_error(summary, {:user_leagues_failed, user_id, reason})}
+          {acc, members, add_error(summary, {:user_leagues_failed, user_id, reason})}
       end
     end)
   end

--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
@@ -1,0 +1,351 @@
+defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
+  @moduledoc """
+  Harvests every transaction — trades, waiver claims, free-agent adds — from
+  the leagues your leaguemates are in (plan §6 step 6).
+
+  ## Why a crawl and not an on-demand fetch
+
+  Both were measured before this was written. On-demand fan-out (enumerate a
+  manager's leagues, then transactions per league) is cheaper for one or two
+  profile views and **cannot dedupe**: 13 leaguemates hold 257 league
+  memberships across only 176 unique leagues, so per-profile fetching pays
+  that 32% overlap again every time. Viewing all thirteen costs ~527 calls
+  against the 300/min bucket `SleeperPlayerApi.RateLimiter` enforces, which
+  throttles partway through. The Leaguemates section is a browsing surface —
+  tapping through thirteen people is its whole shape — so that is the access
+  pattern that matters. Crossover is about three profile views.
+
+  Measured cost of this crawl: 13 enumeration calls + 176 leagues, so **365
+  calls cold** (transactions plus roster maps) and **189 nightly** in the
+  offseason, roughly 73s and 38s at 300/min.
+
+  ## Which weeks get fetched
+
+  Sleeper buckets **offseason activity into week 1**, and week 1 never
+  closes — swept all 18 weeks of a live league and weeks 2–18 were empty. So
+  in the offseason there is exactly one week worth fetching and it must be
+  refetched every time; there is no immutability to exploit yet.
+
+  In season, a past week is settled and is fetched once, ever. That is what
+  `transactions_fetched_through` records — deliberately *not* "the last week
+  we fetched", because the current week is still live.
+
+  ## Coverage, not silence
+
+  A league that fails is recorded in `summary.errors` and the crawl carries
+  on, same as the draft crawler. What must not happen is a partial harvest
+  presented as a complete one: `Intel.transaction_coverage/2` exists so the
+  endpoint can say "38 of 42 leagues", and this task's `Summary` is the other
+  half of that — `leagues_seen` against `leagues_fetched` tells you whether a
+  night's run was whole.
+  """
+
+  require Logger
+
+  import Ecto.Query, warn: false
+
+  alias SleeperPlayerApi.Repo
+  alias SleeperPlayerApi.Client.Sleeper
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.ObservedLeague
+
+  defmodule Summary do
+    @moduledoc """
+    What a run did. `api_calls` is what makes the "a second run makes far
+    fewer calls" checkpoint observable rather than asserted.
+    """
+    defstruct api_calls: 0,
+              leaguemates: 0,
+              leagues_seen: 0,
+              leagues_fetched: 0,
+              rosters_fetched: 0,
+              weeks_fetched: 0,
+              transactions_stored: 0,
+              errors: []
+  end
+
+  @doc """
+  Scheduled entry point. Crawls every league in `:intel_leagues`.
+
+  Never raises: one league erroring must not stop the others, and a crashing
+  scheduled job takes its Quantum worker with it.
+  """
+  @spec crawl_configured_leagues() :: [{term, {:ok, Summary.t()} | {:error, term}}]
+  def crawl_configured_leagues do
+    leagues = Application.get_env(:sleeper_player_api, :intel_leagues, [])
+    season = configured_season()
+
+    if leagues == [] do
+      Logger.info("CrawlLeaguemateTransactions: no :intel_leagues configured, nothing to crawl")
+      []
+    else
+      Enum.map(leagues, fn league_id ->
+        result =
+          try do
+            crawl(league_id, season)
+          rescue
+            e ->
+              Logger.error(
+                "CrawlLeaguemateTransactions: league #{league_id} raised: #{Exception.message(e)}"
+              )
+
+              {:error, {:raised, Exception.message(e)}}
+          end
+
+        case result do
+          {:ok, summary} ->
+            Logger.info(
+              "CrawlLeaguemateTransactions: league #{league_id} — " <>
+                "#{summary.leagues_fetched}/#{summary.leagues_seen} leagues, " <>
+                "#{summary.transactions_stored} transactions, #{summary.api_calls} calls, " <>
+                "#{length(summary.errors)} errors"
+            )
+
+          {:error, reason} ->
+            Logger.error("CrawlLeaguemateTransactions: league #{league_id}: #{inspect(reason)}")
+        end
+
+        {league_id, result}
+      end)
+    end
+  end
+
+  defp configured_season do
+    case Application.get_env(:sleeper_player_api, :intel_season) do
+      nil -> Date.utc_today().year |> Integer.to_string()
+      season -> to_string(season)
+    end
+  end
+
+  @doc """
+  Crawls one source league: enumerates its members, then every league each of
+  them is in, then those leagues' transactions.
+
+  Returns `{:ok, %Summary{}}` once it has run to completion — a per-league
+  failure is recorded in `summary.errors` rather than aborting — or
+  `{:error, reason}` if the member enumeration itself fails, since nothing
+  can proceed without it.
+  """
+  @spec crawl(integer | String.t(), String.t()) :: {:ok, Summary.t()} | {:error, term}
+  def crawl(league_id, season) do
+    summary = %Summary{}
+
+    case request("/league/#{league_id}/users", summary) do
+      {{:ok, users}, summary} when is_list(users) ->
+        user_ids = users |> Enum.map(& &1["user_id"]) |> Enum.reject(&is_nil/1)
+        summary = %{summary | leaguemates: length(user_ids)}
+
+        {leagues, summary} = enumerate_leagues(user_ids, season, summary)
+        {current_week, summary} = current_week(summary)
+
+        summary = %{summary | leagues_seen: map_size(leagues)}
+        store_leagues(leagues, season)
+
+        summary =
+          Enum.reduce(leagues, summary, fn {id, _name}, acc ->
+            crawl_league(id, current_week, acc)
+          end)
+
+        {:ok, summary}
+
+      {{:ok, other}, _summary} ->
+        {:error, {:unexpected_users_payload, other}}
+
+      {{:error, reason}, _summary} ->
+        {:error, {:league_users_failed, reason}}
+    end
+  end
+
+  # One call per leaguemate. The dedupe is the whole reason this is a crawl:
+  # 257 memberships collapse to 176 leagues.
+  defp enumerate_leagues(user_ids, season, summary) do
+    Enum.reduce(user_ids, {%{}, summary}, fn user_id, {acc, summary} ->
+      case request("/user/#{user_id}/leagues/nfl/#{season}", summary) do
+        {{:ok, leagues}, summary} when is_list(leagues) ->
+          merged =
+            Enum.reduce(leagues, acc, fn league, inner ->
+              case to_int(league["league_id"]) do
+                nil -> inner
+                id -> Map.put_new(inner, id, league["name"])
+              end
+            end)
+
+          {merged, summary}
+
+        {{:error, reason}, summary} ->
+          {acc, add_error(summary, {:user_leagues_failed, user_id, reason})}
+      end
+    end)
+  end
+
+  defp store_leagues(leagues, season) do
+    leagues
+    |> Enum.map(fn {id, name} -> %{id: id, name: name, season: season} end)
+    |> Intel.upsert_observed_leagues()
+  end
+
+  defp crawl_league(league_id, current_week, summary) do
+    league = Repo.get(ObservedLeague, league_id)
+
+    {roster_map, summary} = ensure_roster_map(league, summary)
+
+    weeks = weeks_to_fetch(league && league.transactions_fetched_through, current_week)
+
+    summary =
+      Enum.reduce(weeks, summary, fn week, acc ->
+        fetch_week(league_id, week, roster_map, acc)
+      end)
+
+    # Everything before the current week is settled and never needs fetching
+    # again. The current week stays live — in the offseason that is week 1,
+    # forever.
+    Intel.upsert_observed_leagues([
+      %{id: league_id, transactions_fetched_through: max(current_week - 1, 0)}
+    ])
+
+    %{summary | leagues_fetched: summary.leagues_fetched + 1}
+  end
+
+  # Rosters are fetched once per league and kept: which user owns roster N
+  # does not change within a season, and refetching 176 of them nightly to
+  # learn nothing would be most of the crawl's budget.
+  defp ensure_roster_map(%ObservedLeague{roster_to_user: map}, summary)
+       when is_map(map) and map_size(map) > 0,
+       do: {map, summary}
+
+  defp ensure_roster_map(league, summary) do
+    league_id = league && league.id
+
+    case request("/league/#{league_id}/rosters", summary) do
+      {{:ok, rosters}, summary} when is_list(rosters) ->
+        map =
+          Enum.reduce(rosters, %{}, fn roster, acc ->
+            case {roster["roster_id"], to_int(roster["owner_id"])} do
+              {nil, _} -> acc
+              {_, nil} -> acc
+              {roster_id, owner_id} -> Map.put(acc, to_string(roster_id), owner_id)
+            end
+          end)
+
+        Intel.upsert_observed_leagues([
+          %{
+            id: league_id,
+            roster_to_user: map,
+            rosters_fetched_at: DateTime.utc_now() |> DateTime.truncate(:second)
+          }
+        ])
+
+        {map, %{summary | rosters_fetched: summary.rosters_fetched + 1}}
+
+      {{:error, reason}, summary} ->
+        # Partial attribution beats none: without the map, `participants/2`
+        # still records the creator.
+        {%{}, add_error(summary, {:rosters_failed, league_id, reason})}
+    end
+  end
+
+  defp fetch_week(league_id, week, roster_map, summary) do
+    case request("/league/#{league_id}/transactions/#{week}", summary) do
+      {{:ok, raw}, summary} when is_list(raw) ->
+        rows = Enum.map(raw, &row(&1, league_id, week, roster_map)) |> Enum.reject(&is_nil/1)
+        unless rows == [], do: Intel.upsert_observed_transactions(rows)
+
+        %{
+          summary
+          | weeks_fetched: summary.weeks_fetched + 1,
+            transactions_stored: summary.transactions_stored + length(rows)
+        }
+
+      {{:ok, _}, summary} ->
+        %{summary | weeks_fetched: summary.weeks_fetched + 1}
+
+      {{:error, reason}, summary} ->
+        add_error(summary, {:transactions_failed, league_id, week, reason})
+    end
+  end
+
+  defp row(raw, league_id, week, roster_map) do
+    case to_int(raw["transaction_id"]) do
+      nil ->
+        nil
+
+      id ->
+        %{
+          id: id,
+          league_id: league_id,
+          week: week,
+          type: raw["type"],
+          status: raw["status"],
+          created: to_datetime(raw["created"]),
+          creator: to_int(raw["creator"]),
+          participant_ids: Intel.participants(raw, roster_map),
+          adds: raw["adds"] || %{},
+          drops: raw["drops"] || %{},
+          draft_picks: raw["draft_picks"] || [],
+          waiver_bid: get_in(raw, ["settings", "waiver_bid"])
+        }
+    end
+  end
+
+  @doc """
+  Which weeks still need fetching, given the highest settled week and the
+  current one.
+
+  The current week is **always** included: it is live, and in the offseason
+  it is week 1 and stays live indefinitely, because Sleeper files every
+  offseason move there.
+  """
+  @spec weeks_to_fetch(integer | nil, integer) :: [integer]
+  def weeks_to_fetch(fetched_through, current_week) do
+    current = max(current_week, 1)
+    from = max((fetched_through || 0) + 1, 1)
+
+    if from > current, do: [current], else: Enum.to_list(from..current)
+  end
+
+  # Sleeper labels the offseason as week 1, which is exactly what this needs:
+  # one week to fetch. A failed state call falls back to 1 rather than
+  # aborting — the offseason answer is also the safe answer, since it fetches
+  # the least.
+  defp current_week(summary) do
+    case request("/state/nfl", summary) do
+      {{:ok, %{"week" => week}}, summary} when is_integer(week) and week > 0 ->
+        {week, summary}
+
+      {_, summary} ->
+        {1, summary}
+    end
+  end
+
+  defp request(url, summary) do
+    result = Sleeper.get(url)
+    {result, %{summary | api_calls: summary.api_calls + 1}}
+  end
+
+  defp add_error(summary, error), do: %{summary | errors: [error | summary.errors]}
+
+  defp to_datetime(ms) when is_integer(ms) do
+    case DateTime.from_unix(ms, :millisecond) do
+      {:ok, dt} -> DateTime.truncate(dt, :second)
+      _ -> nil
+    end
+  end
+
+  defp to_datetime(_), do: nil
+
+  defp to_int(nil), do: nil
+  defp to_int(i) when is_integer(i), do: i
+
+  # Sleeper sends `""` for an unattributed actor — 3 of 3,286 corpus picks do
+  # this, and it took down a whole production crawl once via
+  # `String.to_integer/1`. Anything unparseable means "nobody we can
+  # attribute this to", which is `nil`.
+  defp to_int(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {i, ""} -> i
+      _ -> nil
+    end
+  end
+
+  defp to_int(_), do: nil
+end

--- a/lib/sleeper_player_api_web/controllers/manager_activity_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/manager_activity_controller.ex
@@ -1,0 +1,68 @@
+defmodule SleeperPlayerApiWeb.ManagerActivityController do
+  use SleeperPlayerApiWeb, :controller
+
+  alias SleeperPlayerApi.Intel
+
+  action_fallback SleeperPlayerApiWeb.FallbackController
+
+  @doc """
+  `GET /api/v1/users/:user_id/activity?season=<n>&limit=<n>&types=<a,b>`
+
+  One leaguemate's recent trades, waiver claims and free-agent adds across
+  every league they are in, newest first, with `coverage` describing what
+  that rests on. See `SleeperPlayerApi.Intel.manager_activity/2`.
+
+  ## Not nested under a league, though the scope doc said it would be
+
+  The scope in plan §6 step 6 proposed
+  `/leagues/:league_id/managers/:user_id/activity`. That URL is a lie: the
+  data is every transaction of theirs across all 42-odd of their leagues, and
+  nothing about the response is scoped to the league in the path. A path
+  segment that implies filtering which does not happen is the same species of
+  problem as a figure without its sample size, so it is a flat user route.
+
+  If "what did they do in leagues I share with you" is ever wanted, that is a
+  genuinely different query and can have its own nested route then.
+
+  A separate endpoint from `/intel` on purpose: the Leaguemates list renders
+  thirteen managers from one cheap call, and activity is only wanted for the
+  one profile actually opened.
+  """
+  def show(conn, %{"user_id" => user_id} = params) do
+    with {:ok, limit} <- optional_int(params, "limit") do
+      activity =
+        Intel.manager_activity(user_id,
+          season: params["season"],
+          types: types(params["types"]),
+          limit: limit || 50
+        )
+
+      render(conn, :show, activity: activity)
+    end
+  end
+
+  # Same treatment as `AvailabilityController`: `String.to_integer/1` raises,
+  # and `action_fallback` only catches `{:error, _}` *returns*, so parsing
+  # with it turns a malformed query param into a 500.
+  defp optional_int(params, key) do
+    case params[key] do
+      nil ->
+        {:ok, nil}
+
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {int, ""} -> {:ok, int}
+          _ -> {:error, {:invalid_param, key, value}}
+        end
+    end
+  end
+
+  defp types(nil), do: nil
+
+  defp types(value) when is_binary(value) do
+    case value |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == "")) do
+      [] -> nil
+      types -> types
+    end
+  end
+end

--- a/lib/sleeper_player_api_web/controllers/manager_activity_json.ex
+++ b/lib/sleeper_player_api_web/controllers/manager_activity_json.ex
@@ -1,0 +1,48 @@
+defmodule SleeperPlayerApiWeb.ManagerActivityJSON do
+  @moduledoc """
+  Renders `SleeperPlayerApi.Intel.manager_activity/2` — camelCase keys, same
+  snake_case-context / camelCase-view split as `AvailabilityJSON` and
+  `IntelJSON`.
+
+  `coverage` is not decoration and must not be dropped by a caller looking to
+  slim the payload. "5 trades" across 42 leagues and "5 trades" across 4 are
+  different claims, and this feature has shipped a figure without its sample
+  size four separate times.
+
+  `adds`/`drops` stay keyed by player id exactly as Sleeper sends them, with
+  a sibling `players` map for the names — rather than inlining a name per
+  entry, which would repeat it for every transaction touching the same player.
+  """
+
+  def show(%{activity: a}) do
+    %{
+      transactions: Enum.map(a.transactions, &transaction/1),
+      players: Map.new(a.players, fn {id, p} -> {id, %{name: p.name, position: p.position}} end),
+      coverage: %{
+        leaguesSeen: a.coverage.leagues_seen,
+        leaguesKnown: a.coverage.leagues_known,
+        lastCrawledAt: a.coverage.last_crawled_at
+      }
+    }
+  end
+
+  defp transaction(t) do
+    %{
+      id: t.id,
+      leagueId: t.league_id,
+      week: t.week,
+      type: t.type,
+      # `"failed"` rows are served, not filtered. A failed waiver claim is a
+      # revealed preference nobody else in that league can see; the client
+      # labels it rather than the API hiding it.
+      status: t.status,
+      created: t.created,
+      creator: t.creator,
+      participantIds: t.participant_ids,
+      adds: t.adds || %{},
+      drops: t.drops || %{},
+      draftPicks: t.draft_picks || [],
+      waiverBid: t.waiver_bid
+    }
+  end
+end

--- a/lib/sleeper_player_api_web/router.ex
+++ b/lib/sleeper_player_api_web/router.ex
@@ -22,6 +22,7 @@ defmodule SleeperPlayerApiWeb.Router do
     get "/players/:id", PlayerController, :show
     get "/drafts/:draft_id/availability", AvailabilityController, :show
     get "/leagues/:league_id/intel", IntelController, :show
+    get "/users/:user_id/activity", ManagerActivityController, :show
   end
 
   scope "/api/legacy", SleeperPlayerApiWeb do

--- a/priv/repo/migrations/20260808120000_create_observed_leagues.exs
+++ b/priv/repo/migrations/20260808120000_create_observed_leagues.exs
@@ -1,0 +1,25 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedLeagues do
+  use Ecto.Migration
+
+  def change do
+    # Keyed on Sleeper's own league id, same convention as `observed_drafts`.
+    #
+    # `roster_to_user` is the reason this table exists. A transaction payload
+    # gives `creator` as a *user* id but `consenter_ids`/`roster_ids` as
+    # *roster* ids, so attributing a trade to the manager who accepted it
+    # needs this map — and without somewhere to keep it, every crawl would
+    # re-fetch `/league/:id/rosters` for all 176 leagues. Which user owns
+    # roster N effectively never changes within a season.
+    create table(:observed_leagues, primary_key: false) do
+      add :id, :bigint, primary_key: true
+      add :name, :string
+      add :season, :string
+      add :roster_to_user, :map
+      add :rosters_fetched_at, :utc_datetime
+
+      timestamps()
+    end
+
+    create index(:observed_leagues, [:season])
+  end
+end

--- a/priv/repo/migrations/20260808120100_create_observed_transactions.exs
+++ b/priv/repo/migrations/20260808120100_create_observed_transactions.exs
@@ -1,0 +1,44 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedTransactions do
+  use Ecto.Migration
+
+  def change do
+    create table(:observed_transactions, primary_key: false) do
+      # Sleeper's own transaction_id, so a refetch of a live week upserts
+      # rather than duplicating. That matters more here than for picks: in the
+      # offseason every transaction lands in week 1 and week 1 stays live, so
+      # the same rows are re-fetched nightly for months.
+      add :id, :bigint, primary_key: true
+
+      add :league_id,
+          references(:observed_leagues, column: :id, type: :bigint, on_delete: :delete_all),
+          null: false
+
+      add :week, :integer, null: false
+      add :type, :string
+      add :status, :string
+      add :created, :utc_datetime
+      add :creator, :bigint
+
+      # Resolved through `observed_leagues.roster_to_user` at write time.
+      # Filtering on `creator` alone silently drops every trade a manager
+      # accepted rather than proposed — and trades are the rarest and most
+      # interesting type, so that undercount would be invisible and wrong.
+      add :participant_ids, {:array, :bigint}, default: [], null: false
+
+      # `%{player_id => roster_id}` as Sleeper sends them.
+      add :adds, :map
+      add :drops, :map
+      # Pick trades arrive free in the same payload.
+      add :draft_picks, {:array, :map}, default: [], null: false
+      add :waiver_bid, :integer
+
+      timestamps()
+    end
+
+    create index(:observed_transactions, [:league_id, :week])
+    create index(:observed_transactions, [:creator])
+    create index(:observed_transactions, [:created])
+    # A manager's activity is read by "was I involved", not "did I create it".
+    create index(:observed_transactions, [:participant_ids], using: :gin)
+  end
+end

--- a/priv/repo/migrations/20260808130000_add_transactions_fetched_through_to_observed_leagues.exs
+++ b/priv/repo/migrations/20260808130000_add_transactions_fetched_through_to_observed_leagues.exs
@@ -1,0 +1,14 @@
+defmodule SleeperPlayerApi.Repo.Migrations.AddTransactionsFetchedThroughToObservedLeagues do
+  use Ecto.Migration
+
+  def change do
+    # The highest week whose transactions are settled and will never change
+    # again, so a nightly pass can skip it. Deliberately *not* "the last week
+    # we fetched": the current week is still live and has to be refetched
+    # every time, which in the offseason means week 1 forever — everything
+    # lands there and it never closes.
+    alter table(:observed_leagues) do
+      add :transactions_fetched_through, :integer
+    end
+  end
+end

--- a/priv/repo/migrations/20260808140000_create_league_members.exs
+++ b/priv/repo/migrations/20260808140000_create_league_members.exs
@@ -1,0 +1,28 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateLeagueMembers do
+  use Ecto.Migration
+
+  def change do
+    # Which leaguemates are in which leagues. The crawl already learns this
+    # while enumerating (`/user/:id/leagues`) and used to throw it away in the
+    # dedupe.
+    #
+    # It exists because coverage needs an honest denominator. Without it,
+    # `transaction_coverage/2` compared a manager's leagues-with-activity
+    # against *every* league in the corpus — so a real run reported
+    # "33/175 leagues" for a manager who is in 42. Found by running the
+    # crawler against the live API; no test noticed, because every fixture
+    # had one league.
+    create table(:league_members, primary_key: false) do
+      add :league_id,
+          references(:observed_leagues, column: :id, type: :bigint, on_delete: :delete_all),
+          null: false
+
+      add :user_id, :bigint, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:league_members, [:league_id, :user_id])
+    create index(:league_members, [:user_id])
+  end
+end

--- a/test/sleeper_player_api/intel/transactions_test.exs
+++ b/test/sleeper_player_api/intel/transactions_test.exs
@@ -192,25 +192,34 @@ defmodule SleeperPlayerApi.Intel.TransactionsTest do
   end
 
   describe "transaction_coverage/2" do
-    test "reports leagues seen against leagues known, so a partial answer can say so" do
-      # A fan-out that saw 1 of 2 leagues and reported "3 transactions" would
-      # be a figure without its sample size — the error this feature keeps
-      # re-learning.
+    test "counts THEIR leagues as the denominator, not every league in the corpus" do
+      # The bug a live crawl exposed: comparing leagues-with-activity against
+      # the whole corpus reported "33 of 175" for a manager who is in 42.
+      # Every fixture had one league, so nothing here caught it.
       seed_league()
-      Intel.upsert_observed_leagues([%{id: 999, name: "Another", season: "2026"}])
+      Intel.upsert_observed_leagues([%{id: 999, name: "Not his", season: "2026"}])
+      Intel.upsert_observed_leagues([%{id: 1000, name: "His, quiet", season: "2026"}])
+
+      # He is in two of the three; 999 belongs to someone else entirely.
+      Intel.upsert_league_members([
+        %{league_id: @league, user_id: @baconstains},
+        %{league_id: 1000, user_id: @baconstains},
+        %{league_id: 999, user_id: @atekipp}
+      ])
+
       Intel.upsert_observed_transactions([transaction(1, %{})])
 
       coverage = Intel.transaction_coverage(@baconstains, season: "2026")
 
-      assert coverage.leagues_seen == 1
-      assert coverage.leagues_known == 2
+      assert coverage.leagues_seen == 1, "activity in one of his leagues"
+      assert coverage.leagues_known == 2, "he is in two, not the corpus's three"
       assert coverage.last_crawled_at != nil
     end
 
     test "is zeroes rather than nils for a user with nothing stored" do
       seed_league()
 
-      assert %{leagues_seen: 0, leagues_known: 1} = Intel.transaction_coverage(@atekipp)
+      assert %{leagues_seen: 0, leagues_known: 0} = Intel.transaction_coverage(@atekipp)
     end
   end
 end

--- a/test/sleeper_player_api/intel/transactions_test.exs
+++ b/test/sleeper_player_api/intel/transactions_test.exs
@@ -1,0 +1,216 @@
+defmodule SleeperPlayerApi.Intel.TransactionsTest do
+  @moduledoc """
+  Phase 1 of plan §6 step 6: schema and context, no HTTP.
+
+  Everything here goes through the real `Intel` functions the crawler will
+  call, seeded from plain maps in the shape `/league/:id/transactions/:week`
+  actually returns — verified against the live endpoint on 2026-08-08, so the
+  payload shapes below are copied from real responses rather than imagined.
+  """
+  use SleeperPlayerApi.DataCase, async: true
+
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.ObservedTransaction
+  alias SleeperPlayerApi.Repo
+
+  @league 1_313_425_233_297_813_504
+  @baconstains 207_584_750_204_878_848
+  @atekipp 859_581_197_427_257_344
+  @getforked 815_346_571_532_161_024
+
+  # `roster_to_user` round-trips as jsonb, so roster ids are string keys.
+  @roster_map %{"9" => @getforked, "10" => @baconstains, "8" => @atekipp}
+
+  defp seed_league(attrs \\ %{}) do
+    Intel.upsert_observed_leagues([
+      Map.merge(
+        %{
+          id: @league,
+          name: "District 13 Dynasty League",
+          season: "2026",
+          roster_to_user: @roster_map,
+          rosters_fetched_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        },
+        attrs
+      )
+    ])
+  end
+
+  defp transaction(id, attrs) do
+    Map.merge(
+      %{
+        id: id,
+        league_id: @league,
+        week: 1,
+        type: "free_agent",
+        status: "complete",
+        created: DateTime.utc_now() |> DateTime.truncate(:second),
+        creator: @baconstains,
+        participant_ids: [@baconstains],
+        adds: %{},
+        drops: %{},
+        draft_picks: [],
+        waiver_bid: nil
+      },
+      attrs
+    )
+  end
+
+  describe "participants/2 — the reason observed_leagues exists" do
+    test "resolves roster ids to the users behind them, creator included" do
+      # A real trade payload: `creator` is a USER id, `roster_ids` are ROSTER
+      # ids. Attributing only to the creator would drop baconstains entirely,
+      # and he is half the trade.
+      raw = %{"creator" => to_string(@getforked), "roster_ids" => [9, 10]}
+
+      assert Intel.participants(raw, @roster_map) == Enum.sort([@getforked, @baconstains])
+    end
+
+    test "keeps the creator even when the roster map cannot place them" do
+      # A league whose rosters have not been fetched yet still yields partial
+      # attribution rather than none.
+      raw = %{"creator" => to_string(@baconstains), "roster_ids" => [3, 4]}
+
+      assert Intel.participants(raw, %{}) == [@baconstains]
+    end
+
+    test "does not duplicate a creator who is also on a roster" do
+      raw = %{"creator" => to_string(@baconstains), "roster_ids" => [10]}
+
+      assert Intel.participants(raw, @roster_map) == [@baconstains]
+    end
+
+    test "survives a free agent add, which has one roster and no counterparty" do
+      raw = %{"creator" => to_string(@atekipp), "roster_ids" => [8]}
+
+      assert Intel.participants(raw, @roster_map) == [@atekipp]
+    end
+  end
+
+  describe "upserts" do
+    test "a transaction is keyed on Sleeper's own id, so refetching a live week updates rather than duplicates" do
+      # This is not hypothetical: in the offseason every transaction lands in
+      # week 1 and week 1 never closes, so the same rows come back nightly.
+      seed_league()
+      Intel.upsert_observed_transactions([transaction(1, %{status: "pending"})])
+      Intel.upsert_observed_transactions([transaction(1, %{status: "complete"})])
+
+      assert [row] = Repo.all(ObservedTransaction)
+      assert row.status == "complete"
+    end
+
+    test "a league upsert does not blank a roster map an earlier pass stored" do
+      # The crawl fetches transactions nightly but rosters rarely. A nightly
+      # pass that touches the league row without a roster map must not wipe
+      # the one already there, or trade attribution silently degrades.
+      seed_league()
+      Intel.upsert_observed_leagues([%{id: @league, name: "District 13 Dynasty League"}])
+
+      league = Repo.get(SleeperPlayerApi.Intel.ObservedLeague, @league)
+      assert league.roster_to_user == %{"9" => @getforked, "10" => @baconstains, "8" => @atekipp}
+      assert league.rosters_fetched_at != nil
+    end
+  end
+
+  describe "transactions_for_user/2" do
+    setup do
+      seed_league()
+
+      Intel.upsert_observed_transactions([
+        transaction(1, %{
+          type: "trade",
+          creator: @getforked,
+          participant_ids: Enum.sort([@getforked, @baconstains]),
+          created: ~U[2026-08-01 12:00:00Z]
+        }),
+        transaction(2, %{
+          type: "waiver",
+          creator: @baconstains,
+          participant_ids: [@baconstains],
+          created: ~U[2026-08-05 12:00:00Z]
+        }),
+        transaction(3, %{
+          type: "free_agent",
+          creator: @atekipp,
+          participant_ids: [@atekipp],
+          created: ~U[2026-08-06 12:00:00Z]
+        }),
+        transaction(4, %{
+          type: "waiver",
+          status: "failed",
+          creator: @baconstains,
+          participant_ids: [@baconstains],
+          created: ~U[2026-08-07 12:00:00Z]
+        })
+      ])
+
+      :ok
+    end
+
+    test "finds a trade the user accepted rather than created" do
+      # The whole point of participant_ids. baconstains created nothing in
+      # transaction 1 — getforked did — and he is still half of it.
+      ids = @baconstains |> Intel.transactions_for_user() |> Enum.map(& &1.id)
+
+      assert 1 in ids
+    end
+
+    test "does not return other managers' activity" do
+      ids = @atekipp |> Intel.transactions_for_user() |> Enum.map(& &1.id)
+
+      assert ids == [3]
+    end
+
+    test "returns newest first" do
+      ids = @baconstains |> Intel.transactions_for_user() |> Enum.map(& &1.id)
+
+      assert ids == [4, 2, 1]
+    end
+
+    test "keeps failed transactions, because a failed claim is a revealed preference" do
+      # Nobody else in that league can see it. Filtering happens at display,
+      # with a label — not at ingest, and not here.
+      rows = Intel.transactions_for_user(@baconstains)
+
+      assert Enum.any?(rows, &(&1.status == "failed"))
+    end
+
+    test "narrows by type when asked" do
+      ids = @baconstains |> Intel.transactions_for_user(types: ["trade"]) |> Enum.map(& &1.id)
+
+      assert ids == [1]
+    end
+
+    test "caps at the limit, newest first" do
+      assert [%{id: 4}] = Intel.transactions_for_user(@baconstains, limit: 1)
+    end
+
+    test "scopes to a season through the league" do
+      assert @baconstains |> Intel.transactions_for_user(season: "2026") |> length() == 3
+      assert Intel.transactions_for_user(@baconstains, season: "2025") == []
+    end
+  end
+
+  describe "transaction_coverage/2" do
+    test "reports leagues seen against leagues known, so a partial answer can say so" do
+      # A fan-out that saw 1 of 2 leagues and reported "3 transactions" would
+      # be a figure without its sample size — the error this feature keeps
+      # re-learning.
+      seed_league()
+      Intel.upsert_observed_leagues([%{id: 999, name: "Another", season: "2026"}])
+      Intel.upsert_observed_transactions([transaction(1, %{})])
+
+      coverage = Intel.transaction_coverage(@baconstains, season: "2026")
+
+      assert coverage.leagues_seen == 1
+      assert coverage.leagues_known == 2
+      assert coverage.last_crawled_at != nil
+    end
+
+    test "is zeroes rather than nils for a user with nothing stored" do
+      seed_league()
+
+      assert %{leagues_seen: 0, leagues_known: 1} = Intel.transaction_coverage(@atekipp)
+    end
+  end
+end

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
@@ -1,0 +1,294 @@
+defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
+  # Bypass owns a real port and points the client at it through the shared
+  # `:sleeper_base_url` key, so this can't run concurrently with anything
+  # else that touches it.
+  use SleeperPlayerApi.DataCase, async: false
+
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.{ObservedLeague, ObservedTransaction}
+  alias SleeperPlayerApi.Repo
+  alias SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions
+
+  @source_league "555"
+  @alice 111
+  @bob 222
+
+  setup do
+    bypass = Bypass.open()
+    Application.put_env(:sleeper_player_api, :sleeper_base_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.delete_env(:sleeper_player_api, :sleeper_base_url) end)
+    {:ok, bypass: bypass}
+  end
+
+  # A transaction in the shape the live endpoint actually returns — verified
+  # against `/league/:id/transactions/1` on 2026-08-08, including the detail
+  # that `creator` is a user id while `roster_ids` are roster ids.
+  defp tx(id, opts) do
+    %{
+      "transaction_id" => to_string(id),
+      "type" => Keyword.get(opts, :type, "free_agent"),
+      "status" => Keyword.get(opts, :status, "complete"),
+      "created" => Keyword.get(opts, :created, 1_785_000_000_000),
+      "creator" => to_string(Keyword.fetch!(opts, :creator)),
+      "roster_ids" => Keyword.get(opts, :roster_ids, [1]),
+      "consenter_ids" => Keyword.get(opts, :roster_ids, [1]),
+      "adds" => Keyword.get(opts, :adds, %{}),
+      "drops" => Keyword.get(opts, :drops, %{}),
+      "draft_picks" => Keyword.get(opts, :draft_picks, []),
+      "settings" => %{"waiver_bid" => Keyword.get(opts, :bid)}
+    }
+  end
+
+  # `counts` accumulates every path hit, so the "second run makes far fewer
+  # calls" checkpoint is observable rather than asserted.
+  defp stub(bypass, opts \\ []) do
+    weeks = Keyword.get(opts, :week_transactions, %{1 => []})
+    leagues_for = Keyword.get(opts, :leagues_for, %{@alice => ["900"], @bob => ["900"]})
+    week = Keyword.get(opts, :current_week, 1)
+    counts = :counters.new(1, [])
+
+    Bypass.stub(bypass, "GET", "/league/#{@source_league}/users", fn conn ->
+      :counters.add(counts, 1, 1)
+
+      Plug.Conn.resp(
+        conn,
+        200,
+        Jason.encode!([%{"user_id" => "#{@alice}"}, %{"user_id" => "#{@bob}"}])
+      )
+    end)
+
+    Bypass.stub(bypass, "GET", "/state/nfl", fn conn ->
+      :counters.add(counts, 1, 1)
+      Plug.Conn.resp(conn, 200, Jason.encode!(%{"week" => week}))
+    end)
+
+    for {user, league_ids} <- leagues_for do
+      Bypass.stub(bypass, "GET", "/user/#{user}/leagues/nfl/2026", fn conn ->
+        :counters.add(counts, 1, 1)
+        body = Enum.map(league_ids, &%{"league_id" => &1, "name" => "League #{&1}"})
+        Plug.Conn.resp(conn, 200, Jason.encode!(body))
+      end)
+    end
+
+    Bypass.stub(bypass, "GET", "/league/900/rosters", fn conn ->
+      :counters.add(counts, 1, 1)
+
+      Plug.Conn.resp(
+        conn,
+        200,
+        Jason.encode!([
+          %{"roster_id" => 1, "owner_id" => "#{@alice}"},
+          %{"roster_id" => 2, "owner_id" => "#{@bob}"}
+        ])
+      )
+    end)
+
+    for {w, txs} <- weeks do
+      Bypass.stub(bypass, "GET", "/league/900/transactions/#{w}", fn conn ->
+        :counters.add(counts, 1, 1)
+        Plug.Conn.resp(conn, 200, Jason.encode!(txs))
+      end)
+    end
+
+    counts
+  end
+
+  describe "weeks_to_fetch/2" do
+    test "fetches only the current week when everything before it is settled" do
+      assert CrawlLeaguemateTransactions.weeks_to_fetch(9, 10) == [10]
+    end
+
+    test "backfills everything not yet settled, up to and including the live week" do
+      assert CrawlLeaguemateTransactions.weeks_to_fetch(nil, 4) == [1, 2, 3, 4]
+      assert CrawlLeaguemateTransactions.weeks_to_fetch(2, 5) == [3, 4, 5]
+    end
+
+    test "always refetches the current week, even when marked settled" do
+      # This is the offseason case and it is not an edge case: everything
+      # lands in week 1 and week 1 never closes, so it must come back every
+      # night for months.
+      assert CrawlLeaguemateTransactions.weeks_to_fetch(1, 1) == [1]
+      assert CrawlLeaguemateTransactions.weeks_to_fetch(5, 1) == [1]
+    end
+  end
+
+  describe "a cold crawl" do
+    test "dedupes the leagues its leaguemates share", %{bypass: bypass} do
+      # Two managers, one shared league. The dedupe is the entire argument
+      # for crawling over on-demand fetching: 257 real memberships collapse
+      # to 176 leagues, and per-profile fetching pays that overlap every time.
+      stub(bypass, week_transactions: %{1 => [tx(1, creator: @alice)]})
+
+      assert {:ok, summary} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert summary.leaguemates == 2
+      assert summary.leagues_seen == 1
+      assert summary.leagues_fetched == 1
+      assert Repo.aggregate(ObservedLeague, :count) == 1
+    end
+
+    test "stores transactions with rosters resolved to the users behind them", %{bypass: bypass} do
+      # A trade created by alice with bob on the other side. `creator` alone
+      # would lose bob, and trades are the rarest and most interesting type.
+      stub(bypass,
+        week_transactions: %{
+          1 => [tx(7, type: "trade", creator: @alice, roster_ids: [1, 2], bid: nil)]
+        }
+      )
+
+      assert {:ok, summary} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert summary.transactions_stored == 1
+
+      assert [row] = Repo.all(ObservedTransaction)
+      assert row.type == "trade"
+      assert row.creator == @alice
+      assert row.participant_ids == Enum.sort([@alice, @bob])
+      assert row.created == ~U[2026-07-25 17:20:00Z]
+
+      # And it is reachable as the accepting manager's own activity.
+      assert [%{id: 7}] = Intel.transactions_for_user(@bob)
+    end
+
+    test "keeps failed transactions and waiver bids", %{bypass: bypass} do
+      stub(bypass,
+        week_transactions: %{
+          1 => [tx(8, type: "waiver", status: "failed", creator: @alice, bid: 37)]
+        }
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert [row] = Repo.all(ObservedTransaction)
+      assert row.status == "failed"
+      assert row.waiver_bid == 37
+    end
+  end
+
+  describe "the second run" do
+    test "makes far fewer calls, and does not refetch the roster map", %{bypass: bypass} do
+      # The §3f-style checkpoint for this step. Rosters are the saving: which
+      # user owns roster N never changes within a season, so refetching 176
+      # of them nightly would be most of the budget.
+      counts = stub(bypass, week_transactions: %{1 => [tx(1, creator: @alice)]})
+
+      assert {:ok, first} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      cold = :counters.get(counts, 1)
+
+      assert {:ok, second} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      warm = :counters.get(counts, 1) - cold
+
+      assert first.rosters_fetched == 1
+      assert second.rosters_fetched == 0, "a second run must not refetch a roster map"
+      assert warm < cold
+
+      # Re-storing the same live week upserts rather than duplicating.
+      assert Repo.aggregate(ObservedTransaction, :count) == 1
+    end
+
+    test "still refetches the live week, because the offseason never closes it", %{bypass: bypass} do
+      counts = stub(bypass, week_transactions: %{1 => [tx(1, creator: @alice)]})
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      before = :counters.get(counts, 1)
+      assert {:ok, second} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert second.weeks_fetched == 1, "week 1 is live and must come back every run"
+      assert :counters.get(counts, 1) > before
+    end
+  end
+
+  describe "failure behaviour" do
+    test "a league whose rosters fail still stores transactions, attributed to the creator", %{
+      bypass: bypass
+    } do
+      # Partial attribution beats none. Without the roster map a trade's
+      # counterparty is unknown, but the creator is still recorded.
+      stub(bypass,
+        week_transactions: %{1 => [tx(3, type: "trade", creator: @alice, roster_ids: [1, 2])]}
+      )
+
+      Bypass.stub(bypass, "GET", "/league/900/rosters", &Plug.Conn.resp(&1, 500, "nope"))
+
+      assert {:ok, summary} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert [{:rosters_failed, 900, _}] = summary.errors
+      assert [row] = Repo.all(ObservedTransaction)
+      assert row.participant_ids == [@alice]
+    end
+
+    test "one leaguemate's enumeration failing does not lose the others", %{bypass: bypass} do
+      stub(bypass, week_transactions: %{1 => [tx(1, creator: @bob)]})
+
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/user/#{@alice}/leagues/nfl/2026",
+        &Plug.Conn.resp(&1, 500, "nope")
+      )
+
+      assert {:ok, summary} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert [{:user_leagues_failed, "111", _}] = summary.errors
+      assert summary.leagues_seen == 1, "bob's leagues still made it"
+      assert Repo.aggregate(ObservedTransaction, :count) == 1
+    end
+
+    test "the member enumeration failing is a hard error, since nothing can proceed", %{
+      bypass: bypass
+    } do
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/league/#{@source_league}/users",
+        &Plug.Conn.resp(&1, 500, "nope")
+      )
+
+      assert {:error, {:league_users_failed, _}} =
+               CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+    end
+
+    test "a failing week is recorded without aborting the league", %{bypass: bypass} do
+      stub(bypass, week_transactions: %{})
+
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/league/900/transactions/1",
+        &Plug.Conn.resp(&1, 429, "slow down")
+      )
+
+      assert {:ok, summary} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert [{:transactions_failed, 900, 1, {:http_error, 429}}] = summary.errors
+      assert summary.leagues_fetched == 1
+    end
+  end
+
+  describe "in-season week handling" do
+    test "backfills past weeks once, then only the live one", %{bypass: bypass} do
+      counts =
+        stub(bypass,
+          current_week: 3,
+          week_transactions: %{
+            1 => [tx(1, creator: @alice)],
+            2 => [tx(2, creator: @alice)],
+            3 => [tx(3, creator: @alice)]
+          }
+        )
+
+      assert {:ok, first} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert first.weeks_fetched == 3
+      cold = :counters.get(counts, 1)
+
+      assert {:ok, second} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      # Weeks 1 and 2 are settled and are never fetched again; week 3 is live.
+      # Enumeration (users + state + one call per leaguemate) still runs every
+      # pass — the saving is the roster map and the settled weeks, which is
+      # where the volume is at 176 leagues.
+      assert second.weeks_fetched == 1
+      assert :counters.get(counts, 1) - cold < cold
+      assert Repo.aggregate(ObservedTransaction, :count) == 3
+    end
+  end
+end

--- a/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
@@ -18,6 +18,11 @@ defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
       }
     ])
 
+    Intel.upsert_league_members([
+      %{league_id: @league, user_id: @alice},
+      %{league_id: @league, user_id: @bob}
+    ])
+
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
@@ -132,7 +137,8 @@ defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
 
     assert body["transactions"] == []
     assert body["coverage"]["leaguesSeen"] == 0
-    assert body["coverage"]["leaguesKnown"] == 1
+    # Not a member of anything we know about, so the denominator is theirs: 0.
+    assert body["coverage"]["leaguesKnown"] == 0
   end
 
   test "a non-numeric limit is a 422, not a 500", %{conn: conn} do

--- a/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
@@ -1,0 +1,143 @@
+defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
+  use SleeperPlayerApiWeb.ConnCase, async: true
+
+  alias SleeperPlayerApi.Intel
+
+  @league 900
+  @alice 111
+  @bob 222
+
+  setup %{conn: conn} do
+    Intel.upsert_observed_leagues([
+      %{
+        id: @league,
+        name: "A League",
+        season: "2026",
+        roster_to_user: %{"1" => @alice, "2" => @bob},
+        rosters_fetched_at: ~U[2026-08-08 06:00:00Z]
+      }
+    ])
+
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  defp seed(transactions), do: Intel.upsert_observed_transactions(transactions)
+
+  defp tx(id, attrs) do
+    Map.merge(
+      %{
+        id: id,
+        league_id: @league,
+        week: 1,
+        type: "free_agent",
+        status: "complete",
+        created: ~U[2026-08-01 12:00:00Z],
+        creator: @alice,
+        participant_ids: [@alice],
+        adds: %{},
+        drops: %{},
+        draft_picks: [],
+        waiver_bid: nil
+      },
+      attrs
+    )
+  end
+
+  test "returns a manager's activity newest first, with coverage alongside", %{conn: conn} do
+    seed([
+      tx(1, %{type: "trade", participant_ids: [@alice, @bob], created: ~U[2026-08-01 12:00:00Z]}),
+      tx(2, %{type: "waiver", created: ~U[2026-08-05 12:00:00Z], waiver_bid: 12})
+    ])
+
+    body = conn |> get(~p"/api/v1/users/#{@alice}/activity?season=2026") |> json_response(200)
+
+    assert Enum.map(body["transactions"], & &1["id"]) == [2, 1]
+    assert [%{"type" => "waiver", "waiverBid" => 12} | _] = body["transactions"]
+
+    # Coverage travels with the transactions, always — "2 transactions" means
+    # something different across 42 leagues than across 1.
+    assert body["coverage"]["leaguesSeen"] == 1
+    assert body["coverage"]["leaguesKnown"] == 1
+    assert body["coverage"]["lastCrawledAt"] != nil
+  end
+
+  test "finds a trade the manager accepted rather than created", %{conn: conn} do
+    # bob created nothing; filtering on `creator` would return an empty list
+    # and it would look like he simply has no activity.
+    seed([tx(1, %{type: "trade", creator: @alice, participant_ids: [@alice, @bob]})])
+
+    body = conn |> get(~p"/api/v1/users/#{@bob}/activity") |> json_response(200)
+
+    assert [%{"id" => 1, "creator" => @alice}] = body["transactions"]
+  end
+
+  test "serves failed transactions rather than hiding them", %{conn: conn} do
+    seed([tx(1, %{type: "waiver", status: "failed"})])
+
+    body = conn |> get(~p"/api/v1/users/#{@alice}/activity") |> json_response(200)
+
+    assert [%{"status" => "failed"}] = body["transactions"]
+  end
+
+  test "resolves the player names behind adds and drops", %{conn: conn} do
+    position =
+      SleeperPlayerApi.Sleeper.get_position_by_abbreviation("WR") ||
+        elem(SleeperPlayerApi.Sleeper.create_position(%{abbreviation: "WR"}), 1)
+
+    %SleeperPlayerApi.Sleeper.Player{}
+    |> SleeperPlayerApi.Sleeper.Player.changeset(%{
+      id: 4001,
+      player_id: "4001",
+      player_json: "{}",
+      active: true,
+      first_name: "Some",
+      last_name: "Player",
+      full_name: "Some Player",
+      search_first_name: "some",
+      search_last_name: "player",
+      search_full_name: "some player",
+      position_id: position.id
+    })
+    |> SleeperPlayerApi.Repo.insert!()
+
+    seed([tx(1, %{adds: %{"4001" => 1}, drops: %{}})])
+
+    body = conn |> get(~p"/api/v1/users/#{@alice}/activity") |> json_response(200)
+
+    # Ids stay as Sleeper sends them; names ride alongside rather than being
+    # repeated into every transaction that touches the same player.
+    assert [%{"adds" => %{"4001" => 1}}] = body["transactions"]
+    assert body["players"]["4001"]["name"] == "Some Player"
+    assert body["players"]["4001"]["position"] == "WR"
+  end
+
+  test "narrows by type and caps at a limit", %{conn: conn} do
+    seed([
+      tx(1, %{type: "trade", created: ~U[2026-08-01 12:00:00Z]}),
+      tx(2, %{type: "waiver", created: ~U[2026-08-02 12:00:00Z]}),
+      tx(3, %{type: "waiver", created: ~U[2026-08-03 12:00:00Z]})
+    ])
+
+    typed = conn |> get(~p"/api/v1/users/#{@alice}/activity?types=trade") |> json_response(200)
+    assert Enum.map(typed["transactions"], & &1["id"]) == [1]
+
+    capped = conn |> get(~p"/api/v1/users/#{@alice}/activity?limit=1") |> json_response(200)
+    assert length(capped["transactions"]) == 1
+  end
+
+  test "an unknown manager is an empty list with honest coverage, not an error", %{conn: conn} do
+    # Nothing stored for them is a real state — a quiet manager, or a crawl
+    # that has not reached their leagues — not a 404.
+    body = conn |> get(~p"/api/v1/users/999999/activity?season=2026") |> json_response(200)
+
+    assert body["transactions"] == []
+    assert body["coverage"]["leaguesSeen"] == 0
+    assert body["coverage"]["leaguesKnown"] == 1
+  end
+
+  test "a non-numeric limit is a 422, not a 500", %{conn: conn} do
+    conn = get(conn, ~p"/api/v1/users/#{@alice}/activity?limit=abc")
+
+    assert json_response(conn, 422)["errors"]["detail"] =~ "limit must be an integer"
+  end
+end


### PR DESCRIPTION
Plan §6 step 6, phases 1–3 plus the Quantum entry. The frontend that consumes
it is my-sleeper-app#152.

## Crawl, not on-demand — measured

Both were measured before anything was written. On-demand fan-out **cannot
dedupe**: 13 leaguemates hold 257 league memberships across only **176 unique
leagues**, so per-profile fetching pays that 32% overlap every time. Viewing
all thirteen costs ~527 calls against the 300/min bucket and throttles
partway. The Leaguemates section is a browsing surface, so that's the access
pattern that matters. Crossover is about three profile views.

## Validated against the live API

| | |
| --- | --- |
| cold | **365 calls, 175 leagues, 13,610 transactions, 0 errors, 28.8s** |
| warm | **190 calls, 0 roster refetches, no duplicate rows** |

365 is exactly the predicted figure.

**It found a bug no test could.** `transaction_coverage/2` compared a
manager's leagues-with-activity against *every* league in the corpus, so a
real run reported **"33 of 175 leagues" for a manager who is in 42** — a
denominator describing nobody, in the one field that exists to stop this
feature overclaiming. Every fixture had a single league. Fixed with
`league_members`, which the crawl already learned while enumerating and was
discarding in the dedupe.

## Design points

- **Keyed on Sleeper's transaction id.** In the offseason every transaction
  lands in week 1 and week 1 never closes, so identical rows return nightly
  for months. Anything else duplicates.
- **`participant_ids`, resolved at write time.** `creator` is a user id;
  `roster_ids`/`consenter_ids` are roster ids. Filtering on creator drops
  every trade a manager *accepted* — the rarest and most interesting half.
  That's what `observed_leagues.roster_to_user` is for, and why its upsert
  COALESCEs rather than replaces.
- **Roster maps fetched once per league.** Refetching 176 nightly to learn
  nothing would be most of the budget.
- **`status: "failed"` stored, not filtered** — 11% of real transactions. A
  failed waiver claim is a revealed preference nobody else in that league can
  see. Labelled at display, not dropped at ingest.

## Endpoint

`GET /api/v1/users/:user_id/activity` — deliberately *not* nested under a
league, though my own scope said it would be. The data spans all ~42 of a
manager's leagues and nothing in the response is league-scoped, so the nested
path would imply a filter that doesn't happen.

`coverage` ships with the transactions so a caller can't render "5 trades"
without what it rests on.

## Schedule

4:30am Central, after the draft sweep, so the two never contend for the same
rate-limit bucket.

212 tests. Sabotage-verified: creator-only attribution, a roster-map-clobbering
upsert, treating the live week as settled, dropping the roster cache, filtering
failed rows at the API, and the corpus-wide denominator each fail their own
cases.