### PR TITLE
Serve the market values we already collect

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -237,6 +237,44 @@ defmodule SleeperPlayerApi.Intel do
   end
 
   @doc """
+  The current market values for `source`, best player first.
+
+  Ordered by `overall_rank` because that is what the caller wants it for — a
+  ranking list is an order, and sorting 600 rows in the browser to recover an
+  order the database can hand over sorted is work for nothing. Rows with no
+  `overall_rank` sort last rather than first, which is what `NULLS LAST` is
+  doing here: Postgres orders nulls first on `ASC` by default, so without it
+  a player the feed has no opinion on would open the list.
+
+  No join to `players`. Every caller of this already has the whole player
+  database — the frontend downloads it for the draft board and the roster
+  view — so returning names here would ship a second copy of data the caller
+  is holding, to save it a map lookup. `player_id` is the join key and
+  FantasyCalc hands it over as a Sleeper id, which is the entire reason that
+  source was chosen (plan §2).
+
+  `as_of` travels per row rather than once for the batch: the refresh writes
+  the whole feed in one pass so they are equal in practice, but a partial
+  refresh is a thing that can happen and "the list is from Tuesday" should
+  not be inferred from one row on the caller's behalf.
+  """
+  @spec player_values(String.t()) :: [map]
+  def player_values(source) do
+    from(pv in PlayerValue,
+      where: pv.source == ^source,
+      order_by: [asc_nulls_last: pv.overall_rank],
+      select: %{
+        player_id: pv.player_id,
+        value: pv.value,
+        overall_rank: pv.overall_rank,
+        position_rank: pv.position_rank,
+        as_of: pv.as_of
+      }
+    )
+    |> Repo.all()
+  end
+
+  @doc """
   One manager's recent activity, plus what it rests on.
 
   Bundles `transactions_for_user/2` with `transaction_coverage/2` and the

--- a/lib/sleeper_player_api_web/controllers/player_value_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/player_value_controller.ex
@@ -1,0 +1,37 @@
+defmodule SleeperPlayerApiWeb.PlayerValueController do
+  use SleeperPlayerApiWeb, :controller
+
+  alias SleeperPlayerApi.Intel
+
+  action_fallback SleeperPlayerApiWeb.FallbackController
+
+  # The only source there is. A path or query segment naming the provider
+  # would imply a choice the caller does not have — the same species of lie
+  # as `ManagerActivityController`'s rejected nested route. When a second
+  # source lands (plan §2 designed `PlayerValueSource` to be swappable), it
+  # can become a parameter then, with something real to choose between.
+  @source "fantasycalc"
+
+  @doc """
+  `GET /api/v1/values` — the current market values, best player first.
+
+  Exists to give the frontend a ranking list it does not have to be given.
+  Every other way into that app's rank list starts with a human pasting text,
+  which is then guessed at: the name parsed out of a line, the player matched
+  fuzzily against 9,000-odd others. This one is keyed by Sleeper id the whole
+  way, so nothing is guessed and nothing can be matched to the wrong person.
+
+  ## What this is *not*
+
+  Not "the rankings". It is one provider's dynasty trade values at fixed
+  settings — superflex, 12-team, full PPR, pinned in
+  `SleeperPlayerApi.Client.FantasyCalc`. In a 1-QB or 10-team league these
+  numbers are simply about a different game, and a caller that presents them
+  as neutral truth is overclaiming in exactly the way this feature has
+  overclaimed four times before. `settings` is in the response so the caller
+  can say what it is showing, and it is not decoration.
+  """
+  def index(conn, _params) do
+    render(conn, :index, values: Intel.player_values(@source))
+  end
+end

--- a/lib/sleeper_player_api_web/controllers/player_value_json.ex
+++ b/lib/sleeper_player_api_web/controllers/player_value_json.ex
@@ -1,0 +1,62 @@
+defmodule SleeperPlayerApiWeb.PlayerValueJSON do
+  @moduledoc """
+  Renders `SleeperPlayerApi.Intel.player_values/1` — camelCase keys, same
+  snake_case-context / camelCase-view split as the other JSON modules here.
+
+  `settings` describes what the numbers are of, and must not be dropped by a
+  caller looking to slim the payload. Dynasty superflex values in a 1-QB
+  league are not slightly off, they are about a different game, and this
+  feature's standing lesson is that the figure is fine and the sentence next
+  to it overclaims. The caller needs this to write that sentence.
+  """
+
+  @doc """
+  The value list, plus what the values are of and when they were taken.
+
+  `asOf` is the newest row's timestamp — the freshness of the list as a whole
+  is the freshest thing in it, and a caller showing "updated 3 days ago"
+  wants that rather than the oldest straggler. `null` for an empty list
+  rather than a fabricated now: before the nightly refresh has ever run this
+  endpoint answers honestly that it has nothing, which is the same shape as
+  `market_rookie_class_entries/1` returning `[]` rather than inventing a
+  market read.
+  """
+  def index(%{values: values}) do
+    %{
+      settings: %{
+        source: "fantasycalc",
+        format: "dynasty",
+        numQbs: 2,
+        numTeams: 12,
+        ppr: 1
+      },
+      asOf: newest(values),
+      values: Enum.map(values, &value/1)
+    }
+  end
+
+  # Sleeper ids are strings on the wire, everywhere in this API. They are
+  # 19 digits for a user and comfortably inside the safe range for a player,
+  # but `IntelJSON` and `ManagerActivityJSON` both string them and a caller
+  # keying one map by a number and another by a string finds out at runtime.
+  defp value(v) do
+    %{
+      playerId: to_string(v.player_id),
+      value: v.value,
+      overallRank: v.overall_rank,
+      positionRank: v.position_rank
+    }
+  end
+
+  defp newest([]), do: nil
+
+  defp newest(values) do
+    values
+    |> Enum.map(& &1.as_of)
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> nil
+      stamps -> Enum.max(stamps, DateTime)
+    end
+  end
+end

--- a/lib/sleeper_player_api_web/router.ex
+++ b/lib/sleeper_player_api_web/router.ex
@@ -20,6 +20,7 @@ defmodule SleeperPlayerApiWeb.Router do
     get "/players", PlayerController, :index
     get "/players/active", PlayerController, :active
     get "/players/:id", PlayerController, :show
+    get "/values", PlayerValueController, :index
     get "/drafts/:draft_id/availability", AvailabilityController, :show
     get "/leagues/:league_id/intel", IntelController, :show
     get "/users/:user_id/activity", ManagerActivityController, :show

--- a/test/sleeper_player_api_web/controllers/player_value_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/player_value_controller_test.exs
@@ -1,0 +1,126 @@
+defmodule SleeperPlayerApiWeb.PlayerValueControllerTest do
+  use SleeperPlayerApiWeb.ConnCase, async: true
+
+  alias SleeperPlayerApi.Intel
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  defp seed(values), do: Intel.upsert_player_values(values)
+
+  defp value(player_id, attrs) do
+    Map.merge(
+      %{
+        player_id: player_id,
+        source: "fantasycalc",
+        value: 1000.0,
+        overall_rank: 1,
+        position_rank: 1,
+        roster_percent: 90.0,
+        trade_frequency: 1.0,
+        as_of: ~U[2026-08-10 08:30:00Z],
+        draft_year: 2025
+        # No inserted_at/updated_at: `insert_all_batched` stamps them, and
+        # they are naive datetimes while `as_of` is a real one.
+      },
+      attrs
+    )
+  end
+
+  describe "GET /api/v1/values" do
+    test "returns the values best player first", %{conn: conn} do
+      seed([
+        value(3, %{overall_rank: 3, value: 800.0}),
+        value(1, %{overall_rank: 1, value: 1000.0}),
+        value(2, %{overall_rank: 2, value: 900.0})
+      ])
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert Enum.map(body["values"], & &1["playerId"]) == ["1", "2", "3"]
+    end
+
+    # Sleeper ids are strings on the wire everywhere else in this API, and a
+    # caller keying one map by a number and another by a string finds out at
+    # runtime rather than at the boundary.
+    test "sends player ids as strings", %{conn: conn} do
+      seed([value(12_345, %{})])
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert [%{"playerId" => "12345"}] = body["values"]
+    end
+
+    test "carries the rank and value behind each player", %{conn: conn} do
+      seed([value(7, %{overall_rank: 4, position_rank: 2, value: 850.5})])
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert [%{"overallRank" => 4, "positionRank" => 2, "value" => 850.5}] = body["values"]
+    end
+
+    # Postgres sorts nulls first on ASC, so without NULLS LAST a player the
+    # feed has no opinion on would open the ranking list.
+    test "puts a player with no overall rank last, not first", %{conn: conn} do
+      seed([
+        value(9, %{overall_rank: nil}),
+        value(1, %{overall_rank: 1}),
+        value(2, %{overall_rank: 2})
+      ])
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert Enum.map(body["values"], & &1["playerId"]) == ["1", "2", "9"]
+    end
+
+    test "reports the settings the values are of", %{conn: conn} do
+      seed([value(1, %{})])
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert body["settings"] == %{
+               "source" => "fantasycalc",
+               "format" => "dynasty",
+               "numQbs" => 2,
+               "numTeams" => 12,
+               "ppr" => 1
+             }
+    end
+
+    test "reports the freshest timestamp in the list", %{conn: conn} do
+      seed([
+        value(1, %{overall_rank: 1, as_of: ~U[2026-08-09 08:30:00Z]}),
+        value(2, %{overall_rank: 2, as_of: ~U[2026-08-10 08:30:00Z]})
+      ])
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert body["asOf"] == "2026-08-10T08:30:00Z"
+    end
+
+    # Before the nightly refresh has ever run. An empty list and a null
+    # timestamp is the honest answer; a fabricated `now` would tell the caller
+    # its empty list was current.
+    test "answers with nothing rather than inventing a timestamp", %{conn: conn} do
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert body["values"] == []
+      assert body["asOf"] == nil
+    end
+
+    # `player_values` is keyed by (player_id, source) and the schema is built
+    # for more than one provider. Another source's rows must not leak into a
+    # list presented as FantasyCalc's.
+    test "returns only the FantasyCalc rows", %{conn: conn} do
+      seed([
+        value(1, %{overall_rank: 1}),
+        value(2, %{source: "somewhere_else", overall_rank: 2})
+      ])
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert Enum.map(body["values"], & &1["playerId"]) == ["1"]
+    end
+  end
+end


### PR DESCRIPTION
`RefreshPlayerValues` has been pulling FantasyCalc into `player_values` nightly since the intel work, and nothing outside this repo can read it. Meanwhile the frontend's rank list can only be filled by a human pasting text, which is then parsed and fuzzily matched against nine thousand players.

`GET /api/v1/values` returns what is already collected, best player first.

```json
{
  "settings": { "source": "fantasycalc", "format": "dynasty", "numQbs": 2, "numTeams": 12, "ppr": 1 },
  "asOf": "2026-08-10T08:30:00Z",
  "values": [{ "playerId": "11631", "value": 9812.0, "overallRank": 1, "positionRank": 1 }]
}
```

## Decisions worth reviewing

**No join to `players`.** Every caller already holds the player database — the frontend downloads it for the draft board and the roster view — so sending names would ship a second copy of what the caller has, to save it a map lookup. `playerId` is the join key, and FantasyCalc handing over Sleeper ids is the whole reason it was picked over KTC.

**`settings` is not decoration.** These are dynasty superflex 12-team full-PPR values, pinned in `Client.FantasyCalc`. In a 1-QB or 10-team league they aren't slightly off, they're about a different game, and the caller needs to be able to say which. Same standing lesson as every other figure in this feature carrying its sample size.

**`asOf` is the newest row, not the oldest**, and `null` for an empty list rather than a fabricated `now` — before the nightly refresh has ever run, the honest answer is that there's nothing yet.

**`NULLS LAST`.** Postgres sorts nulls first on `ASC`, so without it a player the feed has no opinion on would open the ranking list.

**No source parameter.** There's one source; a path or query segment naming it would imply a choice the caller doesn't have. When a second lands, `PlayerValueSource` is already designed to be swappable and it can become a parameter with something real to choose between.

## Checks

`mix test` — 249 passing. 8 new, covering the ordering, the nulls-last case, string ids, the settings block, the freshest-timestamp rule, the empty case, and that another source's rows can't leak into a list presented as FantasyCalc's.

## Unrelated, but noticed

`mix format --check-formatted` **already fails on `main`** — `config/runtime.exs`, `config/prod.exs`, `lib/sleeper_player_api/sleeper.ex`, `sleeper/player.ex`, `tasks/get_sleeper_player_data.ex`, `priv/repo/seeds.exs` and two test files are committed unformatted. I ran a blanket `mix format` by habit, then reverted everything outside this change so the diff stays scoped. Worth its own pass.
