### PR TITLE
Stop asking FantasyCalc a question it does not answer

### DIFF
--- a/lib/sleeper_player_api/intel/market_settings.ex
+++ b/lib/sleeper_player_api/intel/market_settings.ex
@@ -27,13 +27,40 @@ defmodule SleeperPlayerApi.Intel.MarketSettings do
   @max_teams 32
   @max_qbs 4
 
+  # The most quarterbacks FantasyCalc prices differently. Not a bound on what
+  # a caller may ask - `@max_qbs` is that - but the point past which asking
+  # for more returns the same answer. Must stay above its uses: a module
+  # attribute read before it is set is `nil`, and `min(4, nil)` is 4 in Erlang
+  # term order, so the clamp would silently do nothing.
+  @priced_qbs 2
+
   @doc "The slice the nightly refresh stores, and the default for a request."
   @spec default() :: t
   def default, do: @default
 
-  @doc "Whether these are the stored settings, and so answerable without a fetch."
+  @doc """
+  Whether these settings are answerable from the stored slice without a fetch.
+
+  Compares what the provider would actually be asked, not what the caller
+  said - so a 12-team full-PPR dynasty league that starts three quarterbacks
+  is the stored slice, because `effective/1` reads it as two and the values
+  are identical either way.
+  """
   @spec default?(t) :: boolean
-  def default?(settings), do: settings == @default
+  def default?(settings), do: effective(settings) == @default
+
+  # The settings as the provider will actually read them.
+  #
+  # FantasyCalc prices one quarterback or more-than-one, and nothing beyond:
+  # measured against the live API with everything else equal, `numQbs` of 2, 3
+  # and 4 return byte-identical values. So a league that starts four is asking
+  # the same question as one that starts two, and asking it under a different
+  # name buys nothing and costs a second request to somebody else's free API.
+  #
+  # Only what is *sent* is clamped. The settings a caller gets back still
+  # describe their league, because "you start four quarterbacks" is true and
+  # this is a fact about the provider rather than about them.
+  defp effective(settings), do: %{settings | num_qbs: min(settings.num_qbs, @priced_qbs)}
 
   @doc """
   Request params as settings, falling back to the stored slice field by field.
@@ -66,9 +93,17 @@ defmodule SleeperPlayerApi.Intel.MarketSettings do
     end
   end
 
-  @doc "These settings as FantasyCalc's query string."
+  @doc """
+  These settings as FantasyCalc's query string.
+
+  Clamped to what the provider actually prices - see `effective/1`. This
+  string is also the cache key, so the clamp is what stops a three-QB and a
+  four-QB league being two cached copies of one answer.
+  """
   @spec to_query(t) :: String.t()
-  def to_query(%{dynasty: dynasty, num_qbs: num_qbs, num_teams: num_teams, ppr: ppr}) do
+  def to_query(settings) do
+    %{dynasty: dynasty, num_qbs: num_qbs, num_teams: num_teams, ppr: ppr} = effective(settings)
+
     URI.encode_query(%{
       "isDynasty" => to_string(dynasty),
       "numQbs" => num_qbs,

--- a/test/sleeper_player_api/intel/market_settings_test.exs
+++ b/test/sleeper_player_api/intel/market_settings_test.exs
@@ -81,6 +81,22 @@ defmodule SleeperPlayerApi.Intel.MarketSettingsTest do
     test "is false for anything else" do
       refute MarketSettings.default?(%{MarketSettings.default() | num_qbs: 1})
     end
+
+    # The payoff for clamping: a 12-team full-PPR dynasty league that starts
+    # three quarterbacks is asking the stored slice's question, so it is
+    # answered from the database with no fetch at all.
+    test "is true for a league whose extra quarterbacks the provider ignores" do
+      assert MarketSettings.default?(%{MarketSettings.default() | num_qbs: 3})
+      assert MarketSettings.default?(%{MarketSettings.default() | num_qbs: 4})
+    end
+  end
+
+  describe "parse/1 and the clamp" do
+    # Only what is *sent* is clamped. "You start four quarterbacks" is true
+    # about the league, and the clamp is a fact about the provider.
+    test "keeps the caller's own quarterback count in the settings" do
+      assert {:ok, %{num_qbs: 4}} = MarketSettings.parse(%{"num_qbs" => "4"})
+    end
   end
 
   describe "to_query/1" do
@@ -102,6 +118,24 @@ defmodule SleeperPlayerApi.Intel.MarketSettingsTest do
       {:ok, from_float} = MarketSettings.parse(%{"ppr" => "1.0"})
 
       assert MarketSettings.to_query(from_int) == MarketSettings.to_query(from_float)
+    end
+
+    # FantasyCalc prices one quarterback or more-than-one and nothing beyond:
+    # measured against the live API, numQbs of 2, 3 and 4 return identical
+    # values. Asking for 4 spends a second request on somebody else's free API
+    # for an answer already held under a different key.
+    test "asks for no more quarterbacks than the provider prices" do
+      four = MarketSettings.to_query(%{dynasty: true, num_qbs: 4, num_teams: 12, ppr: 1.0})
+      two = MarketSettings.to_query(%{dynasty: true, num_qbs: 2, num_teams: 12, ppr: 1.0})
+
+      assert URI.decode_query(four)["numQbs"] == "2"
+      assert four == two
+    end
+
+    test "leaves a single-quarterback league alone" do
+      query = MarketSettings.to_query(%{dynasty: true, num_qbs: 1, num_teams: 12, ppr: 1.0})
+
+      assert URI.decode_query(query)["numQbs"] == "1"
     end
 
     test "keeps a fractional ppr" do

--- a/test/sleeper_player_api_web/controllers/player_value_settings_test.exs
+++ b/test/sleeper_player_api_web/controllers/player_value_settings_test.exs
@@ -82,6 +82,47 @@ defmodule SleeperPlayerApiWeb.PlayerValueSettingsTest do
     end
   end
 
+  describe "a league with more quarterbacks than the provider prices" do
+    # Bypass is down: if this fetched, it would fail. FantasyCalc returns
+    # identical values for numQbs 2, 3 and 4, so a 12-team full-PPR dynasty
+    # league that starts three is asking the stored slice's question.
+    test "is answered from the stored slice with no fetch", %{conn: conn, bypass: bypass} do
+      Bypass.down(bypass)
+      stored(1, 1)
+
+      body = conn |> get(~p"/api/v1/values?num_qbs=3") |> json_response(200)
+
+      assert Enum.map(body["values"], & &1["playerId"]) == ["1"]
+    end
+
+    # Clamped on the way out, not on the way in - the caller's league really
+    # does start four, and the response describes their league.
+    test "still reports the caller's own quarterback count", %{conn: conn, bypass: bypass} do
+      Bypass.down(bypass)
+      stored(1, 1)
+
+      body = conn |> get(~p"/api/v1/values?num_qbs=4") |> json_response(200)
+
+      assert body["settings"]["numQbs"] == 4
+    end
+
+    test "shares one fetch and one cache entry with the two-QB question", %{
+      conn: conn,
+      bypass: bypass
+    } do
+      # Once, for both requests, despite the different num_qbs.
+      Bypass.expect_once(bypass, "GET", "/values/current", fn conn ->
+        assert conn.query_params["numQbs"] == "2"
+        Plug.Conn.resp(conn, 200, Jason.encode!([live_entry("77", 1)]))
+      end)
+
+      three = conn |> get(~p"/api/v1/values?num_qbs=3&num_teams=10") |> json_response(200)
+      four = conn |> get(~p"/api/v1/values?num_qbs=4&num_teams=10") |> json_response(200)
+
+      assert three["values"] == four["values"]
+    end
+  end
+
   describe "another league shape" do
     test "is fetched from the provider", %{conn: conn, bypass: bypass} do
       stored(1, 1)


### PR DESCRIPTION
Measured against the live API with everything else held equal:

```
numQbs=1 → Bijan Robinson (11076)
numQbs=2 → Bijan Robinson (10223)
numQbs=3 → Bijan Robinson (10223)   ← identical to 2
numQbs=4 → Bijan Robinson (10223)   ← identical to 2
```

They price one quarterback or more-than-one, and nothing beyond. So a league that starts four was spending a second request on somebody else's free API for an answer already held under a different cache key — and a 12-team full-PPR dynasty league that starts three was fetching at all, rather than being served from the stored slice.

## The clamp is on the way out only

`to_query/1` and `default?/1` compare what the provider will actually be asked. `parse/1` keeps what the caller said, because *"you start four quarterbacks"* is true about their league — the clamp is a fact about FantasyCalc, not about them. The response still describes the caller's league.

Both directions are sabotage-tested: removing the clamp fails 5 tests, and moving it into `parse/1` (so the response would report 2 for a 4-QB league) fails 2.

## One that nearly got through

The attribute holding the ceiling has to sit **above** its uses. Set below them it reads as `nil`, and `min(4, nil)` is `4` in Erlang term order — so the clamp compiled, passed every existing test, and silently did nothing. The compiler warned about the undefined attribute; that's the only reason it was caught, and there are now tests that would fail on it directly.

## Checks

`mix test` — 281 passing, 7 new. `mix format --check-formatted` clean.