### PR TITLE
Start keeping roster history instead of overwriting it

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -45,6 +45,7 @@ defmodule SleeperPlayerApi.Intel do
     DraftParticipant,
     ObservedLeague,
     ObservedRoster,
+    ObservedRosterHistory,
     ObservedTransaction,
     LeagueMember
   }
@@ -587,6 +588,67 @@ defmodule SleeperPlayerApi.Intel do
       replace: [:owner_id, :player_ids, :fetched_at, :updated_at]
     )
   end
+
+  @doc """
+  Appends the same roster rows to the daily history, keeping what
+  `upsert_observed_rosters/1` is about to overwrite.
+
+  The exact counterpart of `record_value_history/1`, and it follows the same
+  three rules for the same reasons.
+
+  Takes exactly what `upsert_observed_rosters/1` takes, so the caller shapes
+  its rows once and writes them to both places rather than the crawler having
+  to know there are two, and so the two can never disagree about what was
+  observed.
+
+  `day` is derived from each row's own `fetched_at` rather than from
+  `Date.utc_today/0`, so a crawl that straddles midnight, and any future
+  backfill, land on the day they describe instead of the day they ran. Rows
+  carrying no `fetched_at` are dropped: there is no day to file them under,
+  and guessing one would silently overwrite a real snapshot.
+
+  Last write of a day wins, which makes each row that day's close. Re-running
+  a crawl corrects the day rather than duplicating it.
+
+  Deduplicated by `(league_id, roster_id, day)` before insert, last occurrence
+  winning — Postgres refuses an `ON CONFLICT DO UPDATE` that touches one row
+  twice in a statement, so a payload repeating a `roster_id` would fail the
+  whole batch rather than merely writing twice. Sleeper has not been seen to
+  do that, but the constraint belongs to the table, not to the one caller
+  that currently feeds it.
+  """
+  @spec append_observed_roster_history([map]) :: {non_neg_integer, nil}
+  def append_observed_roster_history(rosters) do
+    rows =
+      rosters
+      |> Enum.flat_map(&roster_history_row/1)
+      |> Enum.reduce(%{}, fn row, acc ->
+        Map.put(acc, {row.league_id, row.roster_id, row.day}, row)
+      end)
+      |> Map.values()
+
+    insert_all_batched(
+      ObservedRosterHistory,
+      rows,
+      conflict_target: [:league_id, :roster_id, :day],
+      replace: [:owner_id, :player_ids, :fetched_at, :updated_at]
+    )
+  end
+
+  defp roster_history_row(%{fetched_at: %DateTime{} = fetched_at} = row) do
+    [
+      %{
+        league_id: row.league_id,
+        roster_id: row.roster_id,
+        day: DateTime.to_date(fetched_at),
+        owner_id: row[:owner_id],
+        player_ids: row[:player_ids] || [],
+        fetched_at: fetched_at
+      }
+    ]
+  end
+
+  defp roster_history_row(_row), do: []
 
   @doc """
   Per-manager ownership: how many of each manager's leagues hold each player.

--- a/lib/sleeper_player_api/intel/observed_roster_history.ex
+++ b/lib/sleeper_player_api/intel/observed_roster_history.ex
@@ -1,0 +1,45 @@
+defmodule SleeperPlayerApi.Intel.ObservedRosterHistory do
+  @moduledoc """
+  One roster in one observed league as it stood on one day — the time series
+  `ObservedRoster` cannot be.
+
+  `observed_rosters` is keyed `(league_id, roster_id)` and refreshed in place
+  on every crawl, so it only ever answers "who is on this roster now". This
+  table answers "who was on it then", which is the question positional need
+  is actually built on: 99% of players taken in corpus drafts are still
+  rostered today (measured 2026-08-09), so a current roster already contains
+  the label and cannot be used to validate a prediction about the moment a
+  pick was made.
+
+  One row per `(league_id, roster_id, day)`, holding that day's close — the
+  last observation written on a date wins. Written unconditionally on every
+  crawl, including when nothing changed, so that a missing day means "we
+  never looked" rather than being ambiguous between that and "nothing moved".
+  See the migration for the measured size that trade costs.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias SleeperPlayerApi.Intel.ObservedLeague
+
+  @primary_key false
+  schema "observed_roster_history" do
+    belongs_to :league, ObservedLeague, references: :id, type: :id, define_field: false
+    field :league_id, :integer
+    field :roster_id, :integer
+    field :day, :date
+    field :owner_id, :integer
+    field :player_ids, {:array, :string}, default: []
+    field :fetched_at, :utc_datetime
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(history, attrs) do
+    history
+    |> cast(attrs, [:league_id, :roster_id, :day, :owner_id, :player_ids, :fetched_at])
+    |> validate_required([:league_id, :roster_id, :day])
+    |> unique_constraint([:league_id, :roster_id, :day])
+  end
+end

--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
@@ -254,7 +254,14 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
           %{id: league_id, roster_to_user: map, rosters_fetched_at: now}
         ])
 
-        Intel.upsert_observed_rosters(roster_rows(league_id, rosters, now))
+        rows = roster_rows(league_id, rosters, now)
+
+        # Both writes take the same rows: one keeps the current snapshot, the
+        # other keeps the day's. Appending only on the failure-free path is
+        # deliberate — a day with no history row must mean "we never looked",
+        # which is what makes a point-in-time read of the history sound.
+        Intel.upsert_observed_rosters(rows)
+        Intel.append_observed_roster_history(rows)
 
         {map, %{summary | rosters_fetched: summary.rosters_fetched + 1}}
 

--- a/priv/repo/migrations/20260815120000_create_observed_roster_history.exs
+++ b/priv/repo/migrations/20260815120000_create_observed_roster_history.exs
@@ -1,0 +1,71 @@
+defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedRosterHistory do
+  use Ecto.Migration
+
+  def change do
+    # The time series `observed_rosters` cannot be. That table is keyed
+    # `(league_id, roster_id)` and refreshed in place on every crawl, so it
+    # holds exactly one current snapshot and has kept nothing since it was
+    # created on 2026-08-09 — the same shape `player_values` was in before
+    # `player_value_history`, and the same fix.
+    #
+    # **Why it matters, and why the clock is the point.** Positional need
+    # cannot be *validated* against current rosters: measured 2026-08-09, 99%
+    # of players taken in corpus drafts are still rostered now, so today's
+    # rosters contain the answer to "was this manager thin at RB when he drew
+    # that pick". Only a roster as it stood *then* can say. Nothing here pays
+    # off until a season's worth has accumulated, which is exactly why the
+    # table has to exist before the season rather than when the question is
+    # asked. Rendering need as live *context* is unaffected and already works.
+    #
+    # One row per roster per day, holding that day's close — the last
+    # observation written on a date wins, via the same `on_conflict: replace`
+    # path every other upsert here uses. The crawl is nightly, so daily is
+    # per-crawl today; stating it as a day means a second run overwrites
+    # rather than duplicating.
+    #
+    # **Daily-always, not append-on-change.** Measured 2026-08-15 against
+    # production: 2,238 rosters across 179 leagues, 26.4 players each,
+    # `observed_rosters` totalling 1,616 kB — so ~740 bytes a row and about
+    # **605 MB a year** written unconditionally, against a 305 MB database and
+    # 14 GB free. Skipping unchanged rosters would cut that roughly fourfold
+    # (rosters move weekly in season, barely at all outside it), and was
+    # rejected anyway: it makes a missing day ambiguous between "nothing
+    # changed" and "we never looked", and every query here is a point-in-time
+    # read of the form "latest snapshot on or before day D", which is only
+    # sound when absence means unobserved. A failed roster fetch already
+    # writes nothing, so that reading holds. Buying crisp semantics for
+    # ~470 MB a year is the right trade at this size; if it ever stops being,
+    # downsampling to weekly is a single windowed DELETE, which is the same
+    # escape hatch `player_value_history` left itself.
+    create table(:observed_roster_history, primary_key: false) do
+      add :league_id, references(:observed_leagues, on_delete: :delete_all, type: :bigint),
+        null: false
+
+      add :roster_id, :integer, null: false
+
+      # UTC date of `fetched_at`, never `Date.utc_today()` — a row must land
+      # on the day it describes so that a backfill, or a crawl that straddles
+      # midnight, is filed correctly rather than filed as today.
+      add :day, :date, null: false
+
+      # Carried rather than joined to `observed_rosters`: ownership changes
+      # when a league replaces a manager mid-season, and a snapshot that has
+      # to be joined to a mutable table to be read is not a snapshot.
+      add :owner_id, :bigint
+      add :player_ids, {:array, :text}, null: false, default: []
+      add :fetched_at, :utc_datetime
+
+      timestamps()
+    end
+
+    # Serves the upsert, the per-roster time series, and the per-league
+    # point-in-time read ("every roster in league L on day D"), since its
+    # leading columns are exactly those filters.
+    #
+    # No `owner_id` index yet, deliberately. The owner-side read is the one
+    # `observed_rosters` indexes, but nothing queries this table by owner
+    # today, and an index costs every insert of ~2,238 rows every night
+    # forever. Adding one when a query needs it is a cheap migration.
+    create unique_index(:observed_roster_history, [:league_id, :roster_id, :day])
+  end
+end

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
@@ -5,7 +5,14 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
   use SleeperPlayerApi.DataCase, async: false
 
   alias SleeperPlayerApi.Intel
-  alias SleeperPlayerApi.Intel.{ObservedLeague, ObservedRoster, ObservedTransaction}
+
+  alias SleeperPlayerApi.Intel.{
+    ObservedLeague,
+    ObservedRoster,
+    ObservedRosterHistory,
+    ObservedTransaction
+  }
+
   alias SleeperPlayerApi.Repo
   alias SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions
 
@@ -278,6 +285,176 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
 
       assert {%{{@alice, "4034"} => 1}, _} = Intel.ownership(["4034"]),
              "a brief Sleeper failure must read as stale, not as 'nobody owns anybody'"
+    end
+  end
+
+  describe "roster history (the time series the crawl used to discard)" do
+    test "the crawl records each roster's contents against the day it saw them", %{
+      bypass: bypass
+    } do
+      stub(bypass)
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      rows = Repo.all(from(h in ObservedRosterHistory, order_by: h.roster_id))
+
+      assert [
+               %{roster_id: 1, owner_id: @alice, player_ids: ["4034", "6794"], league_id: 900},
+               %{roster_id: 2, owner_id: @bob, player_ids: ["4034"], league_id: 900}
+             ] = rows
+
+      # The day is the one the observation carries, not whatever the clock
+      # said when the row was written.
+      assert Enum.all?(rows, &(&1.day == DateTime.to_date(&1.fetched_at)))
+    end
+
+    # The entire reason the table exists. `observed_rosters` is overwritten in
+    # place, so before this the previous contents were simply gone — and a
+    # roster as it stood *then* is the only thing that can validate a read of
+    # positional need made at the time.
+    test "yesterday's roster survives today's overwrite", %{bypass: bypass} do
+      stub(bypass,
+        rosters: [%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034", "6794"]}]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      # Age the stored snapshot by a day. The crawl stamps `fetched_at` from
+      # the clock, so this is the only way to get two days out of two runs
+      # inside one test.
+      yesterday = Date.add(Date.utc_today(), -1)
+
+      Repo.update_all(ObservedRosterHistory,
+        set: [day: yesterday, fetched_at: DateTime.new!(yesterday, ~T[04:30:00Z])]
+      )
+
+      Bypass.down(bypass)
+      bypass = Bypass.open(port: bypass.port)
+
+      stub(bypass,
+        rosters: [%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034"]}]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert [{^yesterday, ["4034", "6794"]}, {_today, ["4034"]}] =
+               Repo.all(
+                 from(h in ObservedRosterHistory,
+                   order_by: h.day,
+                   select: {h.day, h.player_ids}
+                 )
+               )
+
+      assert [%{player_ids: ["4034"]}] = Repo.all(ObservedRoster),
+             "the current-snapshot table still holds only the latest"
+    end
+
+    test "a second crawl on the same day corrects the day rather than duplicating it", %{
+      bypass: bypass
+    } do
+      stub(bypass,
+        rosters: [%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034"]}]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      Bypass.down(bypass)
+      bypass = Bypass.open(port: bypass.port)
+
+      stub(bypass,
+        rosters: [%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034", "6794"]}]
+      )
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert [%{player_ids: ["4034", "6794"]}] = Repo.all(ObservedRosterHistory),
+             "a day holds one row, and it is that day's close"
+    end
+
+    # What makes a point-in-time read of this table sound: a day with no row
+    # means "we never looked", so a failed fetch must write nothing.
+    #
+    # Two leagues, one of which fails, because asserting only that the failing
+    # league wrote nothing is over-determined — it stays green when the append
+    # is deleted outright (confirmed by sabotage). The league that succeeded
+    # has to be in the same run for the assertion to be about the failure.
+    test "a failed roster fetch writes no history row, while its neighbour still does", %{
+      bypass: bypass
+    } do
+      stub(bypass, leagues_for: %{@alice => ["900", "901"], @bob => ["900"]})
+
+      Bypass.stub(bypass, "GET", "/league/901/rosters", &Plug.Conn.resp(&1, 500, "nope"))
+
+      Bypass.stub(bypass, "GET", "/league/901/transactions/1", fn conn ->
+        Plug.Conn.resp(conn, 200, "[]")
+      end)
+
+      assert {:ok, summary} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert [{:rosters_failed, 901, _}] = summary.errors
+
+      assert [900, 900] =
+               Repo.all(
+                 from(h in ObservedRosterHistory, select: h.league_id, order_by: h.roster_id)
+               )
+    end
+  end
+
+  # Two rules the crawler cannot reach: it always stamps `fetched_at`, and
+  # Sleeper has never been seen to repeat a `roster_id` in one payload.
+  describe "append_observed_roster_history/1" do
+    setup do
+      Intel.upsert_observed_leagues([%{id: 900, season: "2026"}])
+      :ok
+    end
+
+    # The crawler always hands over `fetched_at == now`, so nothing reachable
+    # through it can tell `DateTime.to_date(fetched_at)` apart from
+    # `Date.utc_today()`. This is the only test that can.
+    test "files a row under the day it was observed, not the day it was written" do
+      yesterday = Date.add(Date.utc_today(), -1)
+
+      assert {1, _} =
+               Intel.append_observed_roster_history([
+                 %{
+                   league_id: 900,
+                   roster_id: 1,
+                   player_ids: ["1"],
+                   fetched_at: DateTime.new!(yesterday, ~T[04:30:00Z])
+                 }
+               ])
+
+      assert [%{day: ^yesterday}] = Repo.all(ObservedRosterHistory)
+    end
+
+    test "a row with no fetched_at is dropped rather than dated by guesswork" do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      assert {1, _} =
+               Intel.append_observed_roster_history([
+                 %{
+                   league_id: 900,
+                   roster_id: 1,
+                   owner_id: @alice,
+                   player_ids: ["1"],
+                   fetched_at: now
+                 },
+                 %{league_id: 900, roster_id: 2, owner_id: @bob, player_ids: ["2"]}
+               ])
+
+      assert [%{roster_id: 1}] = Repo.all(ObservedRosterHistory)
+    end
+
+    test "one roster twice in a single call collapses, last one winning" do
+      # Postgres refuses an ON CONFLICT DO UPDATE that touches a row twice in
+      # one statement, so without the dedupe this does not write twice — it
+      # fails the whole batch, taking the rest of the league with it.
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      row = fn players ->
+        %{league_id: 900, roster_id: 1, player_ids: players, fetched_at: now}
+      end
+
+      assert {1, _} = Intel.append_observed_roster_history([row.(["1"]), row.(["1", "2"])])
+      assert [%{player_ids: ["1", "2"]}] = Repo.all(ObservedRosterHistory)
     end
   end
 


### PR DESCRIPTION
`observed_rosters` is keyed `(league_id, roster_id)` and refreshed in place, so every nightly crawl overwrote the previous contents and kept nothing. That blocks validating positional need: 99% of players taken in corpus drafts are still rostered today, so a current roster already contains the label — only the roster as it stood *then* can say whether a manager was thin at RB when he made a pick.

Adds `observed_roster_history`: one row per roster per day, appended from the same rows `upsert_observed_rosters/1` already takes, so the two writes can't disagree about what was observed.

Three rules, each with a test:

| Rule | Why |
|---|---|
| `day` comes from the row's `fetched_at`, never `Date.utc_today()` | a crawl straddling midnight, or a future backfill, lands on the day it describes |
| written only on the failure-free path | a missing day must mean "we never looked", which is what makes a point-in-time read sound |
| last write of a day wins, deduped within the call too | re-running a crawl corrects the day instead of duplicating it; Postgres fails the whole batch on a repeated conflict target |

**Daily-always rather than append-on-change.** Measured against production: 2,238 rosters across 179 leagues, `observed_rosters` at 1,616 kB, so ~740 bytes a row and ~605 MB a year written unconditionally — against a 305 MB database and 14 GB free. Skipping unchanged rosters saves roughly four fifths of that and was rejected anyway, because it makes a missing day ambiguous between "nothing changed" and "we never looked". Downsampling to weekly later is a single windowed DELETE.

No `owner_id` index yet — nothing queries this by owner, and an index costs every insert of ~2,238 rows every night.

Nothing reads the table yet. It has to exist before the season for there to be anything to read after it.

Sabotage-verified: removing the append fails 4 tests, dating rows from the clock fails 1, removing the missing-`fetched_at` drop fails 1, removing the within-call dedupe fails 1. The failed-fetch test was over-determined on the first pass (green with the feature deleted) and was reworked to crawl two leagues, one of which fails.