### PR TITLE
Correct the FAAB window the docs claim

### DIFF
--- a/lib/sleeper_player_api/intel/faab_market.ex
+++ b/lib/sleeper_player_api/intel/faab_market.ex
@@ -45,11 +45,22 @@ defmodule SleeperPlayerApi.Intel.FaabMarket do
 
   ## The window is not optional
 
-  Every bid in the corpus today falls between 2026-05-01 and 2026-07-31 —
-  offseason FAAB, which is a different market from the in-season one where
-  most FAAB is actually spent. The window travels with the response for the
-  same reason `coverage` travels with manager activity: a caller that renders
-  "what he costs" over a window like that, without saying so, is overclaiming.
+  The corpus runs from 2025-12-31 to the present, and it is **all offseason**
+  with respect to the 2026 season, which has not started. Measured 2026-08-15,
+  winning claims by month: Dec 2, Jan 167, Feb 26, Mar 150, Apr 227, May 1327,
+  Jun 602, Jul 379, Aug 524. May dominates because that is when rookie drafts
+  land and the run on undrafted rookies follows them.
+
+  Offseason FAAB is a different market from the in-season one where most FAAB
+  actually gets spent — these are prices for speculative adds, not for the
+  week-9 running back everyone suddenly needs. The window travels with the
+  response for the same reason `coverage` travels with manager activity: a
+  caller that renders "what he costs" over a window like that, without saying
+  so, is overclaiming.
+
+  (An earlier version of this doc gave the span as 2026-05-01 to 2026-07-31.
+  That was the *positive-bid* subset. A zero bid is a real winning claim and
+  the full range is wider.)
   """
 
   import Ecto.Query

--- a/lib/sleeper_player_api_web/controllers/faab_json.ex
+++ b/lib/sleeper_player_api_web/controllers/faab_json.ex
@@ -4,8 +4,8 @@ defmodule SleeperPlayerApiWeb.FaabJSON do
   other JSON modules here.
 
   **`window` and `leagues` are not decoration.** Every bid in this corpus was
-  made in the offseason, which is a different market from the in-season one
-  where most FAAB gets spent, and a UI that renders "12% of budget" without
+  made outside the 2026 season, which is a different market from the in-season
+  one where most FAAB gets spent, and a UI that renders "12% of budget" without
   saying over what and across how many leagues is overclaiming. They ride on
   the envelope so a caller has them before it renders a single price.
   """


### PR DESCRIPTION
#53's moduledoc said every bid in the corpus falls between 2026-05-01 and 2026-07-31. That was measured on the *positive-bid* subset. A zero bid is a real winning claim — the module counts it as one on purpose — so the true span is wider: against the live endpoint the corpus runs **2025-12-31 to the present**.

Replaced with the measured monthly counts of winning claims:

| Month | Claims |
|---|---|
| Dec 2025 | 2 |
| Jan | 167 |
| Feb | 26 |
| Mar | 150 |
| Apr | 227 |
| **May** | **1,327** |
| Jun | 602 |
| Jul | 379 |
| Aug (to the 15th) | 524 |

May dominates because that is when rookie drafts land and the run on undrafted rookies follows them.

The substantive caveat is unchanged and slightly clearer for being specific: it is all still offseason with respect to the 2026 season, so these are prices for speculative adds rather than for the week-9 running back everyone suddenly needs.

Comments only — no behaviour change, so no deploy needed. 417 tests, format clean.