### PR TITLE
Say which roster is theirs, so a trade has one side

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -254,7 +254,7 @@ defmodule SleeperPlayerApi.Intel do
   """
   @spec manager_activity(integer | String.t(), keyword) :: map
   def manager_activity(user_id, opts \\ []) do
-    transactions = transactions_for_user(user_id, opts)
+    transactions = user_id |> transactions_for_user(opts) |> with_roster_ids(to_int(user_id))
 
     player_ids =
       transactions
@@ -376,6 +376,37 @@ defmodule SleeperPlayerApi.Intel do
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
     |> Enum.sort()
+  end
+
+  # Which roster in each transaction's league belongs to this user.
+  #
+  # `adds`/`drops` are league-wide - a trade adds a player to one roster and
+  # drops him from another - so without this the same player renders as both
+  # added and dropped. Seen immediately against live data: a real trade came
+  # back as "+Marvin Harrison -Marvin Harrison", which reads as nonsense.
+  # With it the caller can show the move from *this* manager's side.
+  defp with_roster_ids([], _user_id), do: []
+
+  defp with_roster_ids(transactions, user_id) do
+    league_ids = transactions |> Enum.map(& &1.league_id) |> Enum.uniq()
+
+    roster_by_league =
+      ObservedLeague
+      |> where([l], l.id in ^league_ids)
+      |> select([l], {l.id, l.roster_to_user})
+      |> Repo.all()
+      |> Map.new(fn {id, map} ->
+        roster =
+          Enum.find_value(map || %{}, fn {roster_id, owner} ->
+            if to_int(owner) == user_id, do: to_int(roster_id)
+          end)
+
+        {id, roster}
+      end)
+
+    Enum.map(transactions, fn t ->
+      Map.put(t, :roster_id, Map.get(roster_by_league, t.league_id))
+    end)
   end
 
   @doc """

--- a/lib/sleeper_player_api_web/controllers/manager_activity_json.ex
+++ b/lib/sleeper_player_api_web/controllers/manager_activity_json.ex
@@ -31,6 +31,11 @@ defmodule SleeperPlayerApiWeb.ManagerActivityJSON do
       id: t.id,
       leagueId: t.league_id,
       week: t.week,
+      # Which roster is *theirs* in this transaction's league. `adds`/`drops`
+      # are league-wide, so without this a trade renders the same player as
+      # both added and dropped - seen against live data as
+      # "+Marvin Harrison -Marvin Harrison".
+      rosterId: Map.get(t, :roster_id),
       type: t.type,
       # `"failed"` rows are served, not filtered. A failed waiver claim is a
       # revealed preference nobody else in that league can see; the client

--- a/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
@@ -116,6 +116,39 @@ defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
     assert body["players"]["4001"]["position"] == "WR"
   end
 
+  test "says which roster is theirs, so a trade does not render both sides", %{conn: conn} do
+    # `adds`/`drops` are league-wide: a trade adds a player to one roster and
+    # drops him from another. Seen against live data as
+    # "+Marvin Harrison -Marvin Harrison", which reads as nonsense. alice is
+    # roster 1, bob roster 2.
+    seed([
+      tx(1, %{
+        type: "trade",
+        participant_ids: [@alice, @bob],
+        adds: %{"4001" => 1, "4002" => 2},
+        drops: %{"4001" => 2, "4002" => 1}
+      })
+    ])
+
+    alice = conn |> get(~p"/api/v1/users/#{@alice}/activity") |> json_response(200)
+    bob = conn |> get(~p"/api/v1/users/#{@bob}/activity") |> json_response(200)
+
+    assert [%{"rosterId" => 1}] = alice["transactions"]
+    assert [%{"rosterId" => 2}] = bob["transactions"]
+  end
+
+  test "leaves rosterId null when the league's roster map is unknown", %{conn: conn} do
+    # A league whose /rosters call failed still serves its transactions; the
+    # caller shows the move unsided rather than showing nothing.
+    Intel.upsert_observed_leagues([%{id: 901, name: "No map", season: "2026"}])
+    Intel.upsert_league_members([%{league_id: 901, user_id: @alice}])
+    seed([tx(9, %{league_id: 901})])
+
+    body = conn |> get(~p"/api/v1/users/#{@alice}/activity") |> json_response(200)
+
+    assert [%{"rosterId" => nil}] = body["transactions"]
+  end
+
   test "narrows by type and caps at a limit", %{conn: conn} do
     seed([
       tx(1, %{type: "trade", created: ~U[2026-08-01 12:00:00Z]}),


### PR DESCRIPTION
Found the moment the endpoint was queried against production. A real trade came
back as:

```
trade  ok  +[Marvin Harrison] -[Marvin Harrison]  picks:4
```

`adds`/`drops` are **league-wide** — a trade adds a player to one roster and
drops him from another — so rendering both sides shows the same player as added
*and* dropped.

Each transaction now carries `rosterId`: which roster in that league belongs to
the manager being asked about, resolved through `roster_to_user`. `null` where a
league's roster map couldn't be fetched, and the caller shows the move unsided
rather than hiding it — a partial answer beats a blank one.

No test caught it because every fixture had a one-sided free-agent add. Two new
cases cover both the trade and the null-roster path.

213 tests.