### PR TITLE
Keep the waiver budget the crawl already receives

### DIFF
--- a/lib/sleeper_player_api/intel.ex
+++ b/lib/sleeper_player_api/intel.ex
@@ -565,6 +565,11 @@ defmodule SleeperPlayerApi.Intel do
               roster_to_user: fragment("COALESCE(EXCLUDED.roster_to_user, ?)", l.roster_to_user),
               rosters_fetched_at:
                 fragment("COALESCE(EXCLUDED.rosters_fetched_at, ?)", l.rosters_fetched_at),
+              # COALESCE like the rest: the roster path upserts this table too
+              # and sends neither of these, so a plain replace would blank the
+              # budget on every crawl and leave every bid uncomparable again.
+              waiver_budget: fragment("COALESCE(EXCLUDED.waiver_budget, ?)", l.waiver_budget),
+              waiver_type: fragment("COALESCE(EXCLUDED.waiver_type, ?)", l.waiver_type),
               transactions_fetched_through:
                 fragment(
                   "GREATEST(COALESCE(EXCLUDED.transactions_fetched_through, 0), COALESCE(?, 0))",

--- a/lib/sleeper_player_api/intel/observed_league.ex
+++ b/lib/sleeper_player_api/intel/observed_league.ex
@@ -24,6 +24,14 @@ defmodule SleeperPlayerApi.Intel.ObservedLeague do
     field :rosters_fetched_at, :utc_datetime
     field :transactions_fetched_through, :integer
 
+    # Sleeper's own `settings.waiver_budget` / `settings.waiver_type`, kept
+    # out of the league objects the enumeration already returns. A bid is
+    # meaningless without the budget it was made against, and a zero is
+    # meaningless without knowing whether the league bids at all — see the
+    # migration for the measured spread. `waiver_type` 2 is FAAB.
+    field :waiver_budget, :integer
+    field :waiver_type, :integer
+
     timestamps()
   end
 
@@ -36,7 +44,9 @@ defmodule SleeperPlayerApi.Intel.ObservedLeague do
       :season,
       :roster_to_user,
       :rosters_fetched_at,
-      :transactions_fetched_through
+      :transactions_fetched_through,
+      :waiver_budget,
+      :waiver_type
     ])
     |> validate_required([:id])
   end

--- a/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
+++ b/lib/sleeper_player_api/tasks/crawl_leaguemate_transactions.ex
@@ -175,7 +175,7 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
             Enum.reduce(leagues, acc, fn league, inner ->
               case to_int(league["league_id"]) do
                 nil -> inner
-                id -> Map.put_new(inner, id, league["name"])
+                id -> Map.put_new(inner, id, league_row(league))
               end
             end)
 
@@ -194,8 +194,22 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactions do
 
   defp store_leagues(leagues, season) do
     leagues
-    |> Enum.map(fn {id, name} -> %{id: id, name: name, season: season} end)
+    |> Enum.map(fn {id, row} -> Map.merge(row, %{id: id, season: season}) end)
     |> Intel.upsert_observed_leagues()
+  end
+
+  # The waiver settings ride along in the enumeration payload, which already
+  # returns whole league objects — no extra request. Both are needed before a
+  # bid can be compared to any other bid: see the migration for the measured
+  # budget spread, and `Intel.faab_market/1` for what it does with them.
+  defp league_row(league) do
+    settings = league["settings"] || %{}
+
+    %{
+      name: league["name"],
+      waiver_budget: to_int(settings["waiver_budget"]),
+      waiver_type: to_int(settings["waiver_type"])
+    }
   end
 
   defp crawl_league(league_id, current_week, summary) do

--- a/priv/repo/migrations/20260815160000_add_waiver_settings_to_observed_leagues.exs
+++ b/priv/repo/migrations/20260815160000_add_waiver_settings_to_observed_leagues.exs
@@ -1,0 +1,30 @@
+defmodule SleeperPlayerApi.Repo.Migrations.AddWaiverSettingsToObservedLeagues do
+  use Ecto.Migration
+
+  def change do
+    # Both already arrive in a payload the crawler reads and throws away:
+    # `/user/:id/leagues/nfl/:season` returns whole league objects, and
+    # `enumerate_leagues/3` keeps `league_id` and `name` out of them. So this
+    # costs no request, exactly like the injury fields did.
+    #
+    # **Without `waiver_budget` a bid is not a number you can compare.**
+    # Measured 2026-08-15 over 40 corpus leagues that actually carry bids:
+    # budget 100 on 17 of them, 200 on 8, 1000 on 8, 150 on 4, 300 on 2, 250
+    # on 1. Only about 42% use the standard hundred, so a bid of 50 is half a
+    # budget in one league and a twentieth in another, and averaging the raw
+    # figures across leagues produces a number about nothing. Every bid this
+    # app reports has to be a share of its own league's budget.
+    #
+    # **Without `waiver_type` a zero is ambiguous.** Sleeper stores
+    # `waiver_bid` on every transaction, so a league on rolling waivers or
+    # standard priority (types 0 and 1) contributes zeros that are not bids of
+    # nothing — they are the absence of bidding. Type 2 is FAAB. Pooling the
+    # rest would drag every average toward zero while looking like data; 2,784
+    # of the 4,945 non-null bids in the corpus are zeros, and how many of those
+    # are real free claims cannot be told apart until this column exists.
+    alter table(:observed_leagues) do
+      add :waiver_budget, :integer
+      add :waiver_type, :integer
+    end
+  end
+end

--- a/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
+++ b/test/sleeper_player_api/tasks/crawl_leaguemate_transactions_test.exs
@@ -72,7 +72,20 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
     for {user, league_ids} <- leagues_for do
       Bypass.stub(bypass, "GET", "/user/#{user}/leagues/nfl/2026", fn conn ->
         :counters.add(counts, 1, 1)
-        body = Enum.map(league_ids, &%{"league_id" => &1, "name" => "League #{&1}"})
+
+        # Sleeper returns whole league objects here, `settings` included —
+        # which is where the waiver budget comes from without a second call.
+        body =
+          Enum.map(
+            league_ids,
+            &%{
+              "league_id" => &1,
+              "name" => "League #{&1}",
+              "settings" =>
+                Keyword.get(opts, :settings, %{"waiver_budget" => 100, "waiver_type" => 2})
+            }
+          )
+
         Plug.Conn.resp(conn, 200, Jason.encode!(body))
       end)
     end
@@ -285,6 +298,36 @@ defmodule SleeperPlayerApi.Tasks.CrawlLeaguemateTransactionsTest do
 
       assert {%{{@alice, "4034"} => 1}, _} = Intel.ownership(["4034"]),
              "a brief Sleeper failure must read as stale, not as 'nobody owns anybody'"
+    end
+  end
+
+  describe "waiver settings" do
+    test "keeps the budget and type out of the enumeration payload", %{bypass: bypass} do
+      stub(bypass, settings: %{"waiver_budget" => 1000, "waiver_type" => 2})
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert %{waiver_budget: 1000, waiver_type: 2} = Repo.get(ObservedLeague, 900)
+    end
+
+    # The roster path upserts this table without either field. A plain replace
+    # would blank the budget every crawl and leave every stored bid
+    # uncomparable — see `Intel.faab_market/1` for why that matters.
+    test "a later crawl that sends no settings does not blank them", %{bypass: bypass} do
+      stub(bypass, settings: %{"waiver_budget" => 200, "waiver_type" => 2})
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      Intel.upsert_observed_leagues([%{id: 900, roster_to_user: %{"1" => @alice}}])
+
+      assert %{waiver_budget: 200, waiver_type: 2} = Repo.get(ObservedLeague, 900)
+    end
+
+    test "a league with no settings stores nulls rather than guessing a budget", %{bypass: bypass} do
+      # A missing budget must read as unknown. Defaulting to 100 would price
+      # every bid in a 1000-budget league at ten times its real share.
+      stub(bypass, settings: nil)
+      assert {:ok, _} = CrawlLeaguemateTransactions.crawl(@source_league, "2026")
+
+      assert %{waiver_budget: nil, waiver_type: nil} = Repo.get(ObservedLeague, 900)
     end
   end
 


### PR DESCRIPTION
Groundwork for reading FAAB out of the transaction corpus. Nothing reads these yet.

**A bid is not comparable to another bid without its budget.** Measured 2026-08-15 over 40 corpus leagues that actually carry bids:

| Budget | Leagues |
|---|---|
| 100 | 17 |
| 200 | 8 |
| 1000 | 8 |
| 150 | 4 |
| 300 | 2 |
| 250 | 1 |

Only about 42% use the standard hundred, so a bid of 50 is half a budget in one league and a twentieth in another. Averaging raw bids across leagues produces a number about nothing.

**`waiver_type` settles the other ambiguity.** Sleeper stores `waiver_bid` on every transaction regardless of waiver system, so leagues on rolling waivers or priority contribute zeros that are not bids of nothing. 2,784 of the 4,945 non-null bids in the corpus are zeros, and until this column exists there is no way to tell a genuine free claim from a league that does not bid at all. Type 2 is FAAB.

Both fields already arrive in `/user/:id/leagues/nfl/:season` — it returns whole league objects and `enumerate_leagues/3` was keeping only `league_id` and `name` out of them. No new request.

Upserted with `COALESCE` like every other column here, because the roster path upserts this table too and sends neither field; a plain replace would blank the budget on every crawl. A league with no settings stores nulls rather than defaulting to 100, which would price every bid in a 1000-budget league at ten times its real share.

Sabotage-verified: nulling the budget at the shaping site fails 2 tests; swapping the `COALESCE` for a plain replace fails 2.

395 tests, `mix format --check-formatted` clean.