### PR TITLE
Compress responses, so the pick-1 payload stops being 40 KB

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -19,7 +19,31 @@ config :sleeper_player_api, SleeperPlayerApiWeb.Endpoint,
     layout: false
   ],
   pubsub_server: SleeperPlayerApi.PubSub,
-  live_view: [signing_salt: "D+bR61pb"]
+  live_view: [signing_salt: "D+bR61pb"],
+  # Compress responses. Cowboy's own stream handler does it, because there
+  # is no reverse proxy in front of this app — it is `plug_cowboy` talking
+  # to the internet directly (`Plug.Static`'s `gzip: false` was never
+  # relevant: that only ever served pre-compressed *static* files, and
+  # every response here is dynamic JSON).
+  #
+  # It has to be `compress: true`, NOT
+  # `protocol_options: [stream_handlers: [:cowboy_compress_h, ...]]`.
+  # `:stream_handlers` is a top-level `Plug.Cowboy` option, not a Cowboy
+  # protocol option, and `Plug.Cowboy.args/4` merges its own default
+  # handlers *over* anything nested under `:protocol_options`. The nested
+  # form compiles, boots, and silently does nothing — verified by curling
+  # a 4 KB response and finding no `content-encoding` on it.
+  #
+  # Set on both listeners, not just https, because the http one is what
+  # answers before `force_ssl` redirects — and set here rather than in
+  # `prod.exs` so dev and prod compress alike. Phoenix deep-merges these
+  # keyword lists, so the per-environment `port`/`ip` entries survive, as
+  # does `SiteEncrypt.Phoenix.configure_https/1`'s cert merge.
+  #
+  # The measured effect on the endpoint that motivated this: 40,861 bytes
+  # to 4,511 for `/availability` at pick 1 with ten targets.
+  http: [compress: true],
+  https: [compress: true]
 
 # Configures the mailer
 #

--- a/test/sleeper_player_api_web/endpoint_compression_test.exs
+++ b/test/sleeper_player_api_web/endpoint_compression_test.exs
@@ -1,0 +1,43 @@
+defmodule SleeperPlayerApiWeb.EndpointCompressionTest do
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApiWeb.Endpoint
+
+  # `Phoenix.ConnTest` calls the plug pipeline directly and never starts
+  # Cowboy, so no request test can see a `content-encoding` header. The
+  # honest end-to-end check is a real request against a real server, and
+  # it lives in the PR body and `DEPLOY.md`, not here.
+  #
+  # What *is* testable is the step that silently swallowed the first
+  # attempt at this. `:stream_handlers` is a top-level `Plug.Cowboy`
+  # option, not a Cowboy protocol option, so
+  # `protocol_options: [stream_handlers: [:cowboy_compress_h, ...]]` —
+  # which is what the plan and every blog post suggest — parses, boots,
+  # serves traffic, and compresses nothing, because `Plug.Cowboy.args/4`
+  # merges its own defaults over the nested list. Running that merge over
+  # the real endpoint config is the difference between "the config looks
+  # right" and "the handler is actually installed".
+  # Read through `Endpoint.init/2` rather than straight from the app env,
+  # so the https listener carries the cert options `SiteEncrypt` merges in
+  # — both because `Plug.Cowboy` refuses to build args without them, and
+  # because that merge is the other thing in this config that could drop
+  # `compress` on its way to Cowboy.
+  defp listener_opts(scheme) do
+    {:ok, config} =
+      Endpoint.init(:supervisor, Application.fetch_env!(:sleeper_player_api, Endpoint))
+
+    config[scheme]
+  end
+
+  for scheme <- [:http, :https] do
+    test "the #{scheme} listener really installs cowboy's compress handler" do
+      listener_opts = listener_opts(unquote(scheme))
+
+      [_ref, _transport_options, protocol_options] =
+        Plug.Cowboy.args(unquote(scheme), Endpoint, [], listener_opts)
+
+      assert :cowboy_compress_h in protocol_options.stream_handlers,
+             "expected :cowboy_compress_h in #{inspect(protocol_options.stream_handlers)}"
+    end
+  end
+end


### PR DESCRIPTION
Nothing compressed dynamic responses. `Plug.Static`'s `gzip: false` only ever applied to static assets, and there is no reverse proxy in front of the app — it is `plug_cowboy` talking to the internet directly.

Measured against production before the change, with the client already asking for it:

```
$ curl -H 'Accept-Encoding: gzip' .../availability?...&at_pick=1&limit=10
content-length: 40861
(no content-encoding)
```

`compress: true` on both listeners — `Plug.Cowboy`'s own option for putting `:cowboy_compress_h` in front of its stream handlers. Both, not just https, because the http listener is what answers before `force_ssl` redirects.

## The part worth reading

It is **not** `protocol_options: [stream_handlers: [:cowboy_compress_h, ...]]`, which is what the plan's follow-up note and the Cowboy docs point at. `:stream_handlers` is a top-level `Plug.Cowboy` option, not a Cowboy protocol option, so `Plug.Cowboy.args/4` merges its own defaults *over* anything nested under `:protocol_options`.

That version compiles, boots, serves traffic, and compresses nothing. I had it running on a local server before a curl showed no `content-encoding` on a 4 KB response.

## Testing

`ConnTest` never starts Cowboy, so no request test can assert `content-encoding`. The new test instead runs `Plug.Cowboy.args/4` over the real endpoint config — through `Endpoint.init/2`, so the https listener carries SiteEncrypt's cert merge — and asserts `:cowboy_compress_h` survives into the built protocol options. That is the exact step that swallowed the first attempt.

Sabotaged three ways, each grepped before running: the nested `protocol_options` form (both tests fail), no `compress` at all (both fail), and `compress` on https only (the http test alone fails).

Verified end to end on a local server: 4,164 bytes → 101 with `Accept-Encoding: gzip`, `vary: accept-encoding` set, and the full 4,164 returned uncompressed when the client doesn't ask.