### PR TITLE
Refuse an at_pick the draft does not have

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -963,7 +963,9 @@ defmodule SleeperPlayerApi.Intel do
     * `:user_id` (required) — whose remaining picks are "mine"
     * `:at_pick` — analyze as if the draft were currently at this pick
       instead of its actual next open one (plan §3g hypotheticals).
-      Defaults to the draft's actual next pick.
+      Defaults to the draft's actual next pick. Must be within
+      `1..(teams * rounds) + 1` — see `Availability.build/1` on why the
+      range runs one past the final pick.
     * `:limit` — how many corpus players become `targets` (default 20, or
       the length of `:player_ids` when that is given)
     * `:player_ids` — restrict `targets` to these players (plan §6 step 3).
@@ -1006,9 +1008,9 @@ defmodule SleeperPlayerApi.Intel do
 
   Returns `{:ok, response}`, `{:error, :draft_not_found}` if `draft_id`
   isn't stored and can't be fetched from Sleeper either, or `{:error,
-  reason}` from `Availability.build/1` (an unresolvable draft type — see
-  its moduledoc on why that's a hard failure rather than a degraded
-  response).
+  reason}` from `Availability.build/1` (an unresolvable draft type, or an
+  `:at_pick` outside the draft — see its moduledoc on why both are hard
+  failures rather than degraded responses).
   """
   @spec availability(integer | String.t(), keyword) :: {:ok, map} | {:error, term}
   def availability(draft_id, opts \\ []) do

--- a/lib/sleeper_player_api/intel/availability.ex
+++ b/lib/sleeper_player_api/intel/availability.ex
@@ -78,7 +78,8 @@ defmodule SleeperPlayerApi.Intel.Availability do
     current_pick = input[:at_pick] || next_pick(input.picks_made)
     last_pick = input.teams * input.rounds
 
-    with {:ok, board_rosters} <-
+    with :ok <- check_range(input[:at_pick], last_pick),
+         {:ok, board_rosters} <-
            PickOwnership.resolve_board(
              # `//1` is load-bearing: a bare `a..b` where a > b silently
              # becomes a DESCENDING range. Once a draft finishes,
@@ -142,6 +143,26 @@ defmodule SleeperPlayerApi.Intel.Availability do
        }}
     end
   end
+
+  # Only an explicitly asked-for pick is range-checked; the derived one is
+  # `last_pick + 1` at most, by construction.
+  #
+  # The accepted range is `1..last_pick + 1`, one past the end on purpose:
+  # that is what a finished draft reports as its own `current_pick`, and
+  # the frontend's pick selector echoes the response's `currentPick` back
+  # as `at_pick`. Refusing it would 422 every completed draft.
+  #
+  # Without this, `at_pick=999` was a 200 carrying an empty board and
+  # empty `byPick` — the UI renders that as "no read", which is honest
+  # about the answer but hides that the question was nonsense. Below 1 it
+  # did fail, but as `{:unmapped_slot, 0}` raised by `PickOwnership` for
+  # draft slot 0, which describes an internal lookup rather than the
+  # caller's mistake.
+  defp check_range(nil, _last_pick), do: :ok
+
+  defp check_range(at_pick, last_pick) when at_pick in 1..(last_pick + 1)//1, do: :ok
+
+  defp check_range(at_pick, last_pick), do: {:error, {:pick_out_of_range, at_pick, last_pick}}
 
   defp next_pick([]), do: 1
   defp next_pick(picks_made), do: (picks_made |> Enum.map(& &1.pick_no) |> Enum.max()) + 1

--- a/lib/sleeper_player_api/intel/availability.ex
+++ b/lib/sleeper_player_api/intel/availability.ex
@@ -26,6 +26,11 @@ defmodule SleeperPlayerApi.Intel.Availability do
   correctness violation, so it still returns `{:ok, response}` with
   `targets: []` and `corpusDrafts: 0` rather than erroring — the board
   (trade resolution) doesn't depend on the corpus at all.
+
+  An `at_pick` outside the draft is also a hard failure —
+  `{:error, {:pick_out_of_range, at_pick, last_pick}}` — for the same
+  reason in a smaller way: the empty board and empty `byPick` it used to
+  produce are indistinguishable from an honest "nothing left to read".
   """
 
   alias SleeperPlayerApi.Intel.{Estimator, PickOwnership}

--- a/lib/sleeper_player_api_web/controllers/availability_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/availability_controller.ex
@@ -12,6 +12,11 @@ defmodule SleeperPlayerApiWeb.AvailabilityController do
   `user_id` is required (whose remaining picks are "mine"), `at_pick`,
   `limit` and `player_ids` are optional.
 
+  `at_pick` is validated in two stages, because only the second knows the
+  draft: this module rejects anything non-numeric, and
+  `SleeperPlayerApi.Intel.Availability.build/1` rejects a number outside
+  the draft's own picks. Both come back as a 422 via the fallback.
+
   `player_ids` is a comma-separated list of Sleeper player ids and
   restricts `targets` to those players (plan §6 step 3 — the frontend
   sends its rank list). A blank value is treated as absent rather than as

--- a/lib/sleeper_player_api_web/controllers/fallback_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/fallback_controller.ex
@@ -45,6 +45,22 @@ defmodule SleeperPlayerApiWeb.FallbackController do
     })
   end
 
+  # `at_pick` parsed as an integer but isn't a pick this draft has
+  # (`SleeperPlayerApi.Intel.Availability.build/1`). The upper bound is
+  # `last_pick + 1` because that is the `currentPick` a finished draft
+  # reports — see the range check itself for why.
+  def call(conn, {:error, {:pick_out_of_range, at_pick, last_pick}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: SleeperPlayerApiWeb.ErrorJSON)
+    |> Phoenix.Controller.json(%{
+      errors: %{
+        detail:
+          "at_pick must be between 1 and #{last_pick + 1} for this #{last_pick}-pick draft, got: #{at_pick}"
+      }
+    })
+  end
+
   # `SleeperPlayerApi.Intel.PickOwnership` couldn't resolve the draft's own
   # order (not `"linear"`/`"snake"`) — per `Availability`'s moduledoc, this
   # is a hard failure rather than a degraded response, because serving

--- a/test/sleeper_player_api/intel/availability_test.exs
+++ b/test/sleeper_player_api/intel/availability_test.exs
@@ -96,6 +96,53 @@ defmodule SleeperPlayerApi.Intel.AvailabilityTest do
     end
   end
 
+  describe "at_pick range checking" do
+    # Measured against production before this existed: `at_pick=999` on a
+    # 48-pick draft was a 200 with an empty board and a target whose
+    # `byPick` was empty — honest-looking nonsense the request should never
+    # have got past. `at_pick=0` did fail, but only incidentally, as
+    # `{:unmapped_slot, 0}` from `PickOwnership` two layers down.
+    test "a pick past the end of the draft is refused, not answered with an empty board" do
+      input = base_input(%{at_pick: 999})
+      assert Availability.build(input) == {:error, {:pick_out_of_range, 999, 8}}
+    end
+
+    test "pick 0 is out of range on its own terms, not an unmapped draft slot" do
+      input = base_input(%{at_pick: 0})
+      assert Availability.build(input) == {:error, {:pick_out_of_range, 0, 8}}
+    end
+
+    test "a negative pick is refused" do
+      input = base_input(%{at_pick: -5})
+      assert Availability.build(input) == {:error, {:pick_out_of_range, -5, 8}}
+    end
+
+    test "the first and last real picks are both in range" do
+      assert {:ok, first} = Availability.build(base_input(%{at_pick: 1}))
+      assert first.current_pick == 1
+
+      assert {:ok, last} = Availability.build(base_input(%{at_pick: 8}))
+      assert last.current_pick == 8
+      assert last.board == [%{pick: 8, manager: "dave", mine: false, drafts: 0}]
+    end
+
+    # `last_pick + 1` is what a finished draft reports as its own
+    # `currentPick` (see "a draft that has already finished"), so the
+    # response's own value has to be accepted back — otherwise echoing
+    # `currentPick` into `at_pick`, which is exactly what the pick selector
+    # does, 422s at the end of every draft.
+    test "one past the last pick is accepted, because that is what a finished draft reports" do
+      assert {:ok, response} = Availability.build(base_input(%{at_pick: 9}))
+      assert response.current_pick == 9
+      assert response.board == []
+    end
+
+    test "two past the last pick is not" do
+      assert Availability.build(base_input(%{at_pick: 10})) ==
+               {:error, {:pick_out_of_range, 10, 8}}
+    end
+  end
+
   describe "a draft that has already finished" do
     # Regression: found by hitting the deployed endpoint against the real
     # District 13 draft, which completed after the corpus was harvested.

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -543,6 +543,81 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
     end
   end
 
+  describe "GET /api/v1/drafts/:draft_id/availability — at_pick out of range" do
+    # Needs the draft itself (48 picks) to know what "out of range" means,
+    # so unlike the parse-level validation above these go through the stubs.
+    @describetag :corpus
+
+    setup %{bypass: bypass} do
+      seed_users_only!()
+      stub_district_13(bypass)
+      :ok
+    end
+
+    # Measured against production: this was a 200 with `currentPick: 999`,
+    # an empty board, and a target whose `byPick` was empty.
+    test "a pick past the end of the draft is a 422, not a 200 with an empty board", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&at_pick=999"
+        )
+
+      assert json_response(conn, 422)["errors"]["detail"] ==
+               "at_pick must be between 1 and 49 for this 48-pick draft, got: 999"
+    end
+
+    test "pick 0 says the pick is out of range, not that a draft slot is unmapped", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&at_pick=0"
+        )
+
+      detail = json_response(conn, 422)["errors"]["detail"]
+
+      assert detail == "at_pick must be between 1 and 49 for this 48-pick draft, got: 0"
+      refute detail =~ "roster"
+      refute detail =~ "slot"
+    end
+
+    test "a negative pick is a 422 too", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&at_pick=-1"
+        )
+
+      assert json_response(conn, 422)["errors"]["detail"] =~ "got: -1"
+    end
+
+    # The pick selector sends back what the response gave it, and a
+    # finished District 13 reports `currentPick: 49` against `lastPick: 48`.
+    test "the currentPick a finished draft reports is accepted back as at_pick", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&at_pick=49"
+        )
+
+      body = json_response(conn, 200)
+      assert body["currentPick"] == 49
+      assert body["board"] == []
+    end
+
+    test "a real mid-draft pick still works", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&at_pick=48"
+        )
+
+      body = json_response(conn, 200)
+      assert body["currentPick"] == 48
+      assert Enum.map(body["board"], & &1["pick"]) == [48]
+    end
+  end
+
   # ---------------------------------------------------------------------
   # Bypass stubs — the live draft-refresh + roster-ownership fetch path
   # ---------------------------------------------------------------------


### PR DESCRIPTION
`/availability?at_pick=999` on a 48-pick draft was a 200: `currentPick: 999`, an empty board, and a target whose `byPick` was empty. The UI renders that as "no read", which is honest about the answer but hides that the question was nonsense. Below 1 the request did fail, but only incidentally — `PickOwnership` couldn't map draft slot 0, so the 422 read `"no roster mapped for draft slot 0"`, describing an internal lookup rather than the caller's mistake.

Both were measured against production and recorded in the plan's `Known follow-ups`.

`Availability.build/1` now range-checks an explicitly asked-for pick before resolving the board, and the fallback controller renders it:

```
at_pick must be between 1 and 49 for this 48-pick draft, got: 999
```

The check sits in `build/1` rather than the controller because only `build/1` knows `teams * rounds`. The controller keeps the parse-level check it already had, so `at_pick` is validated in two stages and both come back as a 422.

**The upper bound is `last_pick + 1`, one past the end on purpose.** That is what a finished draft reports as its own `currentPick`, so refusing it would 422 anyone echoing the response's own value back.

**No frontend change is needed:** `DraftPanel` never sends `at_pick`, and the pick selector is client-side over `byPick`. This only affects hand-built requests.

Tests: six against `build/1` directly, five through the endpoint. Each was sabotaged three ways first — the check made unconditional, the upper bound cut to `last_pick`, and the fallback clause disabled — and each sabotage failed exactly the tests that name the behaviour it broke.