### PR TITLE
Answer /values for the league that asked, not just ours

### DIFF
--- a/lib/sleeper_player_api/application.ex
+++ b/lib/sleeper_player_api/application.ex
@@ -18,6 +18,8 @@ defmodule SleeperPlayerApi.Application do
       {Finch, name: SleeperPlayerApi.Finch},
       # Start the shared Sleeper API rate limiter
       SleeperPlayerApi.RateLimiter,
+      # Start the market-value cache (owns its ETS table)
+      SleeperPlayerApi.Intel.MarketValuesCache,
       # Start the Endpoint (http/https)
       {SiteEncrypt.Phoenix, SleeperPlayerApiWeb.Endpoint},
       # Start Quantum scheduler

--- a/lib/sleeper_player_api/intel/market_settings.ex
+++ b/lib/sleeper_player_api/intel/market_settings.ex
@@ -1,0 +1,129 @@
+defmodule SleeperPlayerApi.Intel.MarketSettings do
+  @moduledoc """
+  The league shape a set of market values is *of*.
+
+  Values are not one list. FantasyCalc prices a player against a format, and
+  the difference is not a rounding: in superflex their top player is a
+  quarterback and in single-QB it is a running back. A caller handed the
+  wrong slice is not looking at slightly-off numbers, it is looking at a
+  different game.
+
+  The nightly refresh stores exactly one slice — the default below — because
+  the availability model in `SleeperPlayerApi.Intel` is calibrated against
+  it. That default must not change without recalibrating; everything else is
+  fetched on request.
+  """
+
+  @type t :: %{dynasty: boolean, num_qbs: pos_integer, num_teams: pos_integer, ppr: float}
+
+  # The stored slice. `RefreshPlayerValues` writes this one nightly and the
+  # estimator is calibrated against it — see plan §2.
+  @default %{dynasty: true, num_qbs: 2, num_teams: 12, ppr: 1.0}
+
+  # Bounds, not a supported-values list. FantasyCalc answers 200 for anything
+  # asked of it (an 11-team league, `numQbs=3`), so these exist to stop this
+  # API being used to make arbitrary outbound requests, not to second-guess
+  # what leagues exist. A 32-team league is absurd and also harmless.
+  @max_teams 32
+  @max_qbs 4
+
+  @doc "The slice the nightly refresh stores, and the default for a request."
+  @spec default() :: t
+  def default, do: @default
+
+  @doc "Whether these are the stored settings, and so answerable without a fetch."
+  @spec default?(t) :: boolean
+  def default?(settings), do: settings == @default
+
+  @doc """
+  Request params as settings, falling back to the stored slice field by field.
+
+  Field by field rather than all-or-nothing: a caller that knows only its
+  league size should be able to say so without also having to state a PPR it
+  has not looked up.
+
+  Returns `{:error, {:invalid_param, key, value}}` for something unreadable
+  and `{:error, {:param_out_of_range, key, value, min, max}}` for a number
+  that read fine and is not allowed — the two are told apart for the same
+  reason `:pick_out_of_range` is separate from `:invalid_param` elsewhere in
+  this API: "num_teams must be an integer, got 999" is a false statement
+  about a perfectly good integer.
+
+  Either way it is an error rather than a silent fallback. Substituting the
+  default for a bad value answers a question nobody asked, in a feature whose
+  whole point is knowing which question was.
+  """
+  @spec parse(map) ::
+          {:ok, t}
+          | {:error, {:invalid_param, String.t(), term}}
+          | {:error, {:param_out_of_range, String.t(), term, number, number}}
+  def parse(params) do
+    with {:ok, dynasty} <- boolean(params, "dynasty", @default.dynasty),
+         {:ok, num_qbs} <- integer(params, "num_qbs", @default.num_qbs, 1, @max_qbs),
+         {:ok, num_teams} <- integer(params, "num_teams", @default.num_teams, 2, @max_teams),
+         {:ok, ppr} <- number(params, "ppr", @default.ppr, 0, 3) do
+      {:ok, %{dynasty: dynasty, num_qbs: num_qbs, num_teams: num_teams, ppr: ppr}}
+    end
+  end
+
+  @doc "These settings as FantasyCalc's query string."
+  @spec to_query(t) :: String.t()
+  def to_query(%{dynasty: dynasty, num_qbs: num_qbs, num_teams: num_teams, ppr: ppr}) do
+    URI.encode_query(%{
+      "isDynasty" => to_string(dynasty),
+      "numQbs" => num_qbs,
+      "numTeams" => num_teams,
+      "ppr" => format_ppr(ppr)
+    })
+  end
+
+  # 1.0 as "1", 0.5 as "0.5". FantasyCalc takes either, but the query string
+  # is the cache key, so `ppr=1` and `ppr=1.0` arriving from two callers must
+  # not become two entries for one answer.
+  defp format_ppr(ppr) do
+    if ppr == trunc(ppr), do: trunc(ppr), else: ppr
+  end
+
+  defp boolean(params, key, fallback) do
+    case params[key] do
+      nil -> {:ok, fallback}
+      "true" -> {:ok, true}
+      "false" -> {:ok, false}
+      other -> {:error, {:invalid_param, key, other}}
+    end
+  end
+
+  defp integer(params, key, fallback, min, max) do
+    case params[key] do
+      nil ->
+        {:ok, fallback}
+
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {int, ""} when int >= min and int <= max -> {:ok, int}
+          {_int, ""} -> {:error, {:param_out_of_range, key, value, min, max}}
+          _ -> {:error, {:invalid_param, key, value}}
+        end
+
+      other ->
+        {:error, {:invalid_param, key, other}}
+    end
+  end
+
+  defp number(params, key, fallback, min, max) do
+    case params[key] do
+      nil ->
+        {:ok, fallback}
+
+      value when is_binary(value) ->
+        case Float.parse(value) do
+          {float, ""} when float >= min and float <= max -> {:ok, float}
+          {_float, ""} -> {:error, {:param_out_of_range, key, value, min, max}}
+          _ -> {:error, {:invalid_param, key, value}}
+        end
+
+      other ->
+        {:error, {:invalid_param, key, other}}
+    end
+  end
+end

--- a/lib/sleeper_player_api/intel/market_values.ex
+++ b/lib/sleeper_player_api/intel/market_values.ex
@@ -1,0 +1,86 @@
+defmodule SleeperPlayerApi.Intel.MarketValues do
+  @moduledoc """
+  Reading market values for a given league shape.
+
+  Two ways to answer, and the caller does not choose between them. The stored
+  slice — the one `RefreshPlayerValues` writes nightly — comes out of the
+  database. Anything else is fetched from the provider and cached, because
+  storing every combination of format, league size and scoring would be a
+  nightly job against a space nobody has enumerated, for slices most of which
+  no one will ever ask about.
+
+  The cache is a courtesy to FantasyCalc more than a speed measure. They are
+  a free, unauthenticated, public API and this app is a guest: a rank list is
+  a button press, and a button press should not become a third-party request
+  every time somebody presses it twice.
+  """
+
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.MarketSettings
+  alias SleeperPlayerApi.Intel.MarketValuesCache
+
+  @source "fantasycalc"
+
+  @doc """
+  The values for `settings`, best player first.
+
+  Returns `{:error, reason}` only for a live fetch that failed. The stored
+  slice cannot fail this way — an empty table is `{:ok, []}`, which is a
+  truthful "the refresh has not run yet" rather than an error.
+  """
+  @spec values(MarketSettings.t()) :: {:ok, [map]} | {:error, term}
+  def values(settings) do
+    if MarketSettings.default?(settings) do
+      {:ok, Intel.player_values(@source)}
+    else
+      fetch(settings)
+    end
+  end
+
+  defp fetch(settings) do
+    key = MarketSettings.to_query(settings)
+
+    case MarketValuesCache.get(key) do
+      {:ok, cached} ->
+        {:ok, cached}
+
+      :miss ->
+        case source().fetch_values(settings) do
+          {:ok, entries} ->
+            values = entries |> Enum.map(&shape/1) |> Enum.sort_by(&sort_key/1)
+            MarketValuesCache.put(key, values)
+            {:ok, values}
+
+          {:error, _reason} = error ->
+            error
+        end
+    end
+  end
+
+  # The provider shapes for the database — source, roster_percent,
+  # trade_frequency, draft_year — and none of that reaches a caller asking for
+  # a ranking list. Narrowed here so the live path and the stored path hand
+  # back the same thing and the JSON view cannot tell them apart.
+  defp shape(entry) do
+    %{
+      player_id: entry.player_id,
+      value: entry.value,
+      overall_rank: entry.overall_rank,
+      position_rank: entry.position_rank,
+      as_of: entry.as_of
+    }
+  end
+
+  # Same order the stored query uses, nulls last: a player the feed has no
+  # opinion on must not open the list.
+  defp sort_key(%{overall_rank: nil}), do: {1, 0}
+  defp sort_key(%{overall_rank: rank}), do: {0, rank}
+
+  defp source do
+    Application.get_env(
+      :sleeper_player_api,
+      :player_value_source,
+      SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalc
+    )
+  end
+end

--- a/lib/sleeper_player_api/intel/market_values_cache.ex
+++ b/lib/sleeper_player_api/intel/market_values_cache.ex
@@ -1,0 +1,88 @@
+defmodule SleeperPlayerApi.Intel.MarketValuesCache do
+  @moduledoc """
+  A small TTL cache for market-value fetches, keyed by the query string that
+  produced them.
+
+  ETS rather than a dependency: one table, one expiry rule, no eviction
+  policy worth the name. The key space is bounded by how many distinct league
+  shapes ask — a handful — and each entry is a few hundred players, so
+  nothing here needs to be cleverer than "drop it when it is old".
+
+  Reads go straight to ETS rather than through the GenServer. The process
+  exists to own the table and to survive, not to serialise access: a read
+  that queued behind a slow write would make this a bottleneck instead of a
+  courtesy.
+  """
+
+  use GenServer
+
+  @table __MODULE__
+
+  # Six hours. The provider refreshes daily and the nightly job picks that up
+  # at 3:30am Central, so a slice fetched on request is allowed to be some
+  # hours stale - a rank list is a starting point, not a live quote, and the
+  # response carries `asOf` so the caller can say how old it is.
+  @default_ttl_ms 6 * 60 * 60 * 1000
+
+  def start_link(opts \\ []) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    gen_opts = if name, do: [name: name], else: []
+    GenServer.start_link(__MODULE__, opts, gen_opts)
+  end
+
+  @doc """
+  The cached values for `key`, or `:miss` if absent or expired.
+
+  An expired entry is left in place rather than deleted on read: the next
+  `put/2` overwrites it, and deleting from a reader would make a read a
+  write for no benefit.
+  """
+  @spec get(String.t()) :: {:ok, [map]} | :miss
+  def get(key) do
+    case :ets.lookup(@table, key) do
+      [{^key, values, expires_at}] ->
+        if now_ms() < expires_at, do: {:ok, values}, else: :miss
+
+      [] ->
+        :miss
+    end
+  rescue
+    # The table does not exist - the cache is not running, which is possible
+    # in a test that starts a bare application. A cache that is not there is a
+    # miss, not a crash.
+    ArgumentError -> :miss
+  end
+
+  @doc "Stores `values` under `key`, expiring after the configured TTL."
+  @spec put(String.t(), [map]) :: :ok
+  def put(key, values) do
+    :ets.insert(@table, {key, values, now_ms() + ttl_ms()})
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc "Drops everything. Tests use this; nothing in production does."
+  @spec clear() :: :ok
+  def clear do
+    :ets.delete_all_objects(@table)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @impl true
+  def init(opts) do
+    # `:public` because writers are request processes, not this one. `:named_table`
+    # so readers need no handle.
+    :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
+    {:ok, opts}
+  end
+
+  defp ttl_ms do
+    Application.get_env(:sleeper_player_api, __MODULE__, [])
+    |> Keyword.get(:ttl_ms, @default_ttl_ms)
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/lib/sleeper_player_api/intel/player_value_sources/fantasy_calc.ex
+++ b/lib/sleeper_player_api/intel/player_value_sources/fantasy_calc.ex
@@ -12,6 +12,7 @@ defmodule SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalc do
   @behaviour SleeperPlayerApi.Intel.PlayerValueSource
 
   alias SleeperPlayerApi.Client.FantasyCalc, as: Client
+  alias SleeperPlayerApi.Intel.MarketSettings
 
   @source "fantasycalc"
 
@@ -19,8 +20,19 @@ defmodule SleeperPlayerApi.Intel.PlayerValueSources.FantasyCalc do
   def name, do: @source
 
   @impl true
-  def fetch_values do
-    case Client.get() do
+  def fetch_values, do: fetch_values(MarketSettings.default())
+
+  @doc """
+  The same fetch, for a league shape other than the stored one.
+
+  Separate from `fetch_values/0` rather than replacing it: the nightly
+  refresh writes exactly one slice and the availability model is calibrated
+  against it, so the behaviour callback must keep meaning that slice and
+  nothing else. This arity is for a caller asking about *their* league.
+  """
+  @spec fetch_values(MarketSettings.t()) :: {:ok, [map]} | {:error, term}
+  def fetch_values(settings) do
+    case Client.get("/values/current?" <> MarketSettings.to_query(settings)) do
       {:ok, entries} when is_list(entries) ->
         now = DateTime.utc_now() |> DateTime.truncate(:second)
         {:ok, entries |> Enum.flat_map(&shape_entry(&1, now))}

--- a/lib/sleeper_player_api_web/controllers/fallback_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/fallback_controller.ex
@@ -45,6 +45,19 @@ defmodule SleeperPlayerApiWeb.FallbackController do
     })
   end
 
+  # A query param read as a number but is not one this API will accept
+  # (`MarketSettings`' league-shape bounds). Separate from `:invalid_param`
+  # for the same reason `:pick_out_of_range` is: telling someone `999` is not
+  # an integer is a false statement about a perfectly good integer.
+  def call(conn, {:error, {:param_out_of_range, key, value, min, max}}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: SleeperPlayerApiWeb.ErrorJSON)
+    |> Phoenix.Controller.json(%{
+      errors: %{detail: "#{key} must be between #{min} and #{max}, got: #{inspect(value)}"}
+    })
+  end
+
   # `at_pick` parsed as an integer but isn't a pick this draft has
   # (`SleeperPlayerApi.Intel.Availability.build/1`). The upper bound is
   # `last_pick + 1` because that is the `currentPick` a finished draft

--- a/lib/sleeper_player_api_web/controllers/player_value_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/player_value_controller.ex
@@ -1,19 +1,14 @@
 defmodule SleeperPlayerApiWeb.PlayerValueController do
   use SleeperPlayerApiWeb, :controller
 
-  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.MarketSettings
+  alias SleeperPlayerApi.Intel.MarketValues
 
   action_fallback SleeperPlayerApiWeb.FallbackController
 
-  # The only source there is. A path or query segment naming the provider
-  # would imply a choice the caller does not have — the same species of lie
-  # as `ManagerActivityController`'s rejected nested route. When a second
-  # source lands (plan §2 designed `PlayerValueSource` to be swappable), it
-  # can become a parameter then, with something real to choose between.
-  @source "fantasycalc"
-
   @doc """
-  `GET /api/v1/values` — the current market values, best player first.
+  `GET /api/v1/values?dynasty=&num_qbs=&num_teams=&ppr=` — the current market
+  values for a league shape, best player first.
 
   Exists to give the frontend a ranking list it does not have to be given.
   Every other way into that app's rank list starts with a human pasting text,
@@ -21,17 +16,26 @@ defmodule SleeperPlayerApiWeb.PlayerValueController do
   fuzzily against 9,000-odd others. This one is keyed by Sleeper id the whole
   way, so nothing is guessed and nothing can be matched to the wrong person.
 
-  ## What this is *not*
+  ## The params are the point
 
-  Not "the rankings". It is one provider's dynasty trade values at fixed
-  settings — superflex, 12-team, full PPR, pinned in
-  `SleeperPlayerApi.Client.FantasyCalc`. In a 1-QB or 10-team league these
-  numbers are simply about a different game, and a caller that presents them
-  as neutral truth is overclaiming in exactly the way this feature has
-  overclaimed four times before. `settings` is in the response so the caller
-  can say what it is showing, and it is not decoration.
+  A player is priced against a format, and the difference is not a rounding.
+  In superflex the most valuable player is a quarterback; in single-QB he is
+  a running back. Answering every caller with one slice — which this endpoint
+  did when it shipped — hands a 10-team single-QB league a list about a
+  different game and says nothing about it.
+
+  Omitted params fall back to the stored slice field by field, so a caller
+  that knows only its league size can say only that. `settings` comes back in
+  the response describing what was actually answered.
+
+  Anything unparseable or out of range is a 400 rather than a quiet
+  substitution: answering a question nobody asked is the specific failure
+  this whole feature keeps re-learning.
   """
-  def index(conn, _params) do
-    render(conn, :index, values: Intel.player_values(@source))
+  def index(conn, params) do
+    with {:ok, settings} <- MarketSettings.parse(params),
+         {:ok, values} <- MarketValues.values(settings) do
+      render(conn, :index, values: values, settings: settings)
+    end
   end
 end

--- a/lib/sleeper_player_api_web/controllers/player_value_json.ex
+++ b/lib/sleeper_player_api_web/controllers/player_value_json.ex
@@ -8,6 +8,11 @@ defmodule SleeperPlayerApiWeb.PlayerValueJSON do
   league are not slightly off, they are about a different game, and this
   feature's standing lesson is that the figure is fine and the sentence next
   to it overclaims. The caller needs this to write that sentence.
+
+  It echoes the settings that were *answered*, not the ones that were asked
+  for. Those differ whenever a param was omitted and fell back, which is the
+  common case - a caller sending only `num_teams` still needs to be told what
+  format and scoring it got.
   """
 
   @doc """
@@ -21,14 +26,14 @@ defmodule SleeperPlayerApiWeb.PlayerValueJSON do
   `market_rookie_class_entries/1` returning `[]` rather than inventing a
   market read.
   """
-  def index(%{values: values}) do
+  def index(%{values: values, settings: settings}) do
     %{
       settings: %{
         source: "fantasycalc",
-        format: "dynasty",
-        numQbs: 2,
-        numTeams: 12,
-        ppr: 1
+        format: if(settings.dynasty, do: "dynasty", else: "redraft"),
+        numQbs: settings.num_qbs,
+        numTeams: settings.num_teams,
+        ppr: settings.ppr
       },
       asOf: newest(values),
       values: Enum.map(values, &value/1)

--- a/test/sleeper_player_api/intel/market_settings_test.exs
+++ b/test/sleeper_player_api/intel/market_settings_test.exs
@@ -1,0 +1,113 @@
+defmodule SleeperPlayerApi.Intel.MarketSettingsTest do
+  use ExUnit.Case, async: true
+
+  alias SleeperPlayerApi.Intel.MarketSettings
+
+  describe "parse/1" do
+    test "falls back to the stored slice when nothing is asked for" do
+      assert {:ok, settings} = MarketSettings.parse(%{})
+      assert settings == MarketSettings.default()
+    end
+
+    test "reads every field" do
+      assert {:ok, settings} =
+               MarketSettings.parse(%{
+                 "dynasty" => "false",
+                 "num_qbs" => "1",
+                 "num_teams" => "10",
+                 "ppr" => "0.5"
+               })
+
+      assert settings == %{dynasty: false, num_qbs: 1, num_teams: 10, ppr: 0.5}
+    end
+
+    # A caller that knows only its league size should not have to look up a
+    # PPR to say so.
+    test "falls back field by field, not all or nothing" do
+      assert {:ok, settings} = MarketSettings.parse(%{"num_teams" => "10"})
+      assert settings == %{MarketSettings.default() | num_teams: 10}
+    end
+
+    # Substituting the default for a bad value answers a question nobody
+    # asked, in a feature whose whole point is knowing which question was.
+    test "rejects a value it cannot read rather than substituting the default" do
+      assert {:error, {:invalid_param, "num_teams", "twelve"}} =
+               MarketSettings.parse(%{"num_teams" => "twelve"})
+    end
+
+    test "rejects a trailing-garbage number" do
+      assert {:error, {:invalid_param, "num_qbs", "2x"}} =
+               MarketSettings.parse(%{"num_qbs" => "2x"})
+    end
+
+    test "rejects a dynasty flag that is not a boolean" do
+      assert {:error, {:invalid_param, "dynasty", "yes"}} =
+               MarketSettings.parse(%{"dynasty" => "yes"})
+    end
+
+    # Bounds exist so this API cannot be used to make arbitrary outbound
+    # requests, not to second-guess which leagues exist.
+    test "rejects sizes outside the bounds" do
+      assert {:error, {:param_out_of_range, "num_teams", "0", 2, 32}} =
+               MarketSettings.parse(%{"num_teams" => "0"})
+
+      assert {:error, {:param_out_of_range, "num_teams", "99", 2, 32}} =
+               MarketSettings.parse(%{"num_teams" => "99"})
+
+      assert {:error, {:param_out_of_range, "ppr", "-1", 0, 3}} =
+               MarketSettings.parse(%{"ppr" => "-1"})
+    end
+
+    # 999 is a perfectly good integer; saying it is not one is a false
+    # statement, and this feature's standing failure is the sentence rather
+    # than the number.
+    test "tells an unreadable value apart from an out-of-range one" do
+      assert {:error, {:invalid_param, _, _}} = MarketSettings.parse(%{"num_teams" => "twelve"})
+
+      assert {:error, {:param_out_of_range, _, _, _, _}} =
+               MarketSettings.parse(%{"num_teams" => "999"})
+    end
+
+    test "accepts a whole number for ppr" do
+      assert {:ok, %{ppr: 0.0}} = MarketSettings.parse(%{"ppr" => "0"})
+    end
+  end
+
+  describe "default?/1" do
+    test "is true for the stored slice" do
+      assert MarketSettings.default?(MarketSettings.default())
+    end
+
+    test "is false for anything else" do
+      refute MarketSettings.default?(%{MarketSettings.default() | num_qbs: 1})
+    end
+  end
+
+  describe "to_query/1" do
+    test "builds the provider's query string" do
+      query = MarketSettings.to_query(%{dynasty: true, num_qbs: 2, num_teams: 12, ppr: 1.0})
+
+      assert URI.decode_query(query) == %{
+               "isDynasty" => "true",
+               "numQbs" => "2",
+               "numTeams" => "12",
+               "ppr" => "1"
+             }
+    end
+
+    # The query string is the cache key, so two callers asking the same
+    # question must not produce two entries for one answer.
+    test "writes a whole-number ppr the same way however it arrived" do
+      {:ok, from_int} = MarketSettings.parse(%{"ppr" => "1"})
+      {:ok, from_float} = MarketSettings.parse(%{"ppr" => "1.0"})
+
+      assert MarketSettings.to_query(from_int) == MarketSettings.to_query(from_float)
+    end
+
+    test "keeps a fractional ppr" do
+      assert MarketSettings.to_query(%{dynasty: true, num_qbs: 1, num_teams: 10, ppr: 0.5})
+             |> URI.decode_query()
+             |> Map.get("ppr") == "0.5"
+    end
+  end
+end

--- a/test/sleeper_player_api_web/controllers/player_value_settings_test.exs
+++ b/test/sleeper_player_api_web/controllers/player_value_settings_test.exs
@@ -1,0 +1,196 @@
+defmodule SleeperPlayerApiWeb.PlayerValueSettingsTest do
+  # Bypass owns a real port and this points the FantasyCalc client at it, same
+  # as every other Bypass-backed suite here — cannot run concurrently.
+  use SleeperPlayerApiWeb.ConnCase, async: false
+
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.MarketValuesCache
+
+  setup %{conn: conn} do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :sleeper_player_api,
+      :fantasy_calc_base_url,
+      "http://localhost:#{bypass.port}"
+    )
+
+    MarketValuesCache.clear()
+
+    on_exit(fn ->
+      Application.delete_env(:sleeper_player_api, :fantasy_calc_base_url)
+      MarketValuesCache.clear()
+    end)
+
+    {:ok, conn: put_req_header(conn, "accept", "application/json"), bypass: bypass}
+  end
+
+  defp stored(player_id, overall_rank) do
+    Intel.upsert_player_values([
+      %{
+        player_id: player_id,
+        source: "fantasycalc",
+        value: 1000.0,
+        overall_rank: overall_rank,
+        position_rank: 1,
+        as_of: ~U[2026-08-10 08:30:00Z],
+        draft_year: 2025
+      }
+    ])
+  end
+
+  defp live_entry(sleeper_id, overall_rank) do
+    %{
+      "player" => %{
+        "name" => "Player #{sleeper_id}",
+        "sleeperId" => sleeper_id,
+        "position" => "WR"
+      },
+      "value" => 500.0,
+      "overallRank" => overall_rank,
+      "positionRank" => 1,
+      "maybeRosterPercent" => 0.5,
+      "maybeTradeFrequency" => 0.02
+    }
+  end
+
+  # The stored slice is answerable without leaving the building. Anything else
+  # is a fetch, so a test that expects no fetch is asserting the fast path.
+  describe "the stored slice" do
+    test "is served from the database without calling the provider", %{conn: conn, bypass: bypass} do
+      Bypass.down(bypass)
+      stored(1, 1)
+
+      body = conn |> get(~p"/api/v1/values") |> json_response(200)
+
+      assert Enum.map(body["values"], & &1["playerId"]) == ["1"]
+    end
+
+    test "is still the stored slice when its settings are stated explicitly", %{
+      conn: conn,
+      bypass: bypass
+    } do
+      Bypass.down(bypass)
+      stored(1, 1)
+
+      body =
+        conn
+        |> get(~p"/api/v1/values?dynasty=true&num_qbs=2&num_teams=12&ppr=1")
+        |> json_response(200)
+
+      assert Enum.map(body["values"], & &1["playerId"]) == ["1"]
+    end
+  end
+
+  describe "another league shape" do
+    test "is fetched from the provider", %{conn: conn, bypass: bypass} do
+      stored(1, 1)
+
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        # The league that was asked about is the league that gets fetched.
+        assert conn.query_params["numQbs"] == "1"
+        assert conn.query_params["numTeams"] == "10"
+        assert conn.query_params["ppr"] == "0.5"
+        Plug.Conn.resp(conn, 200, Jason.encode!([live_entry("77", 1)]))
+      end)
+
+      body = conn |> get(~p"/api/v1/values?num_qbs=1&num_teams=10&ppr=0.5") |> json_response(200)
+
+      # The live rows, not the stored one.
+      assert Enum.map(body["values"], & &1["playerId"]) == ["77"]
+    end
+
+    test "echoes the settings it answered, including the ones that fell back", %{
+      conn: conn,
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!([live_entry("77", 1)]))
+      end)
+
+      body = conn |> get(~p"/api/v1/values?num_teams=10") |> json_response(200)
+
+      assert body["settings"] == %{
+               "source" => "fantasycalc",
+               "format" => "dynasty",
+               "numQbs" => 2,
+               "numTeams" => 10,
+               "ppr" => 1.0
+             }
+    end
+
+    test "reports a redraft league as redraft", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        assert conn.query_params["isDynasty"] == "false"
+        Plug.Conn.resp(conn, 200, Jason.encode!([live_entry("77", 1)]))
+      end)
+
+      body = conn |> get(~p"/api/v1/values?dynasty=false") |> json_response(200)
+
+      assert body["settings"]["format"] == "redraft"
+    end
+
+    # FantasyCalc is a free public API and this app is a guest: pressing the
+    # import button twice must not be two third-party requests.
+    test "is fetched once and then cached", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        Plug.Conn.resp(conn, 200, Jason.encode!([live_entry("77", 1)]))
+      end)
+
+      first = conn |> get(~p"/api/v1/values?num_teams=10") |> json_response(200)
+      second = conn |> get(~p"/api/v1/values?num_teams=10") |> json_response(200)
+
+      assert first["values"] == second["values"]
+    end
+
+    test "caches each league shape separately", %{conn: conn, bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/values/current", fn conn ->
+        id = if conn.query_params["numTeams"] == "10", do: "10", else: "14"
+        Plug.Conn.resp(conn, 200, Jason.encode!([live_entry(id, 1)]))
+      end)
+
+      ten = conn |> get(~p"/api/v1/values?num_teams=10") |> json_response(200)
+      fourteen = conn |> get(~p"/api/v1/values?num_teams=14") |> json_response(200)
+
+      assert Enum.map(ten["values"], & &1["playerId"]) == ["10"]
+      assert Enum.map(fourteen["values"], & &1["playerId"]) == ["14"]
+    end
+
+    test "sorts a live slice best player first, nulls last", %{conn: conn, bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        entries = [live_entry("3", 3), live_entry("9", nil), live_entry("1", 1)]
+        Plug.Conn.resp(conn, 200, Jason.encode!(entries))
+      end)
+
+      body = conn |> get(~p"/api/v1/values?num_teams=10") |> json_response(200)
+
+      assert Enum.map(body["values"], & &1["playerId"]) == ["1", "3", "9"]
+    end
+
+    test "says so when the provider cannot be reached", %{conn: conn, bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert conn |> get(~p"/api/v1/values?num_teams=10") |> json_response(502)
+    end
+  end
+
+  describe "a request that cannot be read" do
+    test "is rejected rather than quietly substituted", %{conn: conn, bypass: bypass} do
+      Bypass.down(bypass)
+
+      body = conn |> get(~p"/api/v1/values?num_teams=twelve") |> json_response(422)
+
+      assert body["errors"]["detail"] =~ "must be an integer"
+    end
+
+    # 999 *is* an integer. Reusing the invalid_param message here would tell
+    # the caller something false about their input.
+    test "names the bounds when a good number is out of range", %{conn: conn, bypass: bypass} do
+      Bypass.down(bypass)
+
+      body = conn |> get(~p"/api/v1/values?num_teams=999") |> json_response(422)
+
+      assert body["errors"]["detail"] =~ "must be between 2 and 32"
+    end
+  end
+end


### PR DESCRIPTION
`/api/v1/values` shipped serving one slice — dynasty, superflex, 12-team, full PPR — pinned in the client. That isn't a rounding error for anyone else:

| | superflex | single-QB |
| --- | --- | --- |
| market's #1 | Josh Allen | Bijan Robinson |

A 10-team 1-QB league was being handed a list about a different game, with nothing on it saying so.

## What changed

`GET /api/v1/values?dynasty=&num_qbs=&num_teams=&ppr=`. Each param falls back to the stored slice **on its own**, so a caller that knows only its league size can say only that. `settings` in the response echoes what was *answered*, not what was asked — those differ whenever something fell back, which is the common case.

**The stored slice is untouched.** It still comes out of the database, the nightly refresh still writes only that one, and `fetch_values/0` still means exactly that slice — because the availability model is calibrated against it. The new `fetch_values/1` is for a caller asking about their own league.

**Anything else is fetched and cached for six hours.** FantasyCalc is a free, unauthenticated, public API and this app is a guest; pressing the import button twice shouldn't be two requests to them. The cache is one ETS table owned by a supervised process — reads go straight to ETS, since the process exists to own the table, not to serialise access.

## A smaller decision worth a look

Out-of-range is now told apart from unreadable, with its own error and message. `999` is a perfectly good integer, and `num_teams must be an integer, got: "999"` is a false statement about the caller's input. Same reasoning that already separates `:pick_out_of_range` from `:invalid_param`.

The bounds themselves (2–32 teams, 1–4 QBs, 0–3 PPR) exist to stop this endpoint being used to make arbitrary outbound requests — not to second-guess which leagues exist. FantasyCalc answers 200 for an 11-team league and for `numQbs=3`, and neither is this API's business to refuse.

## Checks

`mix test` — 274 passing, 25 new. Covers the stored fast path (asserted by taking Bypass *down* — if it were fetching, it would fail), the live path with the query it actually sends, per-shape caching, the fallback echo, sorting a live slice nulls-last, the 502, and both 422s.

`mix format --check-formatted` is clean, and now means something after #46.
