### PR TITLE
Stop counting leagues the crawl has abandoned as leagues we can see

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -657,7 +657,8 @@ defmodule SleeperPlayerApi.Intel do
   `%{{user_id, player_id} => count}` and `leagues_seen` is
   `%{user_id => count}` — the honest denominator, being the leagues we have
   roster data for, not every league the manager is in. A league whose rosters
-  have never been fetched, or that Sleeper returned empty, is in neither.
+  have never been fetched, that Sleeper returned empty, or that the crawl has
+  stopped refreshing (see `reject_stale_rosters/1`), is in neither.
 
   `player_ids` narrows the ownership map; the denominators are always the
   manager's full count, because "owns him in 2" only means something against
@@ -665,7 +666,9 @@ defmodule SleeperPlayerApi.Intel do
   """
   @spec ownership([String.t()] | nil) :: {map, map}
   def ownership(player_ids \\ nil) do
-    base = from(r in ObservedRoster, where: not is_nil(r.owner_id))
+    base =
+      from(r in ObservedRoster, where: not is_nil(r.owner_id))
+      |> reject_stale_rosters()
 
     # A manager's denominator counts the leagues we can see, and a roster
     # with no players in it is a league we cannot see into — 22 of the 176
@@ -702,6 +705,56 @@ defmodule SleeperPlayerApi.Intel do
       |> Map.new(fn {owner_id, player_id, count} -> {{owner_id, player_id}, count} end)
 
     {ownership, leagues_seen}
+  end
+
+  # How far a roster may trail the freshest one before it stops counting. The
+  # crawl is nightly, so this is "has missed more than two consecutive runs".
+  @roster_staleness_grace_seconds 48 * 60 * 60
+
+  @doc """
+  Drops rosters the crawl has effectively abandoned: those whose `fetched_at`
+  trails the freshest observation in the table by more than
+  #{div(@roster_staleness_grace_seconds, 3600)} hours.
+
+  Rosters go stale without ever being deleted, because nothing in the crawl
+  deletes them. A league leaves `CrawlLeaguemateTransactions`' enumeration the
+  moment the last tracked leaguemate leaves it — `/user/:id/leagues` stops
+  listing it, so `crawl_league/3` is never called for it again — and its rows
+  simply stop being refreshed. Measured 2026-08-15: league 1392042205710946304
+  had 32 rows six days old and still counted, in both the numerator and the
+  `leagues_seen` denominator, as a league we could see into. The gap grows
+  without bound. The same thing happens to a league that *is* still enumerated
+  but whose `/league/:id/rosters` keeps failing, since `ensure_roster_map/2`
+  deliberately leaves the previous rows alone.
+
+  **Relative to the freshest row, not to the wall clock.** An absolute "older
+  than N days" cutoff would empty every manager's ownership at once during a
+  multi-day Sleeper outage — the read-time version of exactly what
+  `ensure_roster_map/2` refuses to do at write time, where a failed fetch must
+  read as stale rather than as "nobody owns anybody". Measuring against
+  `max(fetched_at)` makes an outage move the whole table together and exclude
+  nothing, while a league that has dropped out falls behind a corpus that is
+  still being refreshed nightly.
+
+  Applied to the query both halves are built from, so an excluded league
+  leaves the numerator and the denominator together: the answer becomes
+  "owns him in 2 of 41", never "2 of 42" with one of the 42 six days old.
+
+  A row with no `fetched_at` is kept. Nothing the crawler writes lacks one
+  (`roster_rows/3` always stamps it), so this only reaches rows written by
+  other means, and absence of a timestamp is not evidence of age — this
+  excludes only what it can positively date.
+  """
+  @spec reject_stale_rosters(Ecto.Query.t()) :: Ecto.Query.t()
+  def reject_stale_rosters(query) do
+    case Repo.one(from(r in ObservedRoster, select: max(r.fetched_at))) do
+      nil ->
+        query
+
+      latest ->
+        cutoff = DateTime.add(latest, -@roster_staleness_grace_seconds, :second)
+        from(r in query, where: is_nil(r.fetched_at) or r.fetched_at >= ^cutoff)
+    end
   end
 
   @doc """

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
@@ -499,6 +499,95 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
       assert ownership == %{{@alice, "6794"} => 1}
       assert leagues_seen == %{@alice => 1, @bob => 1}
     end
+
+    test "a league the crawl has stopped refreshing drops out of both sides", %{bypass: bypass} do
+      # The production case: the last tracked leaguemate leaves a league, so
+      # `/user/:id/leagues` stops listing it and `crawl_league/3` is never
+      # called for it again. Nothing deletes its rosters, so without this they
+      # keep counting forever, at whatever age they were abandoned.
+      stub(bypass, leagues_for: %{@alice => ["900", "901"], @bob => ["900"]})
+      stub_extra_league!(bypass, 901)
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      assert {_, %{@alice => 2}} = Intel.ownership(["4034"])
+
+      age_rosters!(901, 6)
+
+      assert {ownership, leagues_seen} = Intel.ownership(["4034"])
+
+      assert ownership == %{{@alice, "4034"} => 1, {@bob, "4034"} => 1},
+             "an abandoned league must leave the numerator"
+
+      assert leagues_seen == %{@alice => 1, @bob => 1},
+             "and the denominator with it — never 1 of 2 where the 2 is six days old"
+    end
+
+    test "one missed run is stale, not gone", %{bypass: bypass} do
+      # The crawl is nightly and a single failed `/league/:id/rosters` is
+      # routine. `ensure_roster_map/2` keeps the previous rows on purpose, and
+      # this must not undo that a night later.
+      stub(bypass, leagues_for: %{@alice => ["900", "901"], @bob => ["900"]})
+      stub_extra_league!(bypass, 901)
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+      age_rosters!(901, 1)
+
+      assert {_, %{@alice => 2}} = Intel.ownership(["4034"])
+    end
+
+    test "a corpus-wide outage excludes nothing", %{bypass: bypass} do
+      # Why the cutoff is measured against the freshest row rather than the
+      # wall clock. Everything ages together during a Sleeper outage, and an
+      # absolute threshold would read that as nobody owning anybody — the
+      # read-time version of the failure `ensure_roster_map/2` refuses to
+      # write.
+      stub(bypass, leagues_for: %{@alice => ["900", "901"], @bob => ["900"]})
+      stub_extra_league!(bypass, 901)
+
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      age_rosters!(900, 6)
+      age_rosters!(901, 6)
+
+      assert {ownership, leagues_seen} = Intel.ownership(["4034"])
+      assert ownership == %{{@alice, "4034"} => 2, {@bob, "4034"} => 1}
+      assert leagues_seen == %{@alice => 2, @bob => 1}
+    end
+  end
+
+  # A second league for @alice, so that one can go stale while another stays
+  # current. The default `stub/2` only serves league 900.
+  defp stub_extra_league!(bypass, league_id) do
+    Bypass.stub(bypass, "GET", "/league/#{league_id}/rosters", fn conn ->
+      Plug.Conn.resp(
+        conn,
+        200,
+        Jason.encode!([%{"roster_id" => 1, "owner_id" => "#{@alice}", "players" => ["4034"]}])
+      )
+    end)
+
+    Bypass.stub(
+      bypass,
+      "GET",
+      "/league/#{league_id}/transactions/1",
+      &Plug.Conn.resp(&1, 200, "[]")
+    )
+  end
+
+  # Backdates a league's rosters as if the crawl had not reached it since.
+  defp age_rosters!(league_id, days) do
+    then =
+      DateTime.utc_now()
+      |> DateTime.add(-days * 24 * 60 * 60, :second)
+      |> DateTime.truncate(:second)
+
+    {count, _} =
+      Repo.update_all(
+        from(r in ObservedRoster, where: r.league_id == ^league_id),
+        set: [fetched_at: then]
+      )
+
+    assert count > 0, "nothing to age — the fixture never stored rosters for #{league_id}"
   end
 
   describe "failure behaviour" do


### PR DESCRIPTION
`observed_rosters` retains rows for leagues that have dropped out of the crawl's enumeration, and those rows still feed `Intel.ownership/1`.

A league leaves `CrawlLeaguemateTransactions`' enumeration the moment the last tracked leaguemate leaves it: `/user/:id/leagues` stops listing it, so `crawl_league/3` is never called for it again. Nothing deletes its rosters, so they keep counting at whatever age they were abandoned.

Found in production 2026-08-15 — league 1392042205710946304 ("Chop: The Colosseum") had `rosters_fetched_at` stuck at 2026-08-09 and 32 `observed_rosters` rows with that same `fetched_at`, feeding both the numerator and the `leagues_seen` denominator of the shipped per-manager ownership figure (be #44, fe #155). The gap grows without bound. Noticed while adding `observed_roster_history` (#49), which correctly writes nothing for that league.

## The fix

`ownership/1` builds its `base` query through a new `reject_stale_rosters/1`, which excludes rosters whose `fetched_at` trails the freshest row in `observed_rosters` by more than 48 hours — at a nightly crawl, "has missed more than two consecutive runs".

Applied to the query both halves are built from, so an excluded league leaves the numerator and the denominator together: the answer becomes "owns him in 2 of 41", never "2 of 42" with one of the 42 six days old.

**Relative to the freshest row, not the wall clock.** An absolute cutoff would empty every manager's ownership at once during a multi-day Sleeper outage — the read-time version of exactly what `ensure_roster_map/2` refuses to do at write time, where a failed fetch must read as stale rather than as "nobody owns anybody". Measured against `max(fetched_at)`, an outage moves the whole table together and excludes nothing, while a league that has dropped out falls behind a corpus still being refreshed nightly.

Rows with a `nil` `fetched_at` are kept. `roster_rows/3` always stamps one, so this only reaches rows written by other means, and a missing timestamp is not evidence of age.

## Why not prune

Pruning `observed_rosters`/`league_members` for leagues absent from an enumeration pass was the alternative. Three things ruled it out:

- **It can't tell "not enumerated" from "the one leaguemate who was our path to it failed enumeration".** `enumerate_leagues/3` drops a user's entire league list on a single failed `/user/:id/leagues` call, recording only `{:user_leagues_failed, ...}` in `errors`. With 13 leaguemates covering 176 leagues, one failed call can make dozens look dropped — so a prune would need a wholly error-free run to be safe, a new invariant someone has to keep holding.
- **It misses the sibling case.** A league that *is* still enumerated but whose `/league/:id/rosters` keeps failing goes stale identically, since `ensure_roster_map/2` deliberately leaves the previous rows alone. A prune never reaches it; this rule covers both.
- **Pruning `league_members` would have introduced a bug.** `transaction_coverage/2` draws its numerator from `observed_transactions` where the user is a participant, and those rows survive a membership prune — a manager who traded in a league before leaving it would report more leagues seen than known. (`league_members` is not part of `ownership/1` at all; `leagues_seen` comes from `observed_rosters.owner_id`.)

## Tests

Three tests in the `ownership/1` block: an abandoned league leaving both sides, one missed run still counting (stale, not gone), and a corpus-wide outage excluding nothing. Verified the first genuinely catches the bug by removing the filter and watching only that test fail.

385 tests, 0 failures. `mix format --check-formatted` clean. No migration, no crawl or schema changes.

## Still open

`observed_leagues` and `league_members` keep accumulating leagues nobody is in anymore. That is now invisible to the ownership figure, but it does inflate `transaction_coverage/2`'s `leagues_known` over time — a manager reads as "38 of 42" where two of the 42 are leagues they left. Pruning it safely needs the enumerated-vs-failed distinction the `Summary` doesn't record.

One caveat on the 48-hour constant: it encodes the crawl cadence. If the nightly crawl ever slips to every other night, a healthy league could fall outside the window. It's a single module attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
