### PR TITLE
Surface injury, liquidity, expected return and bye week

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -241,7 +241,10 @@ defmodule SleeperPlayerApi.Intel do
         :roster_percent,
         :trade_frequency,
         :as_of,
-        :draft_year
+        :draft_year,
+        :liquidity,
+        :injury_return,
+        :bye_week
       ]
     )
   end
@@ -419,6 +422,9 @@ defmodule SleeperPlayerApi.Intel do
         overall_rank: pv.overall_rank,
         position_rank: pv.position_rank,
         as_of: pv.as_of,
+        liquidity: pv.liquidity,
+        injury_return: pv.injury_return,
+        bye_week: pv.bye_week,
         previous_value: p.value,
         since: p.day
       }

--- a/lib/sleeper_player_api/intel/player_value.ex
+++ b/lib/sleeper_player_api/intel/player_value.ex
@@ -19,6 +19,16 @@ defmodule SleeperPlayerApi.Intel.PlayerValue do
     # CLASS", not the full player pool.
     field :draft_year, :integer
 
+    # KeepTradeCut only; see the migration that added them.
+    #
+    # `liquidity` (KTC's `stdLiquidity`, 0-100) is per-format and belongs on
+    # this row. `injury_return` and `bye_week` are facts about the player and
+    # are the same on both format rows — duplicated rather than given a second
+    # writer into `players`, which the Sleeper dump owns.
+    field :liquidity, :float
+    field :injury_return, :date
+    field :bye_week, :integer
+
     timestamps()
   end
 
@@ -34,7 +44,10 @@ defmodule SleeperPlayerApi.Intel.PlayerValue do
       :roster_percent,
       :trade_frequency,
       :as_of,
-      :draft_year
+      :draft_year,
+      :liquidity,
+      :injury_return,
+      :bye_week
     ])
     |> validate_required([:player_id, :source])
     |> unique_constraint([:player_id, :source])

--- a/lib/sleeper_player_api/intel/player_value_sources/keep_trade_cut.ex
+++ b/lib/sleeper_player_api/intel/player_value_sources/keep_trade_cut.ex
@@ -45,6 +45,16 @@ defmodule SleeperPlayerApi.Intel.PlayerValueSources.KeepTradeCut do
   are the same measurement as FantasyCalc's two fields. Mapping one onto the
   other would make two sources look comparable on a column where they are
   not.
+
+  KTC's liquidity is now stored — in its own `liquidity` column, which is the
+  point. It sits beside `trade_frequency` rather than inside it, so a caller
+  reading either knows which provider's measurement it has.
+
+  **Three fields beyond value, added 2026-08-15**: `liquidity`
+  (`stdLiquidity`, per-format), `injury_return` and `bye_week` (both
+  per-player, so identical on the two format rows). Injury *status* is
+  deliberately not among them — Sleeper's own dump has carried it all along.
+  See the migration for the measurements behind both decisions.
   """
 
   @behaviour SleeperPlayerApi.Intel.PlayerValueSource
@@ -193,9 +203,54 @@ defmodule SleeperPlayerApi.Intel.PlayerValueSources.KeepTradeCut do
       roster_percent: nil,
       trade_frequency: nil,
       draft_year: player["draftYear"],
+      # Per-format: KTC prices liquidity separately for 1QB and superflex, so
+      # it belongs on this row rather than beside the per-player fields below.
+      liquidity: to_float(values["stdLiquidity"]),
+      # Per-player, so identical on both format rows. See the migration for
+      # why that duplication was preferred to a second writer into `players`.
+      injury_return: parse_return_date(player["injury"]),
+      bye_week: player["byeWeek"],
       as_of: now
     }
   end
+
+  # KTC dates its expected returns as "Aug 22, 2026". Parsed to a real date so
+  # a return already in the past reads differently from one still ahead; an
+  # unparseable value is dropped rather than guessed at, the same rule
+  # `parse_pick/1` follows.
+  #
+  # The healthy majority carry `%{"injuryCode" => 1}` and no other key —
+  # measured 2026-08-15, 425 of 500 — so a missing `injuryReturn` is the
+  # normal case, not a failure.
+  @months %{
+    "jan" => 1,
+    "feb" => 2,
+    "mar" => 3,
+    "apr" => 4,
+    "may" => 5,
+    "jun" => 6,
+    "jul" => 7,
+    "aug" => 8,
+    "sep" => 9,
+    "oct" => 10,
+    "nov" => 11,
+    "dec" => 12
+  }
+
+  @return_date ~r/^([A-Za-z]{3})[a-z]*\s+(\d{1,2}),\s*(\d{4})$/
+
+  defp parse_return_date(%{"injuryReturn" => date}) when is_binary(date) do
+    with [month, day, year] <-
+           Regex.run(@return_date, String.trim(date), capture: :all_but_first),
+         month when not is_nil(month) <- @months[String.downcase(month)],
+         {:ok, parsed} <- Date.new(String.to_integer(year), month, String.to_integer(day)) do
+      parsed
+    else
+      _ -> nil
+    end
+  end
+
+  defp parse_return_date(_), do: nil
 
   # The payload's ids arrive as integers; the crosswalk is keyed by string.
   # Normalising here rather than at every call site is what stops a

--- a/lib/sleeper_player_api/sleeper.ex
+++ b/lib/sleeper_player_api/sleeper.ex
@@ -22,6 +22,8 @@ defmodule SleeperPlayerApi.Sleeper do
     :search_full_name,
     :search_rank,
     :years_exp,
+    :injury_status,
+    :injury_body_part,
     :status_id,
     :team_id,
     :position_id,

--- a/lib/sleeper_player_api/sleeper/player.ex
+++ b/lib/sleeper_player_api/sleeper/player.ex
@@ -19,6 +19,12 @@ defmodule SleeperPlayerApi.Sleeper.Player do
     field :search_rank, :integer
     field :years_exp, :integer
 
+    # Sleeper carries these on every player in `/players/nfl` and the dump has
+    # always stored them inside `player_json` without extracting them. See the
+    # migration: this is where injury data comes from, not from KeepTradeCut.
+    field :injury_status, :string
+    field :injury_body_part, :string
+
     belongs_to :team, Team, on_replace: :update
     belongs_to :position, Position, on_replace: :update
     belongs_to :status, Status, on_replace: :update
@@ -44,6 +50,8 @@ defmodule SleeperPlayerApi.Sleeper.Player do
       :search_full_name,
       :search_rank,
       :years_exp,
+      :injury_status,
+      :injury_body_part,
       :position_id,
       :status_id,
       :team_id

--- a/lib/sleeper_player_api_web/controllers/dynasty_value_json.ex
+++ b/lib/sleeper_player_api_web/controllers/dynasty_value_json.ex
@@ -40,7 +40,13 @@ defmodule SleeperPlayerApiWeb.DynastyValueJSON do
       # unknown are different answers and the UI renders them differently.
       change: v.change,
       changePct: v.change_pct,
-      since: v.since
+      since: v.since,
+      # KTC only, and `null` on a FantasyCalc row rather than 0 — the same
+      # flat-vs-unknown rule `change` follows. `liquidity` is how tradeable
+      # the market finds him (0-100), which is not what `value` says.
+      liquidity: v.liquidity,
+      injuryReturn: v.injury_return,
+      byeWeek: v.bye_week
     }
   end
 

--- a/lib/sleeper_player_api_web/controllers/player_json.ex
+++ b/lib/sleeper_player_api_web/controllers/player_json.ex
@@ -39,6 +39,8 @@ defmodule SleeperPlayerApiWeb.PlayerJSON do
       first_name: player.first_name,
       last_name: player.last_name,
       full_name: player.full_name,
+      injury_status: player.injury_status,
+      injury_body_part: player.injury_body_part,
       player_id: player.player_id,
       position: if(player.position, do: player.position.abbreviation, else: nil),
       search_first_name: player.search_first_name,

--- a/priv/repo/migrations/20260815120000_create_observed_roster_history.exs
+++ b/priv/repo/migrations/20260815120000_create_observed_roster_history.exs
@@ -24,10 +24,13 @@ defmodule SleeperPlayerApi.Repo.Migrations.CreateObservedRosterHistory do
     # rather than duplicating.
     #
     # **Daily-always, not append-on-change.** Measured 2026-08-15 against
-    # production: 2,238 rosters across 179 leagues, 26.4 players each,
-    # `observed_rosters` totalling 1,616 kB — so ~740 bytes a row and about
-    # **605 MB a year** written unconditionally, against a 305 MB database and
-    # 14 GB free. Skipping unchanged rosters would cut that roughly fourfold
+    # production: 2,238 rosters across 179 leagues, 26.4 players each, so
+    # about **377 MB a year** written unconditionally, against a 305 MB
+    # database and 14 GB free. (Estimated at 605 MB before the fact, by
+    # extrapolating 740 bytes a row from `observed_rosters`; that table
+    # carries two indexes to this one's one, and the first day's real rows
+    # came in at 1,008 kB for 2,206 — ~468 bytes each.) Skipping unchanged
+    # rosters would cut that roughly fourfold
     # (rosters move weekly in season, barely at all outside it), and was
     # rejected anyway: it makes a missing day ambiguous between "nothing
     # changed" and "we never looked", and every query here is a point-in-time

--- a/priv/repo/migrations/20260815140000_add_injury_and_ktc_extras.exs
+++ b/priv/repo/migrations/20260815140000_add_injury_and_ktc_extras.exs
@@ -1,0 +1,62 @@
+defmodule SleeperPlayerApi.Repo.Migrations.AddInjuryAndKtcExtras do
+  use Ecto.Migration
+
+  def change do
+    # Injury comes from Sleeper's own nightly dump, not from KeepTradeCut.
+    #
+    # This was assumed the other way round until it was measured on
+    # 2026-08-15. Sleeper's `/players/nfl` payload has carried
+    # `injury_status` and `injury_body_part` all along — they sit unread
+    # inside `players.player_json`, which the dump already stores. Across
+    # active players: 357 Questionable, 73 IR, 61 NA, 55 PUP, 8 Sus, 5 Out,
+    # 2 DNR, and 525 with a body part. On the 488-player dynasty pool that is
+    # 77 with a status, against KTC's 75 — the same answer from a source the
+    # app already fetches, refreshes nightly, and uses for every other player
+    # fact.
+    #
+    # So no new request buys this, and it does not belong on `player_values`:
+    # an injury is a fact about a player, not about what a market thinks he
+    # is worth. `Player.changeset/2` casts from the raw payload, so adding
+    # the columns to the cast list is all the nightly dump needs to fill them.
+    alter table(:players) do
+      add :injury_status, :string
+      add :injury_body_part, :string
+    end
+
+    # What KeepTradeCut has that Sleeper does not.
+    #
+    # `liquidity` is KTC's `stdLiquidity`, 0-100 — how *tradeable* a player
+    # is, as distinct from what he is worth. Measured live: present for all
+    # 500 entries, range 0.0-99.0, mean 20.7. It is the one field here with no
+    # sample-size caveat, and it says something a value cannot — "worth 4,300
+    # but almost never moves" is a warning the number alone hides.
+    #
+    # Deliberately NOT `trade_frequency`, which stays null for KTC. Those are
+    # different measurements from different providers and folding one into the
+    # other would make two sources look comparable on a column where they are
+    # not — the same reason `roster_percent` stays null. See the source's
+    # moduledoc.
+    #
+    # `injury_return` is an expected return date. Sleeper carries nothing like
+    # it: measured on the dynasty pool, 0 of 77 injured players have an
+    # `injury_start_date` and only 21 have `injury_notes`, which is a one-word
+    # cause ("Surgery", "Soreness") rather than a timeline. It is stored as a
+    # date, not KTC's "Aug 22, 2026" string, so that a return already in the
+    # past can be told from one still ahead — an unparseable value is dropped
+    # rather than guessed at, the same rule `parse_pick/1` follows.
+    #
+    # `bye_week` likewise: Sleeper's player payload has no bye week at all
+    # (0 of 488 on the pool), and KTC ships one for every entry.
+    #
+    # These two are per-*player* while `liquidity` is per-format, so both are
+    # duplicated across the `keeptradecut:1qb` and `keeptradecut:sf` rows. The
+    # alternative was a second writer into `players`, which the Sleeper dump
+    # owns; two nullable columns repeated across two rows a player is a much
+    # smaller price than splitting ownership of that table.
+    alter table(:player_values) do
+      add :liquidity, :float
+      add :injury_return, :date
+      add :bye_week, :integer
+    end
+  end
+end

--- a/test/sleeper_player_api/intel/player_value_sources/keep_trade_cut_test.exs
+++ b/test/sleeper_player_api/intel/player_value_sources/keep_trade_cut_test.exs
@@ -17,8 +17,22 @@ defmodule SleeperPlayerApi.Intel.PlayerValueSources.KeepTradeCutTest do
       "position" => "RB",
       "draftYear" => 2023,
       "mflid" => 16_162,
-      "oneQBValues" => %{"value" => 9999, "rank" => 1, "positionalRank" => 1},
-      "superflexValues" => %{"value" => 9997, "rank" => 1, "positionalRank" => 1}
+      "byeWeek" => 6,
+      # The healthy shape, and the common one: 425 of 500 entries carry an
+      # `injuryCode` and nothing else (measured 2026-08-15).
+      "injury" => %{"injuryCode" => 1},
+      "oneQBValues" => %{
+        "value" => 9999,
+        "rank" => 1,
+        "positionalRank" => 1,
+        "stdLiquidity" => 41.0
+      },
+      "superflexValues" => %{
+        "value" => 9997,
+        "rank" => 1,
+        "positionalRank" => 1,
+        "stdLiquidity" => 35.0
+      }
     },
     %{
       "playerName" => "Zay Flowers",
@@ -26,8 +40,26 @@ defmodule SleeperPlayerApi.Intel.PlayerValueSources.KeepTradeCutTest do
       "position" => "WR",
       "draftYear" => 2023,
       "mflid" => 16_190,
-      "oneQBValues" => %{"value" => 6012, "rank" => 24, "positionalRank" => 12},
-      "superflexValues" => %{"value" => 5359, "rank" => 41, "positionalRank" => 18}
+      "byeWeek" => 11,
+      # The injured shape, verbatim from the live payload.
+      "injury" => %{
+        "injuryArea" => "Hamstring",
+        "injuryCode" => 2,
+        "injuryName" => "Questionable",
+        "injuryReturn" => "Aug 22, 2026"
+      },
+      "oneQBValues" => %{
+        "value" => 6012,
+        "rank" => 24,
+        "positionalRank" => 12,
+        "stdLiquidity" => 12.0
+      },
+      "superflexValues" => %{
+        "value" => 5359,
+        "rank" => 41,
+        "positionalRank" => 18,
+        "stdLiquidity" => 9.0
+      }
     },
     %{
       "playerName" => "2027 Early 1st",
@@ -143,6 +175,66 @@ defmodule SleeperPlayerApi.Intel.PlayerValueSources.KeepTradeCutTest do
 
     assert {:ok, entries} = KeepTradeCut.fetch_values()
     assert Enum.all?(entries, &(&1.roster_percent == nil and &1.trade_frequency == nil))
+  end
+
+  test "liquidity is shaped per format, not once per player", %{bypass: bypass} do
+    # The reason it lives on the value row rather than beside `bye_week`: KTC
+    # prices how tradeable a player is separately for 1QB and superflex, and
+    # collapsing the two would report one league's market to the other.
+    stub(bypass, @players)
+
+    assert {:ok, entries} = KeepTradeCut.fetch_values()
+
+    assert [%{liquidity: 41.0}, %{liquidity: 35.0}] =
+             entries |> Enum.filter(&(&1.player_id == 9509)) |> Enum.sort_by(& &1.source)
+  end
+
+  test "an expected return is stored as a date, and the bye week travels with it", %{
+    bypass: bypass
+  } do
+    stub(bypass, @players)
+
+    assert {:ok, entries} = KeepTradeCut.fetch_values()
+    flowers = Enum.filter(entries, &(&1.player_id == 9500))
+
+    # A date rather than KTC's "Aug 22, 2026" string, so a return already in
+    # the past can be told from one still ahead.
+    assert Enum.all?(flowers, &(&1.injury_return == ~D[2026-08-22]))
+
+    # Per-player, so the same on both format rows — unlike liquidity above.
+    assert Enum.all?(flowers, &(&1.bye_week == 11))
+  end
+
+  test "a healthy player carries no return date at all", %{bypass: bypass} do
+    # `%{"injuryCode" => 1}` is the healthy majority, and it must read as "no
+    # date" rather than as a date the parser invented.
+    stub(bypass, @players)
+
+    assert {:ok, entries} = KeepTradeCut.fetch_values()
+    gibbs = Enum.filter(entries, &(&1.player_id == 9509))
+
+    assert Enum.all?(gibbs, &(&1.injury_return == nil))
+    assert Enum.all?(gibbs, &(&1.bye_week == 6))
+  end
+
+  test "a return date KTC words differently is dropped, not guessed at", %{bypass: bypass} do
+    # Same rule as `parse_pick/1`: a value that does not parse means the feed
+    # changed, and that should surface as a missing date rather than a wrong
+    # one. "Week 4" and "TBD" are the shapes a date field tends to drift into.
+    odd =
+      Enum.map(@players, fn p ->
+        if p["mflid"] == 16_190,
+          do: Map.put(p, "injury", %{"injuryCode" => 2, "injuryReturn" => "Week 4"}),
+          else: p
+      end)
+
+    stub(bypass, odd)
+
+    assert {:ok, entries} = KeepTradeCut.fetch_values()
+
+    assert entries
+           |> Enum.filter(&(&1.player_id == 9500))
+           |> Enum.all?(&(&1.injury_return == nil))
   end
 
   test "a player the crosswalk cannot resolve is dropped, not failed over", %{bypass: bypass} do

--- a/test/sleeper_player_api/tasks/get_sleeper_player_data_test.exs
+++ b/test/sleeper_player_api/tasks/get_sleeper_player_data_test.exs
@@ -1,0 +1,63 @@
+defmodule SleeperPlayerApi.Tasks.GetSleeperPlayerDataTest do
+  use SleeperPlayerApi.DataCase, async: true
+
+  alias SleeperPlayerApi.Repo
+  alias SleeperPlayerApi.Sleeper.Player
+  alias SleeperPlayerApi.Tasks.GetSleeperPlayerData
+
+  # A trimmed slice of a real `/players/nfl` entry (2026-08-15), keeping the
+  # injury fields exactly as Sleeper spells them. They have been in this
+  # payload all along, landing in `player_json` and read by nothing — see the
+  # migration that added the columns.
+  defp payload(attrs \\ %{}) do
+    Map.merge(
+      %{
+        "player_id" => "6794",
+        "first_name" => "Malik",
+        "last_name" => "Nabers",
+        "full_name" => "Malik Nabers",
+        "search_first_name" => "malik",
+        "search_last_name" => "nabers",
+        "search_full_name" => "maliknabers",
+        "active" => true,
+        "age" => 23,
+        "years_exp" => 2,
+        "injury_status" => "Questionable",
+        "injury_body_part" => "Knee - ACL"
+      },
+      attrs
+    )
+  end
+
+  test "the nightly dump extracts the injury fields it used to bury in player_json" do
+    GetSleeperPlayerData.add_or_update_player_in_repo(payload())
+
+    assert %Player{injury_status: "Questionable", injury_body_part: "Knee - ACL"} =
+             Repo.get(Player, 6794)
+  end
+
+  test "a player who gets hurt between runs stops reading healthy" do
+    GetSleeperPlayerData.add_or_update_player_in_repo(payload(%{"injury_status" => nil}))
+    assert %Player{injury_status: nil} = Repo.get(Player, 6794)
+
+    GetSleeperPlayerData.add_or_update_player_in_repo(payload())
+    assert %Player{injury_status: "Questionable"} = Repo.get(Player, 6794)
+  end
+
+  # The direction that actually goes wrong. Sleeper sends the key with an
+  # explicit `null` rather than omitting it when a player is healthy —
+  # measured 2026-08-15 over 2,886 uninjured actives, key present on all of
+  # them, absent on none — which is what lets `cast/3` clear the column. Were
+  # it omitted instead, cast would skip it and last week's injury would stay
+  # on screen forever, so this pins the payload shape as much as the code.
+  test "a player who recovers stops reading hurt" do
+    GetSleeperPlayerData.add_or_update_player_in_repo(payload())
+    assert %Player{injury_status: "Questionable"} = Repo.get(Player, 6794)
+
+    GetSleeperPlayerData.add_or_update_player_in_repo(
+      payload(%{"injury_status" => nil, "injury_body_part" => nil})
+    )
+
+    assert %Player{injury_status: nil, injury_body_part: nil} = Repo.get(Player, 6794)
+  end
+end

--- a/test/sleeper_player_api_web/controllers/dynasty_value_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/dynasty_value_controller_test.exs
@@ -135,6 +135,40 @@ defmodule SleeperPlayerApiWeb.DynastyValueControllerTest do
     assert [%{"change" => 3000.0}] = body["values"]
   end
 
+  test "liquidity, expected return and bye week reach the wire", %{conn: conn} do
+    # These come from KTC and nothing else does the shaping, so the endpoint
+    # contract is the only place the whole path is pinned end to end.
+    Intel.upsert_player_values([
+      %{
+        player_id: 4984,
+        source: "keeptradecut:sf",
+        value: 6000.0,
+        overall_rank: 1,
+        position_rank: 1,
+        as_of: DateTime.utc_now() |> DateTime.truncate(:second),
+        liquidity: 12.5,
+        injury_return: ~D[2026-08-22],
+        bye_week: 11
+      }
+    ])
+
+    body = conn |> get(~p"/api/v1/dynasty-values") |> json_response(200)
+
+    assert [%{"liquidity" => 12.5, "injuryReturn" => "2026-08-22", "byeWeek" => 11}] =
+             body["values"]
+  end
+
+  test "a value without them sends null rather than zero", %{conn: conn} do
+    # Same flat-vs-unknown rule `change` follows. FantasyCalc rows carry no
+    # liquidity at all, and 0.0 would read as "never traded" rather than "not
+    # measured here"; `seed_value/4` shapes a row the same way, without them.
+    seed_value(4984, "keeptradecut:sf", 6000.0, 1)
+
+    body = conn |> get(~p"/api/v1/dynasty-values") |> json_response(200)
+
+    assert [%{"liquidity" => nil, "injuryReturn" => nil, "byeWeek" => nil}] = body["values"]
+  end
+
   test "picks come back alongside the players", %{conn: conn} do
     Intel.upsert_draft_pick_values([
       %{

--- a/test/sleeper_player_api_web/controllers/player_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/player_controller_test.exs
@@ -17,6 +17,18 @@ defmodule SleeperPlayerApiWeb.PlayerControllerTest do
       conn = get(conn, ~p"/api/v1/players/active")
       assert json_response(conn, 200)["data"] == []
     end
+
+    # Injury comes from Sleeper's own dump rather than from a value source, so
+    # this endpoint is where the frontend reads it — see the migration.
+    test "carries the injury fields the dump extracts", %{conn: conn} do
+      SleeperPlayerApi.SleeperFixtures.player_fixture(%{
+        injury_status: "Questionable",
+        injury_body_part: "Hamstring"
+      })
+
+      assert [%{"injury_status" => "Questionable", "injury_body_part" => "Hamstring"}] =
+               conn |> get(~p"/api/v1/players/active") |> json_response(200) |> Map.get("data")
+    end
   end
 
   #  @create_attrs %{


### PR DESCRIPTION
Follow-up to #49. All four fields were already being fetched and thrown away — this stores and serves them.

## Injury comes from Sleeper, not KeepTradeCut

This was assumed the other way round. Measured 2026-08-15: `/players/nfl` has carried `injury_status` and `injury_body_part` all along, landing in `players.player_json` and read by nothing.

| | Sleeper | KTC |
|---|---|---|
| Dynasty pool (488) with a status | **77** | 75 |
| All actives with a status | **561** | n/a — KTC's pool is 500 |
| With a body part | **525** | 75 |
| With an expected return date | **0** | **75** |

So no new request buys injury status, and it does not belong on `player_values` — an injury is a fact about a player, not about what a market thinks he is worth. `Player.changeset/2` casts from the raw payload, so adding the columns to the cast list is all the nightly dump needed.

Sleeper sends the keys with an explicit `null` when a player is healthy (measured: present on all 2,886 uninjured actives, absent on none), which is what lets `cast/3` clear a stale injury. Pinned by a test, since an omitted key would leave last week's injury on screen forever.

## What KTC has that Sleeper does not

Three columns on `player_values`:

- **`liquidity`** — KTC's `stdLiquidity`, 0-100. Present for all 500 entries, range 0.0-99.0, mean 20.7. The one field here with no sample-size caveat, and it says something a value cannot: "worth 4,300 but almost never moves". Per-format, so it belongs on the value row.
- **`injury_return`** — stored as a date, not KTC's `"Aug 22, 2026"` string, so a return already in the past can be told from one still ahead. Unparseable values are dropped rather than guessed at, same rule `parse_pick/1` follows.
- **`bye_week`** — Sleeper's player payload has none (0 of 488 on the pool).

The last two are per-*player*, so they are duplicated across the `keeptradecut:1qb` and `keeptradecut:sf` rows. The alternative was a second writer into `players`, which the Sleeper dump owns; two nullable columns repeated twice a player is the smaller price.

`roster_percent` and `trade_frequency` still stay null for KTC — liquidity sits *beside* `trade_frequency` rather than inside it, so a caller knows whose measurement it has.

## Notes

The endpoint test earned its place: `Sleeper.list_active_players/0` selects an explicit field list, so the new columns reached the database and stopped at the query. Nothing else would have caught that.

Also corrects the size estimate in #49's migration comment — 605 MB/yr was extrapolated from a table with two indexes; the real first day measured ~468 bytes a row, so ~377 MB/yr.

Sabotage-verified: dropping the cast fields fails 4; dropping them from the select list fails 1; nulling `liquidity` fails 1; making the date parser accept anything fails 1.

392 tests, `mix format --check-formatted` clean.