### PR TITLE
Send Sleeper ids as strings, not numbers

### DIFF
--- a/lib/sleeper_player_api_web/controllers/availability_json.ex
+++ b/lib/sleeper_player_api_web/controllers/availability_json.ex
@@ -11,7 +11,9 @@ defmodule SleeperPlayerApiWeb.AvailabilityJSON do
   def show(%{availability: a}) do
     %{
       league: a.league,
-      draftId: a.draft_id,
+      # String — see IntelJSON.userId. Nothing reads this back today, but a
+      # rounded id in a response is a trap for whoever does next.
+      draftId: to_string(a.draft_id),
       currentPick: a.current_pick,
       lastPick: a.last_pick,
       teams: a.teams,

--- a/lib/sleeper_player_api_web/controllers/intel_json.ex
+++ b/lib/sleeper_player_api_web/controllers/intel_json.ex
@@ -25,7 +25,14 @@ defmodule SleeperPlayerApiWeb.IntelJSON do
 
   defp manager(m) do
     %{
-      userId: m.user_id,
+      # A STRING, deliberately. Sleeper ids are 19 digits and exceed
+      # JavaScript's Number.MAX_SAFE_INTEGER (9,007,199,254,740,991), so
+      # `JSON.parse` silently rounds them: 859581197427257344 arrives as
+      # ...257300. That is invisible while an id is only ever compared to
+      # itself, and breaks the moment one is used to call another endpoint -
+      # which is exactly what happened when the Leaguemates profile started
+      # requesting /activity.
+      userId: to_string(m.user_id),
       displayName: m.display_name,
       leaguesCount: m.leagues_count,
       draftsCount: m.drafts_count,

--- a/lib/sleeper_player_api_web/controllers/manager_activity_json.ex
+++ b/lib/sleeper_player_api_web/controllers/manager_activity_json.ex
@@ -26,10 +26,13 @@ defmodule SleeperPlayerApiWeb.ManagerActivityJSON do
     }
   end
 
+  # Every id here is a string for the same reason `IntelJSON.userId` is:
+  # Sleeper's 19-digit ids exceed JavaScript's safe integer range, and
+  # `JSON.parse` rounds them without complaint.
   defp transaction(t) do
     %{
-      id: t.id,
-      leagueId: t.league_id,
+      id: to_string(t.id),
+      leagueId: to_string(t.league_id),
       week: t.week,
       # Which roster is *theirs* in this transaction's league. `adds`/`drops`
       # are league-wide, so without this a trade renders the same player as
@@ -42,8 +45,8 @@ defmodule SleeperPlayerApiWeb.ManagerActivityJSON do
       # labels it rather than the API hiding it.
       status: t.status,
       created: t.created,
-      creator: t.creator,
-      participantIds: t.participant_ids,
+      creator: t.creator && to_string(t.creator),
+      participantIds: Enum.map(t.participant_ids || [], &to_string/1),
       adds: t.adds || %{},
       drops: t.drops || %{},
       draftPicks: t.draft_picks || [],

--- a/lib/sleeper_player_api_web/controllers/player_json.ex
+++ b/lib/sleeper_player_api_web/controllers/player_json.ex
@@ -34,19 +34,20 @@ defmodule SleeperPlayerApiWeb.PlayerJSON do
       id: player.id,
       active: player.active,
       age: player.age,
-      fantasy_positions: Enum.map(Map.get(player, :fantasy_positions, []), fn p -> p.abbreviation end),
+      fantasy_positions:
+        Enum.map(Map.get(player, :fantasy_positions, []), fn p -> p.abbreviation end),
       first_name: player.first_name,
       last_name: player.last_name,
       full_name: player.full_name,
       player_id: player.player_id,
-      position: (if player.position, do: player.position.abbreviation, else: nil),
+      position: if(player.position, do: player.position.abbreviation, else: nil),
       search_first_name: player.search_first_name,
       search_last_name: player.search_last_name,
       search_full_name: player.search_full_name,
       search_rank: player.search_rank,
-      status: (if player.status, do: player.status.status, else: nil),
+      status: if(player.status, do: player.status.status, else: nil),
       years_exp: player.years_exp,
-      team: (if player.team, do: player.team.abbreviation, else: nil)
+      team: if(player.team, do: player.team.abbreviation, else: nil)
     }
   end
 end

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -47,7 +47,7 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
       body = json_response(conn, 200)
 
       assert body["league"] == "District 13 Dynasty League"
-      assert body["draftId"] == String.to_integer(@draft_id)
+      assert body["draftId"] == @draft_id
       assert body["currentPick"] == 35
       assert body["lastPick"] == 48
       assert body["teams"] == 12

--- a/test/sleeper_player_api_web/controllers/error_json_test.exs
+++ b/test/sleeper_player_api_web/controllers/error_json_test.exs
@@ -2,7 +2,9 @@ defmodule SleeperPlayerApiWeb.ErrorJSONTest do
   use SleeperPlayerApiWeb.ConnCase, async: true
 
   test "renders 404" do
-    assert SleeperPlayerApiWeb.ErrorJSON.render("404.json", %{}) == %{errors: %{detail: "Not Found"}}
+    assert SleeperPlayerApiWeb.ErrorJSON.render("404.json", %{}) == %{
+             errors: %{detail: "Not Found"}
+           }
   end
 
   test "renders 500" do

--- a/test/sleeper_player_api_web/controllers/intel_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/intel_controller_test.exs
@@ -56,9 +56,11 @@ defmodule SleeperPlayerApiWeb.IntelControllerTest do
       body = json_response(conn, 200)
 
       assert %{"managers" => managers, "corpus" => corpus} = body
-      assert Enum.map(managers, & &1["userId"]) == [100, 200]
+      # Strings: Sleeper ids exceed JavaScript's safe integer range, so the
+      # API sends them as strings rather than let JSON.parse round them.
+      assert Enum.map(managers, & &1["userId"]) == ["100", "200"]
 
-      alice = Enum.find(managers, &(&1["userId"] == 100))
+      alice = Enum.find(managers, &(&1["userId"] == "100"))
       assert alice["displayName"] == "alice"
       assert is_integer(alice["leaguesCount"])
       assert is_integer(alice["draftsCount"])
@@ -89,7 +91,7 @@ defmodule SleeperPlayerApiWeb.IntelControllerTest do
       conn = get(conn, ~p"/api/v1/leagues/555/intel?season=2026")
       body = json_response(conn, 200)
 
-      carol = Enum.find(body["managers"], &(&1["userId"] == 300))
+      carol = Enum.find(body["managers"], &(&1["userId"] == "300"))
       assert carol["displayName"] == "carol"
       assert carol["draftsCount"] == 0
       assert carol["leaguesCount"] == 0

--- a/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/manager_activity_controller_test.exs
@@ -56,7 +56,7 @@ defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
 
     body = conn |> get(~p"/api/v1/users/#{@alice}/activity?season=2026") |> json_response(200)
 
-    assert Enum.map(body["transactions"], & &1["id"]) == [2, 1]
+    assert Enum.map(body["transactions"], & &1["id"]) == ["2", "1"]
     assert [%{"type" => "waiver", "waiverBid" => 12} | _] = body["transactions"]
 
     # Coverage travels with the transactions, always — "2 transactions" means
@@ -73,7 +73,8 @@ defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
 
     body = conn |> get(~p"/api/v1/users/#{@bob}/activity") |> json_response(200)
 
-    assert [%{"id" => 1, "creator" => @alice}] = body["transactions"]
+    assert [%{"id" => "1", "creator" => creator}] = body["transactions"]
+    assert creator == to_string(@alice)
   end
 
   test "serves failed transactions rather than hiding them", %{conn: conn} do
@@ -157,7 +158,7 @@ defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
     ])
 
     typed = conn |> get(~p"/api/v1/users/#{@alice}/activity?types=trade") |> json_response(200)
-    assert Enum.map(typed["transactions"], & &1["id"]) == [1]
+    assert Enum.map(typed["transactions"], & &1["id"]) == ["1"]
 
     capped = conn |> get(~p"/api/v1/users/#{@alice}/activity?limit=1") |> json_response(200)
     assert length(capped["transactions"]) == 1
@@ -172,6 +173,31 @@ defmodule SleeperPlayerApiWeb.ManagerActivityControllerTest do
     assert body["coverage"]["leaguesSeen"] == 0
     # Not a member of anything we know about, so the denominator is theirs: 0.
     assert body["coverage"]["leaguesKnown"] == 0
+  end
+
+  test "sends ids as strings, because Sleeper ids exceed JavaScript's safe integer range", %{
+    conn: conn
+  } do
+    # 859581197427257344 parses as ...257300 in JSON. Invisible while an id is
+    # only compared to itself, and fatal the moment one is used to call
+    # another endpoint - which is what happened when the Leaguemates profile
+    # started requesting this one with a userId from /intel.
+    big = 859_581_197_427_257_344
+
+    Intel.upsert_observed_leagues([
+      %{id: 902, name: "Big", season: "2026", roster_to_user: %{"1" => big}}
+    ])
+
+    Intel.upsert_league_members([%{league_id: 902, user_id: big}])
+    seed([tx(1_390_152_751_601_713_152, %{league_id: 902, creator: big, participant_ids: [big]})])
+
+    body = conn |> get(~p"/api/v1/users/#{big}/activity") |> json_response(200)
+
+    assert [t] = body["transactions"]
+    assert t["id"] == "1390152751601713152"
+    assert t["creator"] == "859581197427257344"
+    assert t["participantIds"] == ["859581197427257344"]
+    assert t["leagueId"] == "902"
   end
 
   test "a non-numeric limit is a 422, not a 500", %{conn: conn} do

--- a/test/sleeper_player_api_web/controllers/player_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/player_controller_test.exs
@@ -1,7 +1,6 @@
 defmodule SleeperPlayerApiWeb.PlayerControllerTest do
   use SleeperPlayerApiWeb.ConnCase
 
-
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
@@ -20,130 +19,129 @@ defmodule SleeperPlayerApiWeb.PlayerControllerTest do
     end
   end
 
+  #  @create_attrs %{
+  #    active: true,
+  #    age: 42,
+  #    fantasy_positions: ["option1", "option2"],
+  #    first_name: "some first_name",
+  #    full_name: "some full_name",
+  #    last_name: "some last_name",
+  #    player_id: "some player_id",
+  #    player_json: %{},
+  #    position: "some position",
+  #    search_first_name: "some search_first_name",
+  #    search_full_name: "some search_full_name",
+  #    search_last_name: "some search_last_name",
+  #    search_rank: 42,
+  #    status: "some status",
+  #    team: "some team",
+  #    years_exp: 42
+  #  }
+  #  @update_attrs %{
+  #    active: false,
+  #    age: 43,
+  #    fantasy_positions: ["option1"],
+  #    first_name: "some updated first_name",
+  #    full_name: "some updated full_name",
+  #    last_name: "some updated last_name",
+  #    player_id: "some updated player_id",
+  #    player_json: %{},
+  #    position: "some updated position",
+  #    search_first_name: "some updated search_first_name",
+  #    search_full_name: "some updated search_full_name",
+  #    search_last_name: "some updated search_last_name",
+  #    search_rank: 43,
+  #    status: "some updated status",
+  #    team: "some updated team",
+  #    years_exp: 43
+  #  }
+  #  @invalid_attrs %{active: nil, age: nil, fantasy_positions: nil, first_name: nil, full_name: nil, last_name: nil, player_id: nil, player_json: nil, position: nil, search_first_name: nil, search_full_name: nil, search_last_name: nil, search_rank: nil, status: nil, team: nil, years_exp: nil}
 
-#  @create_attrs %{
-#    active: true,
-#    age: 42,
-#    fantasy_positions: ["option1", "option2"],
-#    first_name: "some first_name",
-#    full_name: "some full_name",
-#    last_name: "some last_name",
-#    player_id: "some player_id",
-#    player_json: %{},
-#    position: "some position",
-#    search_first_name: "some search_first_name",
-#    search_full_name: "some search_full_name",
-#    search_last_name: "some search_last_name",
-#    search_rank: 42,
-#    status: "some status",
-#    team: "some team",
-#    years_exp: 42
-#  }
-#  @update_attrs %{
-#    active: false,
-#    age: 43,
-#    fantasy_positions: ["option1"],
-#    first_name: "some updated first_name",
-#    full_name: "some updated full_name",
-#    last_name: "some updated last_name",
-#    player_id: "some updated player_id",
-#    player_json: %{},
-#    position: "some updated position",
-#    search_first_name: "some updated search_first_name",
-#    search_full_name: "some updated search_full_name",
-#    search_last_name: "some updated search_last_name",
-#    search_rank: 43,
-#    status: "some updated status",
-#    team: "some updated team",
-#    years_exp: 43
-#  }
-#  @invalid_attrs %{active: nil, age: nil, fantasy_positions: nil, first_name: nil, full_name: nil, last_name: nil, player_id: nil, player_json: nil, position: nil, search_first_name: nil, search_full_name: nil, search_last_name: nil, search_rank: nil, status: nil, team: nil, years_exp: nil}
-
-#  describe "create player" do
-#    test "renders player when data is valid", %{conn: conn} do
-#      conn = post(conn, ~p"/api/players", player: @create_attrs)
-#      assert %{"id" => id} = json_response(conn, 201)["data"]
-#
-#      conn = get(conn, ~p"/api/players/#{id}")
-#
-#      assert %{
-#               "id" => ^id,
-#               "active" => true,
-#               "age" => 42,
-#               "fantasy_positions" => ["option1", "option2"],
-#               "first_name" => "some first_name",
-#               "full_name" => "some full_name",
-#               "last_name" => "some last_name",
-#               "player_id" => "some player_id",
-#               "player_json" => %{},
-#               "position" => "some position",
-#               "search_first_name" => "some search_first_name",
-#               "search_full_name" => "some search_full_name",
-#               "search_last_name" => "some search_last_name",
-#               "search_rank" => 42,
-#               "status" => "some status",
-#               "team" => "some team",
-#               "years_exp" => 42
-#             } = json_response(conn, 200)["data"]
-#    end
-#
-#    test "renders errors when data is invalid", %{conn: conn} do
-#      conn = post(conn, ~p"/api/players", player: @invalid_attrs)
-#      assert json_response(conn, 422)["errors"] != %{}
-#    end
-#  end
-#
-#  describe "update player" do
-#    setup [:create_player]
-#
-#    test "renders player when data is valid", %{conn: conn, player: %Player{id: id} = player} do
-#      conn = put(conn, ~p"/api/players/#{player}", player: @update_attrs)
-#      assert %{"id" => ^id} = json_response(conn, 200)["data"]
-#
-#      conn = get(conn, ~p"/api/players/#{id}")
-#
-#      assert %{
-#               "id" => ^id,
-#               "active" => false,
-#               "age" => 43,
-#               "fantasy_positions" => ["option1"],
-#               "first_name" => "some updated first_name",
-#               "full_name" => "some updated full_name",
-#               "last_name" => "some updated last_name",
-#               "player_id" => "some updated player_id",
-#               "player_json" => %{},
-#               "position" => "some updated position",
-#               "search_first_name" => "some updated search_first_name",
-#               "search_full_name" => "some updated search_full_name",
-#               "search_last_name" => "some updated search_last_name",
-#               "search_rank" => 43,
-#               "status" => "some updated status",
-#               "team" => "some updated team",
-#               "years_exp" => 43
-#             } = json_response(conn, 200)["data"]
-#    end
-#
-#    test "renders errors when data is invalid", %{conn: conn, player: player} do
-#      conn = put(conn, ~p"/api/players/#{player}", player: @invalid_attrs)
-#      assert json_response(conn, 422)["errors"] != %{}
-#    end
-#  end
-#
-#  describe "delete player" do
-#    setup [:create_player]
-#
-#    test "deletes chosen player", %{conn: conn, player: player} do
-#      conn = delete(conn, ~p"/api/players/#{player}")
-#      assert response(conn, 204)
-#
-#      assert_error_sent 404, fn ->
-#        get(conn, ~p"/api/players/#{player}")
-#      end
-#    end
-#  end
-#
-#  defp create_player(_) do
-#    player = player_fixture()
-#    %{player: player}
-#  end
+  #  describe "create player" do
+  #    test "renders player when data is valid", %{conn: conn} do
+  #      conn = post(conn, ~p"/api/players", player: @create_attrs)
+  #      assert %{"id" => id} = json_response(conn, 201)["data"]
+  #
+  #      conn = get(conn, ~p"/api/players/#{id}")
+  #
+  #      assert %{
+  #               "id" => ^id,
+  #               "active" => true,
+  #               "age" => 42,
+  #               "fantasy_positions" => ["option1", "option2"],
+  #               "first_name" => "some first_name",
+  #               "full_name" => "some full_name",
+  #               "last_name" => "some last_name",
+  #               "player_id" => "some player_id",
+  #               "player_json" => %{},
+  #               "position" => "some position",
+  #               "search_first_name" => "some search_first_name",
+  #               "search_full_name" => "some search_full_name",
+  #               "search_last_name" => "some search_last_name",
+  #               "search_rank" => 42,
+  #               "status" => "some status",
+  #               "team" => "some team",
+  #               "years_exp" => 42
+  #             } = json_response(conn, 200)["data"]
+  #    end
+  #
+  #    test "renders errors when data is invalid", %{conn: conn} do
+  #      conn = post(conn, ~p"/api/players", player: @invalid_attrs)
+  #      assert json_response(conn, 422)["errors"] != %{}
+  #    end
+  #  end
+  #
+  #  describe "update player" do
+  #    setup [:create_player]
+  #
+  #    test "renders player when data is valid", %{conn: conn, player: %Player{id: id} = player} do
+  #      conn = put(conn, ~p"/api/players/#{player}", player: @update_attrs)
+  #      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+  #
+  #      conn = get(conn, ~p"/api/players/#{id}")
+  #
+  #      assert %{
+  #               "id" => ^id,
+  #               "active" => false,
+  #               "age" => 43,
+  #               "fantasy_positions" => ["option1"],
+  #               "first_name" => "some updated first_name",
+  #               "full_name" => "some updated full_name",
+  #               "last_name" => "some updated last_name",
+  #               "player_id" => "some updated player_id",
+  #               "player_json" => %{},
+  #               "position" => "some updated position",
+  #               "search_first_name" => "some updated search_first_name",
+  #               "search_full_name" => "some updated search_full_name",
+  #               "search_last_name" => "some updated search_last_name",
+  #               "search_rank" => 43,
+  #               "status" => "some updated status",
+  #               "team" => "some updated team",
+  #               "years_exp" => 43
+  #             } = json_response(conn, 200)["data"]
+  #    end
+  #
+  #    test "renders errors when data is invalid", %{conn: conn, player: player} do
+  #      conn = put(conn, ~p"/api/players/#{player}", player: @invalid_attrs)
+  #      assert json_response(conn, 422)["errors"] != %{}
+  #    end
+  #  end
+  #
+  #  describe "delete player" do
+  #    setup [:create_player]
+  #
+  #    test "deletes chosen player", %{conn: conn, player: player} do
+  #      conn = delete(conn, ~p"/api/players/#{player}")
+  #      assert response(conn, 204)
+  #
+  #      assert_error_sent 404, fn ->
+  #        get(conn, ~p"/api/players/#{player}")
+  #      end
+  #    end
+  #  end
+  #
+  #  defp create_player(_) do
+  #    player = player_fixture()
+  #    %{player: player}
+  #  end
 end


### PR DESCRIPTION
Found by opening a Leaguemate profile against the **deployed** endpoint: the
activity block said "Nothing seen yet" for a manager the API had four
transactions for.

The request had gone to `/users/859581197427257300/activity` for a manager
whose id is `859581197427257344`.

## Sleeper ids exceed JavaScript's safe integer range

```
Number.MAX_SAFE_INTEGER    9007199254740991
a real user id             859581197427257344  ->  859581197427257300
a real transaction id     1390152751601713152  -> 1390152751601713200
a real league id          1313425233297813504  -> 1313425233297813500
```

`JSON.parse` rounds them without complaint.

## Why nothing caught it

It was invisible while an id was only ever compared to *itself*. The
Leaguemates list keys rows by a mangled `userId` and looks them up with the
same mangled value — self-consistent, so it worked by accident. It breaks the
moment one endpoint's id is used to call another, which is precisely what the
activity fetch does.

And no test could have caught it: every fixture used small ids like `111`,
which round-trip fine. There's one now with a real 19-digit id.

## The change

`userId` (`/intel`), `id`/`leagueId`/`creator`/`participantIds` (`/activity`)
and `draftId` (`/availability`) all serialize as strings. Nothing reads
`draftId` back today, but a rounded id sitting in a response is a trap for
whoever does next.

214 tests.