### PR TITLE
Show how much of a player each leaguemate actually owns

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -42,6 +42,7 @@ defmodule SleeperPlayerApi.Intel do
     PlayerValue,
     DraftParticipant,
     ObservedLeague,
+    ObservedRoster,
     ObservedTransaction,
     LeagueMember
   }
@@ -304,6 +305,79 @@ defmodule SleeperPlayerApi.Intel do
           ]
         )
     )
+  end
+
+  @doc """
+  Stores each league's rosters and their current contents.
+
+  Unlike `upsert_observed_leagues/1` this **replaces** `player_ids` rather
+  than coalescing it. An empty list is a real answer — a manager can drop to
+  nothing, and a roster that has been emptied must stop reporting the players
+  it used to hold. Coalescing would make ownership monotonically increasing,
+  which is the one thing a "how much do they own" number must never be.
+  """
+  @spec upsert_observed_rosters([map]) :: {non_neg_integer, nil}
+  def upsert_observed_rosters(rosters) do
+    insert_all_batched(
+      ObservedRoster,
+      rosters,
+      conflict_target: [:league_id, :roster_id],
+      replace: [:owner_id, :player_ids, :fetched_at, :updated_at]
+    )
+  end
+
+  @doc """
+  Per-manager ownership: how many of each manager's leagues hold each player.
+
+  Returns `{ownership, leagues_seen}` where `ownership` is
+  `%{{user_id, player_id} => count}` and `leagues_seen` is
+  `%{user_id => count}` — the honest denominator, being the leagues we have
+  roster data for, not every league the manager is in. A league whose rosters
+  have never been fetched, or that Sleeper returned empty, is in neither.
+
+  `player_ids` narrows the ownership map; the denominators are always the
+  manager's full count, because "owns him in 2" only means something against
+  how many leagues he has.
+  """
+  @spec ownership([String.t()] | nil) :: {map, map}
+  def ownership(player_ids \\ nil) do
+    base = from(r in ObservedRoster, where: not is_nil(r.owner_id))
+
+    # A manager's denominator counts the leagues we can see, and a roster
+    # with no players in it is a league we cannot see into — 22 of the 176
+    # come back empty, and counting them would read every ownership figure
+    # ~13% low.
+    leagues_seen =
+      base
+      |> where([r], fragment("cardinality(?) > 0", r.player_ids))
+      |> group_by([r], r.owner_id)
+      |> select([r], {r.owner_id, count(r.league_id, :distinct)})
+      |> Repo.all()
+      |> Map.new()
+
+    # `inner_lateral_join`, not `join`: the subquery reads `r.player_ids` from
+    # the row it is joined to, which a plain join cannot see ("invalid
+    # reference to FROM-clause entry").
+    unnested =
+      from(r in base,
+        inner_lateral_join: pid in fragment("SELECT unnest(?) AS id", r.player_ids),
+        on: true,
+        group_by: [r.owner_id, pid.id],
+        select: {r.owner_id, pid.id, count(r.league_id, :distinct)}
+      )
+
+    ownership_query =
+      case player_ids do
+        nil -> unnested
+        ids -> from([r, pid] in unnested, where: pid.id in ^ids)
+      end
+
+    ownership =
+      ownership_query
+      |> Repo.all()
+      |> Map.new(fn {owner_id, player_id, count} -> {{owner_id, player_id}, count} end)
+
+    {ownership, leagues_seen}
   end
 
   @doc """
@@ -952,6 +1026,41 @@ defmodule SleeperPlayerApi.Intel do
   end
 
   @doc """
+  `ownership/1` keyed by manager name rather than user id, ready for
+  `Availability.build/1`.
+
+  Returns `%{owns: %{{manager, player_id} => count}, leagues: %{manager =>
+  count}}`. Managers we hold no roster data for are absent from `leagues`
+  entirely, which is what lets the response distinguish "owns him nowhere"
+  from "we cannot see his leagues" — the same distinction the no-chip trap
+  is about.
+  """
+  @spec ownership_by_manager([String.t()], %{integer => String.t()}) :: %{
+          owns: map,
+          leagues: map
+        }
+  def ownership_by_manager(player_ids, user_id_to_manager) do
+    {owns, leagues_seen} = ownership(player_ids)
+
+    %{
+      owns:
+        for {{user_id, player_id}, count} <- owns,
+            manager = Map.get(user_id_to_manager, user_id),
+            not is_nil(manager),
+            into: %{} do
+          {{manager, player_id}, count}
+        end,
+      leagues:
+        for {user_id, count} <- leagues_seen,
+            manager = Map.get(user_id_to_manager, user_id),
+            not is_nil(manager),
+            into: %{} do
+          {manager, count}
+        end
+    }
+  end
+
+  @doc """
   The `/availability` endpoint's context entry point (plan §3f step 4).
   Trade-resolves `draft_id`'s remaining picks and, for every corpus player
   still on the board, its Kaplan-Meier survival curve conditioned on that
@@ -1084,7 +1193,8 @@ defmodule SleeperPlayerApi.Intel do
         candidate_lookup: player_lookup(candidate_ids),
         market_rank: Estimator.rookie_class_rank(market_rookie_class_entries(draft.season)),
         raw_picks: manager_pick_strings(candidate_ids, user_id_to_manager),
-        eligible_ids: eligible_ids(candidate_ids, player_ids)
+        eligible_ids: eligible_ids(candidate_ids, player_ids),
+        ownership: ownership_by_manager(candidate_ids, user_id_to_manager)
       })
     end
   end

--- a/lib/sleeper_player_api/intel/availability.ex
+++ b/lib/sleeper_player_api/intel/availability.ex
@@ -62,7 +62,11 @@ defmodule SleeperPlayerApi.Intel.Availability do
         candidate_lookup: %{String.t() => %{name: String.t() | nil, position: String.t() | nil}},
         market_rank: %{String.t() => pos_integer},
         raw_picks: %{{String.t(), String.t()} => [String.t()]},
-        eligible_ids: MapSet.t(String.t()) | nil    # optional; see "Which players become targets?" below
+        eligible_ids: MapSet.t(String.t()) | nil,   # optional; see "Which players become targets?" below
+        ownership: %{                               # optional; see `per_manager/2`
+          owns: %{{String.t(), String.t()} => pos_integer},
+          leagues: %{String.t() => pos_integer}
+        }
       }
 
   ## Which players become `targets`? (plan §3f step 4 — underspecified)
@@ -295,20 +299,41 @@ defmodule SleeperPlayerApi.Intel.Availability do
   # Per-manager ADP + "notable" (plan §3 Frontend / §4e-bis)
   # ---------------------------------------------------------------------
 
+  # An entry appears when a manager has *either* drafted the player or owns
+  # him somewhere now. Those two populations barely overlap: measured
+  # 2026-08-09 across the real corpus, 94% of (manager, player) ownership
+  # pairs never appear in a crawled draft at all, because the player arrived
+  # by trade or waiver or in a league whose draft was never crawled. Listing
+  # only the drafters would drop most of what the rosters know.
+  #
+  # `adp`/`picks` stay nil/[] for an ownership-only entry rather than being
+  # faked from the ownership count — the draft read and the holdings read are
+  # different questions and §4e-bis's whole point is not to conflate two
+  # numbers that look alike.
   defp per_manager(input, player_id) do
-    for manager <- Enum.sort(MapSet.to_list(known_managers(input))),
+    ownership = Map.get(input, :ownership, %{owns: %{}, leagues: %{}})
+    managers = Enum.sort(MapSet.to_list(known_managers(input)))
+
+    # `of_leagues` is deliberately NOT bound as a comprehension filter. An
+    # assignment used as a filter drops the row when the value is falsy, and
+    # this one is nil for any manager we hold no roster data for — which
+    # silently removed managers who had drafted the player from the list
+    # entirely. It is read in the body instead, where nil is just nil.
+    for manager <- managers,
         took = Estimator.manager_took(input.corpus, manager, player_id),
-        took > 0 do
+        owns = Map.get(ownership.owns, {manager, player_id}, 0),
+        took > 0 or owns > 0 do
       seen = Estimator.manager_seen(input.corpus, manager)
       events = manager_events(input.corpus, manager, player_id)
-      adp = Enum.sum(events) / length(events)
 
       %{
         manager: manager,
         times: took,
         of: seen,
-        adp: round1(adp),
-        picks: raw_picks_for(input, manager, player_id)
+        adp: if(events == [], do: nil, else: round1(Enum.sum(events) / length(events))),
+        picks: raw_picks_for(input, manager, player_id),
+        owns: owns,
+        of_leagues: Map.get(ownership.leagues, manager)
       }
     end
     |> Enum.sort_by(& &1.manager)

--- a/lib/sleeper_player_api/intel/observed_roster.ex
+++ b/lib/sleeper_player_api/intel/observed_roster.ex
@@ -1,0 +1,39 @@
+defmodule SleeperPlayerApi.Intel.ObservedRoster do
+  @moduledoc """
+  One roster in one observed league: its owner, and who is on it now.
+
+  This is the half of `/league/:id/rosters` that `ObservedLeague` discards.
+  `roster_to_user` is stable within a season, so the transactions crawler
+  fetches it once; `players` is not — it moves with every trade, waiver and
+  free-agent add — so this table is refreshed on every crawl.
+
+  It exists to answer "how much of this player do your leaguemates own",
+  which the rookie-draft corpus cannot: measured 2026-08-09, 94% of
+  (manager, player) ownership pairs never appear in the corpus at all, and
+  the managers with the least draft history have the most leagues.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SleeperPlayerApi.Intel.ObservedLeague
+
+  @primary_key false
+  schema "observed_rosters" do
+    belongs_to :league, ObservedLeague, references: :id, type: :id, define_field: false
+    field :league_id, :integer
+    field :roster_id, :integer
+    field :owner_id, :integer
+    field :player_ids, {:array, :string}, default: []
+    field :fetched_at, :utc_datetime
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(observed_roster, attrs) do
+    observed_roster
+    |> cast(attrs, [:league_id, :roster_id, :owner_id, :player_ids, :fetched_at])
+    |> validate_required([:league_id, :roster_id])
+    |> unique_constraint([:league_id, :roster_id])
+  end
+end

--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
@@ -16,8 +16,13 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
   pattern that matters. Crossover is about three profile views.
 
   Measured cost of this crawl: 13 enumeration calls + 176 leagues, so **365
-  calls cold** (transactions plus roster maps) and **189 nightly** in the
-  offseason, roughly 73s and 38s at 300/min.
+  calls cold** (transactions plus rosters) and **~346 nightly** in the
+  offseason, roughly 73s and 69s at 300/min.
+
+  The nightly figure was 189 until rosters started being refetched every run
+  rather than cached for the season — see `ensure_roster_map/2`. That is the
+  price of a current answer to "how much of this player do they own"; the
+  cached roster list could only ever describe the first night we looked.
 
   ## Which weeks get fetched
 
@@ -215,13 +220,20 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
     %{summary | leagues_fetched: summary.leagues_fetched + 1}
   end
 
-  # Rosters are fetched once per league and kept: which user owns roster N
-  # does not change within a season, and refetching 176 of them nightly to
-  # learn nothing would be most of the crawl's budget.
-  defp ensure_roster_map(%ObservedLeague{roster_to_user: map}, summary)
-       when is_map(map) and map_size(map) > 0,
-       do: {map, summary}
-
+  # Rosters are fetched on **every** run, where they used to be fetched once
+  # and cached forever.
+  #
+  # The cache was right for what it stored: `roster_to_user` doesn't change
+  # within a season, so re-fetching 176 leagues nightly to relearn it would
+  # have been most of the crawl's budget for nothing. But the same payload's
+  # `players` is the opposite — it moves with every trade, waiver and
+  # free-agent add — and that is what per-manager ownership reads. A cached
+  # roster list would answer "who did he own the first night we looked",
+  # which is worse than no answer because it looks current.
+  #
+  # Measured cost: +154 calls on a warm run (176 leagues, 22 of which have no
+  # rosters yet), taking it from ~192 to ~346 against a 300/min limiter and
+  # Sleeper's documented 1000/min.
   defp ensure_roster_map(league, summary) do
     league_id = league && league.id
 
@@ -236,22 +248,43 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
             end
           end)
 
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+
         Intel.upsert_observed_leagues([
-          %{
-            id: league_id,
-            roster_to_user: map,
-            rosters_fetched_at: DateTime.utc_now() |> DateTime.truncate(:second)
-          }
+          %{id: league_id, roster_to_user: map, rosters_fetched_at: now}
         ])
+
+        Intel.upsert_observed_rosters(roster_rows(league_id, rosters, now))
 
         {map, %{summary | rosters_fetched: summary.rosters_fetched + 1}}
 
       {{:error, reason}, summary} ->
         # Partial attribution beats none: without the map, `participants/2`
-        # still records the creator.
-        {%{}, add_error(summary, {:rosters_failed, league_id, reason})}
+        # still records the creator. A failed fetch leaves the previous
+        # roster rows in place rather than emptying them — a league Sleeper
+        # is briefly unhappy about should read as stale, not as "nobody owns
+        # anybody".
+        {stored_roster_map(league), add_error(summary, {:rosters_failed, league_id, reason})}
     end
   end
+
+  # `players` is null rather than [] for a roster nobody has filled yet, and
+  # Sleeper sends player ids as strings — which they must stay, per the
+  # 19-digit id rule that applies to every id this app touches.
+  defp roster_rows(league_id, rosters, now) do
+    for roster <- rosters, roster_id = roster["roster_id"], not is_nil(roster_id) do
+      %{
+        league_id: league_id,
+        roster_id: roster_id,
+        owner_id: to_int(roster["owner_id"]),
+        player_ids: Enum.map(roster["players"] || [], &to_string/1),
+        fetched_at: now
+      }
+    end
+  end
+
+  defp stored_roster_map(%ObservedLeague{roster_to_user: map}) when is_map(map), do: map
+  defp stored_roster_map(_), do: %{}
 
   defp fetch_week(league_id, week, roster_map, summary) do
     case request("/league/#{league_id}/transactions/#{week}", summary) do

--- a/lib/sleeper_player_api_web/controllers/availability_json.ex
+++ b/lib/sleeper_player_api_web/controllers/availability_json.ex
@@ -72,8 +72,24 @@ defmodule SleeperPlayerApiWeb.AvailabilityJSON do
   # none of which vary by target pick. See `Estimator.hazards/6`.
   defp hazard(h), do: %{pick: h.pick, prob: h.prob}
 
+  # `times`/`of`/`adp`/`picks` are the draft read; `owns`/`ofLeagues` are the
+  # holdings read. Both can be present, and either can be empty on its own -
+  # a manager who traded for him has owns > 0 with times 0, and one who
+  # drafted him and moved him on has the reverse.
+  #
+  # `ofLeagues` is null, not 0, when we hold no roster data for that manager:
+  # "owns him in 0 of 0 leagues" is not a fact about him, and the client has
+  # to be able to tell that apart from a real zero.
   defp per_manager(m) do
-    %{manager: m.manager, times: m.times, of: m.of, adp: m.adp, picks: m.picks}
+    %{
+      manager: m.manager,
+      times: m.times,
+      of: m.of,
+      adp: m.adp,
+      picks: m.picks,
+      owns: m.owns,
+      ofLeagues: m.of_leagues
+    }
   end
 
   defp notable(false), do: false

--- a/priv/repo/migrations/20260809160000_create_observed_rosters.exs
+++ b/priv/repo/migrations/20260809160000_create_observed_rosters.exs
@@ -1,0 +1,38 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedRosters do
+  use Ecto.Migration
+
+  def change do
+    # One row per roster per league: who owns it, and who is on it right now.
+    #
+    # `observed_leagues.roster_to_user` already answers "who owns roster N",
+    # which is why the transactions crawler fetches `/league/:id/rosters` once
+    # and never again. This table is the part of that same payload it throws
+    # away — `players` — and it is *not* stable within a season: it changes
+    # with every trade, waiver and free-agent add.
+    #
+    # Measured 2026-08-09, this is what makes a per-manager ownership read
+    # possible: 94% of (manager, player) ownership pairs are invisible to the
+    # rookie-draft corpus, because they arrived by trade or waiver or in a
+    # league whose draft was never crawled. It also gives the thin-sample
+    # managers a denominator — `skeefe` has 1 corpus draft and 30 leagues.
+    #
+    # `player_ids` is text[], not a jsonb map: Sleeper player ids are strings
+    # in the payload and the only query is membership.
+    create table(:observed_rosters, primary_key: false) do
+      add :league_id, references(:observed_leagues, on_delete: :delete_all, type: :bigint),
+        null: false
+
+      add :roster_id, :integer, null: false
+      add :owner_id, :bigint
+      add :player_ids, {:array, :text}, null: false, default: []
+      add :fetched_at, :utc_datetime
+
+      timestamps()
+    end
+
+    create unique_index(:observed_rosters, [:league_id, :roster_id])
+    # The read is "which of this manager's rosters hold player X", so the
+    # owner is the selective side.
+    create index(:observed_rosters, [:owner_id])
+  end
+end

--- a/test/sleeper_player_api/intel/availability_test.exs
+++ b/test/sleeper_player_api/intel/availability_test.exs
@@ -96,6 +96,93 @@ defmodule SleeperPlayerApi.Intel.AvailabilityTest do
     end
   end
 
+  describe "per-manager ownership" do
+    # One corpus draft in which bob took P1. alice never drafted him but
+    # holds him in 3 of her 9 leagues - the trade/waiver case, which is 94%
+    # of real ownership and invisible to the corpus.
+    setup do
+      corpus = [%{l_d: 8.0, picks: [%{norm: 2.0, player_id: "P1", manager: "bob"}]}]
+
+      ownership = %{
+        owns: %{{"alice", "P1"} => 3, {"bob", "P1"} => 1},
+        leagues: %{"alice" => 9, "bob" => 4, "carol" => 2}
+      }
+
+      {:ok, input: base_input(%{corpus: corpus, ownership: ownership, limit: 1})}
+    end
+
+    test "lists a manager who owns him but never drafted him", %{input: input} do
+      assert {:ok, response} = Availability.build(input)
+      assert [target] = response.targets
+
+      assert [alice, bob] = target.per_manager
+      assert alice.manager == "alice"
+      assert alice.owns == 3
+      assert alice.of_leagues == 9
+      assert alice.times == 0
+      assert alice.adp == nil, "an ownership-only entry has no draft ADP to report"
+      assert alice.picks == []
+
+      assert bob.manager == "bob"
+      assert bob.times == 1
+      assert bob.owns == 1
+      assert bob.of_leagues == 4
+      assert bob.adp == 2.0
+    end
+
+    test "a manager who neither drafted nor owns him is still absent", %{input: input} do
+      assert {:ok, response} = Availability.build(input)
+      assert [target] = response.targets
+      refute Enum.any?(target.per_manager, &(&1.manager == "carol"))
+    end
+
+    test "of_leagues is nil for a manager we hold no roster data for" do
+      corpus = [%{l_d: 8.0, picks: [%{norm: 2.0, player_id: "P1", manager: "bob"}]}]
+
+      input =
+        base_input(%{
+          corpus: corpus,
+          limit: 1,
+          ownership: %{owns: %{}, leagues: %{"alice" => 9}}
+        })
+
+      assert {:ok, response} = Availability.build(input)
+      assert [%{manager: "bob", owns: 0, of_leagues: nil}] = hd(response.targets).per_manager
+    end
+
+    test "with no ownership data at all the draft read is unchanged" do
+      corpus = [%{l_d: 8.0, picks: [%{norm: 2.0, player_id: "P1", manager: "bob"}]}]
+      input = base_input(%{corpus: corpus, limit: 1})
+
+      assert {:ok, response} = Availability.build(input)
+
+      assert [%{manager: "bob", times: 1, adp: 2.0, owns: 0, of_leagues: nil}] =
+               hd(response.targets).per_manager
+    end
+
+    # `notable` gates on drafts seen and times taken. An ownership-only entry
+    # has times 0, so it can never become the notable claim - which matters
+    # because notable prints an ADP delta this entry has no ADP for.
+    test "an ownership-only entry can never become the notable claim" do
+      corpus =
+        for i <- 1..10 do
+          %{l_d: 8.0, picks: [%{norm: 2.0, player_id: "P1", manager: "bob"}]}
+          |> Map.put(:draft_no, i)
+        end
+
+      input =
+        base_input(%{
+          corpus: corpus,
+          limit: 1,
+          ownership: %{owns: %{{"alice", "P1"} => 9}, leagues: %{"alice" => 9}}
+        })
+
+      assert {:ok, response} = Availability.build(input)
+      notable = hd(response.targets).notable
+      assert notable == false or notable.manager != "alice"
+    end
+  end
+
   describe "at_pick range checking" do
     # Measured against production before this existed: `at_pick=999` on a
     # 48-pick draft was a 200 with an empty board and a target whose

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
@@ -5,7 +5,7 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
   use SleeperPlayerApi.DataCase, async: false
 
   alias SleeperPlayerApi.Intel
-  alias SleeperPlayerApi.Intel.{ObservedLeague, ObservedTransaction}
+  alias SleeperPlayerApi.Intel.{ObservedLeague, ObservedRoster, ObservedTransaction}
   alias SleeperPlayerApi.Repo
   alias SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions
 
@@ -70,17 +70,18 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
       end)
     end
 
+    # `players` is what per-manager ownership reads. Sleeper sends the ids as
+    # strings and omits the key entirely for an unfilled roster, so the
+    # default here carries both shapes.
+    rosters =
+      Keyword.get(opts, :rosters, [
+        %{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034", "6794"]},
+        %{"roster_id" => 2, "owner_id" => "#{@bob}", "players" => ["4034"]}
+      ])
+
     Bypass.stub(bypass, "GET", "/league/900/rosters", fn conn ->
       :counters.add(counts, 1, 1)
-
-      Plug.Conn.resp(
-        conn,
-        200,
-        Jason.encode!([
-          %{"roster_id" => 1, "owner_id" => "#{@alice}"},
-          %{"roster_id" => 2, "owner_id" => "#{@bob}"}
-        ])
-      )
+      Plug.Conn.resp(conn, 200, Jason.encode!(rosters))
     end)
 
     for {w, txs} <- weeks do
@@ -165,11 +166,26 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
   end
 
   describe "the second run" do
-    test "makes far fewer calls, and does not refetch the roster map", %{bypass: bypass} do
-      # The §3f-style checkpoint for this step. Rosters are the saving: which
-      # user owns roster N never changes within a season, so refetching 176
-      # of them nightly would be most of the budget.
-      counts = stub(bypass, week_transactions: %{1 => [tx(1, creator: @alice)]})
+    test "makes far fewer calls, but does refetch the rosters", %{bypass: bypass} do
+      # The §3f-style checkpoint for this step. This used to assert the
+      # opposite — that a warm run never refetches rosters — which was right
+      # while the only thing read out of that payload was `roster_to_user`,
+      # a value that cannot change within a season.
+      #
+      # It now also carries `players`, which changes with every trade, waiver
+      # and free-agent add. A cached roster list answers "who did he own the
+      # first night we looked", which is worse than no answer because it
+      # looks current. Measured cost of the change: ~192 calls to ~346.
+      #
+      # The saving is now entirely in the settled weeks, so this runs at week
+      # 3 rather than week 1: with one league in the offseason there is one
+      # live week and nothing else to skip, and a warm run legitimately costs
+      # exactly what a cold one does.
+      counts =
+        stub(bypass,
+          current_week: 3,
+          week_transactions: %{1 => [tx(1, creator: @alice)], 2 => [], 3 => []}
+        )
 
       assert {:ok, first} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
       cold = :counters.get(counts, 1)
@@ -178,8 +194,8 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
       warm = :counters.get(counts, 1) - cold
 
       assert first.rosters_fetched == 1
-      assert second.rosters_fetched == 0, "a second run must not refetch a roster map"
-      assert warm < cold
+      assert second.rosters_fetched == 1, "roster contents go stale and must be refetched"
+      assert warm < cold, "the week/league dedupe still has to save most of the budget"
 
       # Re-storing the same live week upserts rather than duplicating.
       assert Repo.aggregate(ObservedTransaction, :count) == 1
@@ -194,6 +210,117 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
 
       assert second.weeks_fetched == 1, "week 1 is live and must come back every run"
       assert :counters.get(counts, 1) > before
+    end
+  end
+
+  describe "roster contents (per-manager ownership)" do
+    test "stores who is on each roster, as strings, from the crawl itself", %{bypass: bypass} do
+      stub(bypass)
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      rows = Repo.all(from(r in ObservedRoster, order_by: r.roster_id))
+
+      assert [%{roster_id: 1, owner_id: @alice, player_ids: ["4034", "6794"]}, %{roster_id: 2}] =
+               rows
+
+      assert Enum.all?(rows, &(&1.league_id == 900))
+      assert Enum.all?(rows, &(&1.fetched_at != nil))
+    end
+
+    test "a roster with no players yet stores an empty list, not a null", %{bypass: bypass} do
+      stub(bypass,
+        rosters: [
+          %{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => nil},
+          %{"roster_id" => 2, "owner_id" => "#{@bob}"}
+        ]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert Repo.all(from(r in ObservedRoster, select: r.player_ids)) == [[], []]
+    end
+
+    # The whole point of refetching. A cached list would keep reporting a
+    # player his manager has already traded away.
+    test "a dropped player stops being owned on the next run", %{bypass: bypass} do
+      stub(bypass,
+        rosters: [%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034", "6794"]}]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert {%{{@alice, "6794"} => 1}, _} = Intel.ownership(["6794"])
+
+      Bypass.down(bypass)
+      bypass = Bypass.open(port: bypass.port)
+
+      stub(bypass,
+        rosters: [%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034"]}]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert {ownership, _} = Intel.ownership(["6794"])
+      assert ownership == %{}, "ownership must be able to go down as well as up"
+    end
+
+    test "a failed roster fetch leaves the previous contents alone", %{bypass: bypass} do
+      stub(bypass,
+        rosters: [%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034"]}]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      Bypass.down(bypass)
+      bypass = Bypass.open(port: bypass.port)
+      stub(bypass)
+      Bypass.stub(bypass, "GET", "/league/900/rosters", &Plug.Conn.resp(&1, 500, "nope"))
+
+      assert {:ok, summary} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert [{:rosters_failed, 900, _}] = summary.errors
+
+      assert {%{{@alice, "4034"} => 1}, _} = Intel.ownership(["4034"]),
+             "a brief Sleeper failure must read as stale, not as 'nobody owns anybody'"
+    end
+  end
+
+  describe "ownership/1" do
+    test "counts leagues per manager per player, and gives an honest denominator", %{
+      bypass: bypass
+    } do
+      stub(bypass,
+        leagues_for: %{@alice => ["900", "901"], @bob => ["900"]},
+        rosters: [
+          %{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034"]},
+          %{"roster_id" => 2, "owner_id" => "#{@bob}", "players" => []}
+        ]
+      )
+
+      # League 901 answers with rosters nobody has filled — the case that
+      # made every production figure read 13% low when it was counted.
+      Bypass.stub(bypass, "GET", "/league/901/rosters", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          Jason.encode!([%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => []}])
+        )
+      end)
+
+      Bypass.stub(bypass, "GET", "/league/901/transactions/1", &Plug.Conn.resp(&1, 200, "[]"))
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert {ownership, leagues_seen} = Intel.ownership()
+      assert ownership == %{{@alice, "4034"} => 1}
+
+      assert leagues_seen == %{@alice => 1},
+             "an empty league is one we cannot see into, not one he owns nobody in"
+    end
+
+    test "narrowing by player_ids does not narrow the denominators", %{bypass: bypass} do
+      stub(bypass)
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert {ownership, leagues_seen} = Intel.ownership(["6794"])
+      assert ownership == %{{@alice, "6794"} => 1}
+      assert leagues_seen == %{@alice => 1, @bob => 1}
     end
   end
 

--- a/test/sleeper_player_api_web/controllers/availability_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/availability_controller_test.exs
@@ -543,6 +543,84 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
     end
   end
 
+  describe "GET /api/v1/drafts/:draft_id/availability — per-manager ownership" do
+    @describetag :corpus
+
+    setup %{bypass: bypass} do
+      seed_corpus_from_json!()
+      seed_target_players!()
+      stub_district_13(bypass)
+      :ok
+    end
+
+    test "carries owns/ofLeagues alongside the draft read", %{conn: conn} do
+      # ryangh holds this player in 2 of the 3 leagues we have rosters for.
+      # The third roster is his and does not hold him, which is what makes
+      # the denominator a real 3 rather than "however many we looked at".
+      ryangh = String.to_integer(@ryangh_user_id)
+      player_id = "13353"
+
+      seed_rosters!([
+        {901, 1, ryangh, [player_id, "6786"]},
+        {902, 1, ryangh, [player_id]},
+        {903, 1, ryangh, ["6786"]}
+      ])
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=#{player_id}"
+        )
+
+      assert [target] = json_response(conn, 200)["targets"]
+      assert entry = Enum.find(target["perManager"], &(&1["manager"] == "ryangh"))
+
+      assert entry["owns"] == 2
+      assert entry["ofLeagues"] == 3
+    end
+
+    test "a manager who owns him but never drafted him still appears", %{conn: conn} do
+      # atekipp has drafts in this corpus, so if he shows up for a player he
+      # never took, it is the roster data putting him there.
+      player_id = "13353"
+      atekipp = 859_581_197_427_257_344
+
+      seed_rosters!([{904, 1, atekipp, [player_id]}])
+
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=#{player_id}"
+        )
+
+      assert [target] = json_response(conn, 200)["targets"]
+      entry = Enum.find(target["perManager"], &(&1["manager"] == "atekipp"))
+
+      refute is_nil(entry), "a manager who owns him must be listed even with no picks"
+      assert entry["owns"] == 1
+      assert entry["ofLeagues"] == 1
+      assert entry["times"] == 0
+      assert entry["adp"] == nil
+      assert entry["picks"] == []
+    end
+
+    test "with no roster data at all, ofLeagues is null rather than zero", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/api/v1/drafts/#{@draft_id}/availability?user_id=#{@ryangh_user_id}&player_ids=13353"
+        )
+
+      assert [target] = json_response(conn, 200)["targets"]
+      assert target["perManager"] != []
+
+      for entry <- target["perManager"] do
+        assert entry["owns"] == 0
+        assert entry["ofLeagues"] == nil, "0 of 0 is not a fact about anybody"
+      end
+    end
+  end
+
   describe "GET /api/v1/drafts/:draft_id/availability — at_pick out of range" do
     # Needs the draft itself (48 picks) to know what "out of range" means,
     # so unlike the parse-level validation above these go through the stubs.
@@ -743,6 +821,28 @@ defmodule SleeperPlayerApiWeb.AvailabilityControllerTest do
     |> Enum.sort_by(fn {_id, count} -> -count end)
     |> Enum.map(fn {id, _count} -> id end)
     |> Enum.take(25)
+  end
+
+  # `{league_id, roster_id, owner_id, player_ids}`. The leagues have to exist
+  # first: `observed_rosters.league_id` is a real FK, which is what stops a
+  # roster row outliving the league it describes.
+  defp seed_rosters!(rows) do
+    rows
+    |> Enum.map(fn {league_id, _, _, _} -> %{id: league_id, season: "2026"} end)
+    |> Enum.uniq()
+    |> Intel.upsert_observed_leagues()
+
+    Intel.upsert_observed_rosters(
+      Enum.map(rows, fn {league_id, roster_id, owner_id, player_ids} ->
+        %{
+          league_id: league_id,
+          roster_id: roster_id,
+          owner_id: owner_id,
+          player_ids: player_ids,
+          fetched_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        }
+      end)
+    )
   end
 
   defp seed_users_only! do


### PR DESCRIPTION
The draft block answers "how often does he take this guy". It cannot answer "does he have him right now", and measurement says those are mostly different questions.

Measured across the real corpus on 2026-08-09, by fetching `/league/:id/rosters` for all 176 observed leagues:

| | |
| --- | --- |
| draft rate vs ownership rate | **Spearman 0.785** |
| ownership pairs never appearing in a crawled draft | **94%** (46,906 of 50,022) |
| 2026 rookies owned by a manager who never drafted them | 3,036 pairs |

It helps most where the draft read is weakest. `skeefe` has **1** crawled draft — the 8-draft signal gate hides him entirely — and **30** leagues of roster data. `N8TEDAGR38T`: 27 drafts, 58 leagues.

This is *not* the number §5 rejected. That was the corpus-wide aggregate ("rostered in 87% of leagues"), which measured 0.9744 against League ADP on the rookie class and is recorded as rejected in the plan. This is the per-manager one, which was never assessed.

## What changed

`/league/:id/rosters` was already fetched by the transaction crawl; its `players` list was discarded. It now lands in `observed_rosters` and reaches the API as `owns` / `ofLeagues` on each `perManager` entry.

An entry now appears when a manager has drafted the player **or** owns him somewhere, so the ownership-only managers show up. `adp`/`picks` stay null/empty for those rather than being faked from the ownership count.

## Three calls worth reviewing

- **Rosters are refetched every run**, where they were cached for the season. Right for `roster_to_user`, which cannot change within a season; wrong for contents, which move with every transaction. ~192 calls a night to ~346, against a 300/min limiter and Sleeper's 1000/min.
- **The denominator counts only leagues we can see into.** 22 of the 176 return no rostered players; counting them capped ownership at 87.5% and read every figure ~13% low. Same shape as the corpus-wide denominator defect the leaguemates view already shipped once.
- **`ofLeagues` is null, not 0**, when we hold no roster data for a manager. "Owns him in 0 of 0 leagues" is not a fact about anybody, and the client has to tell that apart from a real zero.

## Testing

11 new tests. Ownership goes through the real crawler against Bypass rather than a seeding helper, per the standing rule — including a player being dropped between runs, which is the case a cached roster list gets wrong.

One existing assertion was inverted on purpose: "a second run must not refetch a roster map" encoded the old policy. Its replacement runs at week 3, because with one league in the offseason a warm run legitimately costs what a cold one does, and the saving is entirely in the settled weeks.

Sabotaged five ways, each grepped before running: denominator counting empty leagues (1 failure), rosters cached again (3), upsert coalescing instead of replacing `player_ids` (1), dropping ownership-only entries (3), and `ofLeagues` as 0 instead of null (3).

A test also caught a live bug during development: binding `of_leagues` as a comprehension filter silently dropped any manager we had no roster data for — including ones who *had* drafted the player — because nil reads as a falsy filter.