### PR TITLE
Read FAAB prices out of the transaction corpus

### DIFF
--- a/lib/sleeper_player_api/intel/faab_market.ex
+++ b/lib/sleeper_player_api/intel/faab_market.ex
@@ -1,0 +1,185 @@
+defmodule SleeperPlayerApi.Intel.FaabMarket do
+  @moduledoc """
+  What players actually cost in FAAB across the observed leagues — not a
+  projection, what was *paid*.
+
+  Reads `observed_transactions`, which the nightly crawl has been filling
+  since 2026-08-08 and which nothing outside a single manager's profile has
+  ever looked at in aggregate. No new request, no new table.
+
+  ## Every figure here is a share of the league's own budget
+
+  Measured 2026-08-15 across the 147 FAAB leagues in the corpus: budget 100 on
+  67 of them, 1000 on 33, 200 on 19, 300 on 14, 150 on 7, 250 on 4, 500 on 2,
+  400 on 1. Fewer than half use the standard hundred, so a raw bid of 50 is
+  half a budget in one league and a twentieth in another. Every bid is divided
+  by `observed_leagues.waiver_budget` before it meets another bid.
+
+  Leagues on rolling waivers or priority (`waiver_type` 0 and 1, 31 of them)
+  are excluded outright rather than contributing zeros. Sleeper stores
+  `waiver_bid` on every transaction regardless of waiver system, so those
+  zeros are not bids of nothing — they are the absence of bidding, and pooling
+  them would drag every figure toward zero while looking like data.
+
+  ## A distribution, never a price
+
+  The same player goes for wildly different money in different leagues:
+  measured over the corpus, players with five or more winning claims routinely
+  span 0% to 100% of budget. So this returns `median`, `low` and `high`
+  together and no caller can render one without them. A single "he costs 12%"
+  would be a fiction about a spread that wide — the same discipline the
+  survival number follows, where the distribution *is* the answer.
+
+  ## What counts as a price
+
+  Only **winning** claims (`status: "complete"`). A failed claim is a bid that
+  did not buy the player, and averaging it into what he cost would report a
+  price nobody paid. Failed claims are returned separately, as a count, and
+  deliberately without interpretation: Sleeper does not say *why* a claim
+  failed, and "outbid" and "invalid roster move" look identical here.
+
+  Every winning claim in the corpus adds exactly one player (3,404 of 3,404
+  measured), so a bid attributes to a player unambiguously. If a multi-player
+  claim ever appears, the bid bought the whole claim and this would start
+  overstating each piece — worth re-checking if `adds` sizes ever change.
+
+  ## The window is not optional
+
+  Every bid in the corpus today falls between 2026-05-01 and 2026-07-31 —
+  offseason FAAB, which is a different market from the in-season one where
+  most FAAB is actually spent. The window travels with the response for the
+  same reason `coverage` travels with manager activity: a caller that renders
+  "what he costs" over a window like that, without saying so, is overclaiming.
+  """
+
+  import Ecto.Query
+
+  alias SleeperPlayerApi.Repo
+  alias SleeperPlayerApi.Intel.{ObservedLeague, ObservedTransaction}
+
+  @faab 2
+
+  @doc """
+  Per-player FAAB prices, plus the sample they rest on.
+
+  Returns
+
+      %{
+        window: %{from: ~D[...], to: ~D[...]} | nil,
+        leagues: 147,
+        players: %{"8161" => %{claims: 10, leagues: 9, median: 85.5, low: 0.2,
+                               high: 101.0, failed: 3}}
+      }
+
+  `median`/`low`/`high` are percentages of the paying league's budget, rounded
+  to one place. `claims` is winning claims and `leagues` how many distinct
+  leagues they came from — the honest denominator, since ten claims in one
+  league says much less than ten across ten.
+
+  Nothing is filtered by sample size here. A caller decides what it is willing
+  to render, but it cannot do that without `claims`, which is why the count
+  ships with every entry rather than being left to a follow-up query.
+  """
+  @spec prices(keyword) :: map
+  def prices(opts \\ []) do
+    min_claims = Keyword.get(opts, :min_claims, 1)
+
+    %{
+      window: window(),
+      leagues: league_count(),
+      players: players(min_claims)
+    }
+  end
+
+  defp players(min_claims) do
+    # `inner_lateral_join`, not a plain join: the subquery reads `t.adds` from
+    # the row beside it. Same shape `Intel.ownership/1` uses to unnest roster
+    # arrays, and it drops a claim with no adds rather than counting it.
+    from(t in ObservedTransaction,
+      join: l in ObservedLeague,
+      on: l.id == t.league_id,
+      inner_lateral_join: p in fragment("SELECT jsonb_object_keys(?) AS player_id", t.adds),
+      on: true,
+      where:
+        l.waiver_type == @faab and l.waiver_budget > 0 and t.type == "waiver" and
+          not is_nil(t.waiver_bid),
+      group_by: p.player_id,
+      having: fragment("count(*) FILTER (WHERE ? = 'complete')", t.status) >= ^min_claims,
+      select: %{
+        player_id: p.player_id,
+        claims: fragment("count(*) FILTER (WHERE ? = 'complete')", t.status),
+        leagues:
+          fragment("count(DISTINCT ?) FILTER (WHERE ? = 'complete')", t.league_id, t.status),
+        median:
+          fragment(
+            "percentile_cont(0.5) WITHIN GROUP (ORDER BY 100.0 * ? / ?) FILTER (WHERE ? = 'complete')",
+            t.waiver_bid,
+            l.waiver_budget,
+            t.status
+          ),
+        low:
+          fragment(
+            "min(100.0 * ? / ?) FILTER (WHERE ? = 'complete')",
+            t.waiver_bid,
+            l.waiver_budget,
+            t.status
+          ),
+        high:
+          fragment(
+            "max(100.0 * ? / ?) FILTER (WHERE ? = 'complete')",
+            t.waiver_bid,
+            l.waiver_budget,
+            t.status
+          ),
+        failed: fragment("count(*) FILTER (WHERE ? = 'failed')", t.status)
+      }
+    )
+    |> Repo.all()
+    |> Map.new(fn row ->
+      {row.player_id,
+       %{
+         claims: row.claims,
+         leagues: row.leagues,
+         median: round_pct(row.median),
+         low: round_pct(row.low),
+         high: round_pct(row.high),
+         failed: row.failed
+       }}
+    end)
+  end
+
+  # The span of the corpus, so a caller can say which market these prices are
+  # from. Bounded by the same league filter as the prices themselves —
+  # reporting a window that includes leagues whose bids were excluded would
+  # describe a sample nobody is looking at.
+  defp window do
+    from(t in ObservedTransaction,
+      join: l in ObservedLeague,
+      on: l.id == t.league_id,
+      where:
+        l.waiver_type == @faab and l.waiver_budget > 0 and t.type == "waiver" and
+          t.status == "complete" and not is_nil(t.waiver_bid),
+      select: {min(t.created), max(t.created)}
+    )
+    |> Repo.one()
+    |> case do
+      {%DateTime{} = from, %DateTime{} = to} ->
+        %{from: DateTime.to_date(from), to: DateTime.to_date(to)}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp league_count do
+    from(l in ObservedLeague, where: l.waiver_type == @faab and l.waiver_budget > 0)
+    |> Repo.aggregate(:count, :id)
+  end
+
+  # Decimal out of Postgres, and one place is all the precision a crowd-sourced
+  # share of a budget can carry.
+  defp round_pct(nil), do: nil
+  defp round_pct(%Decimal{} = value), do: value |> Decimal.to_float() |> Float.round(1)
+  defp round_pct(value) when is_float(value), do: Float.round(value, 1)
+  defp round_pct(value) when is_integer(value), do: value * 1.0
+end

--- a/lib/sleeper_player_api_web/controllers/faab_controller.ex
+++ b/lib/sleeper_player_api_web/controllers/faab_controller.ex
@@ -1,0 +1,47 @@
+defmodule SleeperPlayerApiWeb.FaabController do
+  use SleeperPlayerApiWeb, :controller
+
+  alias SleeperPlayerApi.Intel.FaabMarket
+
+  action_fallback SleeperPlayerApiWeb.FallbackController
+
+  # One claim is a real observation and the response says so with `claims`, so
+  # the default hides nothing. A caller wanting only well-sampled players asks
+  # for them rather than being given a filtered list it cannot tell from a
+  # complete one.
+  @default_min_claims 1
+  @max_min_claims 100
+
+  @doc """
+  `GET /api/v1/faab?minClaims=` — what players actually went for in the
+  observed leagues, as a share of each paying league's budget.
+
+  Not a projection: these are winning waiver claims that happened, in leagues
+  the manager's own leaguemates are in. Every entry carries `claims`,
+  `leagues` and the `low`/`high` spread alongside the median, and the response
+  carries the `window` those bids fall in — the prices are meaningless without
+  them, and a caller cannot fetch one without the others.
+  """
+  def index(conn, params) do
+    with {:ok, min_claims} <- parse_min_claims(params["minClaims"]) do
+      render(conn, :index, market: FaabMarket.prices(min_claims: min_claims))
+    end
+  end
+
+  defp parse_min_claims(nil), do: {:ok, @default_min_claims}
+
+  defp parse_min_claims(raw) when is_binary(raw) do
+    case Integer.parse(raw) do
+      {n, ""} when n >= 1 and n <= @max_min_claims ->
+        {:ok, n}
+
+      {n, ""} ->
+        {:error, {:param_out_of_range, :minClaims, n, 1, @max_min_claims}}
+
+      _ ->
+        {:error, {:invalid_param, :minClaims, raw}}
+    end
+  end
+
+  defp parse_min_claims(raw), do: {:error, {:invalid_param, :minClaims, raw}}
+end

--- a/lib/sleeper_player_api_web/controllers/faab_json.ex
+++ b/lib/sleeper_player_api_web/controllers/faab_json.ex
@@ -1,0 +1,45 @@
+defmodule SleeperPlayerApiWeb.FaabJSON do
+  @moduledoc """
+  Renders `Intel.FaabMarket.prices/1` — camelCase keys, same split as the
+  other JSON modules here.
+
+  **`window` and `leagues` are not decoration.** Every bid in this corpus was
+  made in the offseason, which is a different market from the in-season one
+  where most FAAB gets spent, and a UI that renders "12% of budget" without
+  saying over what and across how many leagues is overclaiming. They ride on
+  the envelope so a caller has them before it renders a single price.
+  """
+
+  @doc """
+  Prices keyed by Sleeper id, plus the sample behind them.
+  """
+  def index(%{market: market}) do
+    %{
+      window: window(market.window),
+      leagues: market.leagues,
+      players: Map.new(market.players, fn {id, stats} -> {to_string(id), price(stats)} end)
+    }
+  end
+
+  defp price(stats) do
+    %{
+      # What he went for in the middle league, as a percentage of that
+      # league's budget.
+      median: stats.median,
+      low: stats.low,
+      high: stats.high,
+      # The denominator, always. `claims` is winning claims and `leagues` how
+      # many distinct leagues they came from — ten claims in one league is a
+      # much weaker read than ten across ten.
+      claims: stats.claims,
+      leagues: stats.leagues,
+      # Bids that did not buy him. Sent without interpretation: Sleeper does
+      # not say why a claim failed, so "outbid" and "invalid move" look
+      # identical from here.
+      failed: stats.failed
+    }
+  end
+
+  defp window(nil), do: nil
+  defp window(%{from: from, to: to}), do: %{from: from, to: to}
+end

--- a/lib/sleeper_player_api_web/router.ex
+++ b/lib/sleeper_player_api_web/router.ex
@@ -22,6 +22,7 @@ defmodule SleeperPlayerApiWeb.Router do
     get "/players/:id", PlayerController, :show
     get "/values", PlayerValueController, :index
     get "/dynasty-values", DynastyValueController, :index
+    get "/faab", FaabController, :index
     get "/drafts/:draft_id/availability", AvailabilityController, :show
     get "/leagues/:league_id/intel", IntelController, :show
     get "/leagues/:league_id/trades", TradeController, :index

--- a/test/sleeper_player_api/intel/faab_market_test.exs
+++ b/test/sleeper_player_api/intel/faab_market_test.exs
@@ -1,0 +1,154 @@
+defmodule SleeperPlayerApi.Intel.FaabMarketTest do
+  use SleeperPlayerApi.DataCase, async: true
+
+  alias SleeperPlayerApi.Intel
+  alias SleeperPlayerApi.Intel.FaabMarket
+
+  @alice 111
+  @bob 222
+
+  defp league(id, attrs) do
+    Intel.upsert_observed_leagues([
+      Map.merge(%{id: id, season: "2026", waiver_type: 2, waiver_budget: 100}, attrs)
+    ])
+
+    id
+  end
+
+  # `created` matters: the response's window is built from it, and the window
+  # is what tells a caller which market these prices came from.
+  defp claim(id, league_id, player_id, bid, attrs \\ %{}) do
+    Intel.upsert_observed_transactions([
+      Map.merge(
+        %{
+          id: id,
+          league_id: league_id,
+          week: 1,
+          type: "waiver",
+          status: "complete",
+          created: ~U[2026-06-15 12:00:00Z],
+          creator: @alice,
+          participant_ids: [@alice],
+          adds: %{player_id => 1},
+          drops: %{},
+          waiver_bid: bid
+        },
+        attrs
+      )
+    ])
+  end
+
+  describe "prices/1" do
+    # The whole reason `waiver_budget` is stored. 50 of 100 and 50 of 1000 are
+    # not the same bid, and a version that averaged the raw numbers would call
+    # both of these 50.
+    test "prices a bid as a share of its own league's budget, not as a number" do
+      league(900, %{waiver_budget: 100})
+      league(901, %{waiver_budget: 1000})
+      claim(1, 900, "4034", 50)
+      claim(2, 901, "4034", 50)
+
+      assert %{"4034" => %{median: 27.5, low: 5.0, high: 50.0, claims: 2, leagues: 2}} =
+               FaabMarket.prices().players
+    end
+
+    test "reports the spread, not just the middle" do
+      # Players in this corpus routinely span 0% to 100%, so a median alone
+      # would describe a price nobody paid twice.
+      league(900, %{})
+      league(901, %{})
+      league(902, %{})
+      claim(1, 900, "4034", 0)
+      claim(2, 901, "4034", 30)
+      claim(3, 902, "4034", 100)
+
+      assert %{"4034" => %{median: 30.0, low: 0.0, high: 100.0}} = FaabMarket.prices().players
+    end
+
+    # A bid that lost did not buy the player. Averaging it into the price
+    # reports money nobody paid.
+    test "a failed claim is counted apart, never priced in" do
+      league(900, %{})
+      claim(1, 900, "4034", 10)
+      claim(2, 900, "4034", 90, %{status: "failed"})
+
+      assert %{"4034" => %{median: 10.0, high: 10.0, claims: 1, failed: 1}} =
+               FaabMarket.prices().players
+    end
+
+    # Sleeper stores `waiver_bid` on every transaction whatever the waiver
+    # system, so a rolling-waivers league contributes zeros that are not bids.
+    test "leagues that do not bid are excluded, not counted as bids of nothing" do
+      league(900, %{waiver_budget: 100})
+      league(901, %{waiver_type: 0, waiver_budget: 100})
+      claim(1, 900, "4034", 40)
+      claim(2, 901, "4034", 0)
+
+      assert %{"4034" => %{median: 40.0, claims: 1, leagues: 1}} = FaabMarket.prices().players
+    end
+
+    test "a league with no stored budget is skipped rather than assumed to be 100" do
+      league(900, %{waiver_budget: nil})
+      claim(1, 900, "4034", 50)
+
+      assert FaabMarket.prices().players == %{}
+    end
+
+    # A free-agent add is not a purchase. Only `waiver` claims are bids.
+    test "free agent adds are not prices" do
+      league(900, %{})
+      claim(1, 900, "4034", 0, %{type: "free_agent"})
+
+      assert FaabMarket.prices().players == %{}
+    end
+
+    test "a zero bid in a bidding league is a real price and stays in" do
+      # He was claimed and nobody else wanted him. That is information, and
+      # dropping zeros would bias every figure upward.
+      league(900, %{})
+      claim(1, 900, "4034", 0)
+
+      assert %{"4034" => %{median: 0.0, claims: 1}} = FaabMarket.prices().players
+    end
+
+    test "counts distinct leagues, so ten claims in one league cannot read as ten" do
+      league(900, %{})
+      claim(1, 900, "4034", 10)
+      claim(2, 900, "4034", 20, %{creator: @bob})
+
+      assert %{"4034" => %{claims: 2, leagues: 1}} = FaabMarket.prices().players
+    end
+
+    test "min_claims filters thin players out at the source" do
+      league(900, %{})
+      league(901, %{})
+      claim(1, 900, "4034", 10)
+      claim(2, 901, "4034", 20)
+      claim(3, 900, "6794", 30)
+
+      assert Map.keys(FaabMarket.prices(min_claims: 2).players) == ["4034"]
+    end
+  end
+
+  describe "the sample the prices rest on" do
+    test "carries the window the bids come from" do
+      league(900, %{})
+      claim(1, 900, "4034", 10, %{created: ~U[2026-05-02 09:00:00Z]})
+      claim(2, 900, "6794", 20, %{created: ~U[2026-07-30 09:00:00Z]})
+
+      assert %{from: ~D[2026-05-02], to: ~D[2026-07-30]} = FaabMarket.prices().window
+    end
+
+    test "counts the bidding leagues, not every league observed" do
+      league(900, %{})
+      league(901, %{})
+      league(902, %{waiver_type: 0})
+
+      assert FaabMarket.prices().leagues == 2
+    end
+
+    test "an empty corpus reports no window rather than an invented one" do
+      assert %{window: nil, leagues: 0, players: %{}} = FaabMarket.prices()
+    end
+  end
+end

--- a/test/sleeper_player_api_web/controllers/faab_controller_test.exs
+++ b/test/sleeper_player_api_web/controllers/faab_controller_test.exs
@@ -1,0 +1,97 @@
+defmodule SleeperPlayerApiWeb.FaabControllerTest do
+  use SleeperPlayerApiWeb.ConnCase, async: true
+
+  alias SleeperPlayerApi.Intel
+
+  defp league(id, attrs \\ %{}) do
+    Intel.upsert_observed_leagues([
+      Map.merge(%{id: id, season: "2026", waiver_type: 2, waiver_budget: 100}, attrs)
+    ])
+  end
+
+  defp claim(id, league_id, player_id, bid, attrs \\ %{}) do
+    Intel.upsert_observed_transactions([
+      Map.merge(
+        %{
+          id: id,
+          league_id: league_id,
+          week: 1,
+          type: "waiver",
+          status: "complete",
+          created: ~U[2026-06-15 12:00:00Z],
+          creator: 111,
+          participant_ids: [111],
+          adds: %{player_id => 1},
+          drops: %{},
+          waiver_bid: bid
+        },
+        attrs
+      )
+    ])
+  end
+
+  test "serves a price as a share of budget, with its spread and denominator", %{conn: conn} do
+    league(900, %{waiver_budget: 100})
+    league(901, %{waiver_budget: 1000})
+    claim(1, 900, "4034", 50)
+    claim(2, 901, "4034", 50)
+
+    body = conn |> get(~p"/api/v1/faab") |> json_response(200)
+
+    assert %{"median" => 27.5, "low" => 5.0, "high" => 50.0, "claims" => 2, "leagues" => 2} =
+             body["players"]["4034"]
+  end
+
+  # The prices mean nothing without these, so they ride on the envelope rather
+  # than being a second request a caller can forget to make.
+  test "the window and league count travel with the prices", %{conn: conn} do
+    league(900)
+    claim(1, 900, "4034", 10, %{created: ~U[2026-05-02 09:00:00Z]})
+    claim(2, 900, "6794", 20, %{created: ~U[2026-07-30 09:00:00Z]})
+
+    body = conn |> get(~p"/api/v1/faab") |> json_response(200)
+
+    assert body["window"] == %{"from" => "2026-05-02", "to" => "2026-07-30"}
+    assert body["leagues"] == 1
+  end
+
+  test "an empty corpus sends a null window rather than an invented one", %{conn: conn} do
+    body = conn |> get(~p"/api/v1/faab") |> json_response(200)
+
+    assert body["window"] == nil
+    assert body["players"] == %{}
+  end
+
+  test "minClaims narrows to the well-sampled players", %{conn: conn} do
+    league(900)
+    league(901)
+    claim(1, 900, "4034", 10)
+    claim(2, 901, "4034", 20)
+    claim(3, 900, "6794", 30)
+
+    body = conn |> get(~p"/api/v1/faab?minClaims=2") |> json_response(200)
+
+    assert Map.keys(body["players"]) == ["4034"]
+  end
+
+  test "a non-numeric minClaims is a 422 rather than a silent default", %{conn: conn} do
+    assert conn |> get(~p"/api/v1/faab?minClaims=lots") |> json_response(422)
+  end
+
+  test "an out-of-range minClaims is a 422, and says the range", %{conn: conn} do
+    body = conn |> get(~p"/api/v1/faab?minClaims=0") |> json_response(422)
+
+    assert body["errors"] |> inspect() =~ "100"
+  end
+
+  # Sleeper ids are strings on the wire everywhere in this API — a caller
+  # keying one map by number and another by string finds out at runtime.
+  test "keys players by string id", %{conn: conn} do
+    league(900)
+    claim(1, 900, "4034", 10)
+
+    body = conn |> get(~p"/api/v1/faab") |> json_response(200)
+
+    assert ["4034"] = Map.keys(body["players"])
+  end
+end


### PR DESCRIPTION
`observed_transactions` has carried `waiver_bid` on every row since the crawl started, and nothing outside a single manager's profile has looked at it in aggregate. `GET /api/v1/faab` turns it into what players actually went for across the observed leagues.

No new request, no new table. Builds on #52, which stored the budgets this needs.

## What the corpus actually holds

| | |
|---|---|
| Winning waiver claims in FAAB leagues | 3,404 |
| Distinct players priced | 516 |
| …with ≥3 / ≥5 / ≥10 claims | 261 / 175 / 90 |
| Failed claims (bids that bought nothing) | 1,565 |
| FAAB leagues | 147 of 179 |

## Three rules, each with a test

**Every figure is a share of the paying league's own budget.** 67 of the 147 FAAB leagues use 100, but 33 use 1000, 19 use 200, 14 use 300. Raw bids are not comparable; a bid of 50 is half a budget in one league and a twentieth in another.

**Only winning claims are prices.** A failed claim is a bid that did not buy the player. Failed counts come back separately and without interpretation — Sleeper does not say whether a claim failed on the bid or on an invalid roster move, and those look identical from here.

**Median, low and high travel together.** Measured on the corpus, a player with five or more claims routinely spans 0% to 100% of budget. A single "he costs 12%" would be a fiction about a spread that wide. This is the survival-number discipline: the distribution *is* the answer.

Leagues on rolling waivers or priority (31 of them) are excluded outright rather than contributing zeros — Sleeper stores `waiver_bid` regardless of waiver system, so those zeros are the absence of bidding, not bids of nothing.

## The caveat is in the payload, not just the docs

Every bid in the corpus falls between 2026-05-01 and 2026-07-31 — offseason FAAB, a different market from the in-season one where most FAAB gets spent. `window` and `leagues` ride on the response envelope so a caller has them before it renders a single price, the same way `coverage` travels with manager activity.

## Notes

Every winning claim in the corpus adds exactly one player (3,404 of 3,404 measured), so a bid attributes unambiguously. Documented as something to re-check if `adds` sizes ever change.

Two bids exceed their league's budget, both by exactly 1 (101/100, 301/300). Left unclamped — 2 in 3,404, and clamping would hide it.

Sabotage-verified: dropping the budget normalization fails 2 tests; pricing failed claims in fails 1; letting rolling-waiver leagues through fails 1; dropping the window fails 2.

417 tests, `mix format --check-formatted` clean.